### PR TITLE
chore: upload code coverage to codecov

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "start:beta:ci": "ENVIRONMENT=ci npm run start:beta",
     "start:standalone": "STANDALONE=true npm start",
     "test": "jest",
-    "verify": "npm-run-all build lint test"
+    "verify": "npm-run-all build lint coverage"
   },
   "dependencies": {
     "@patternfly/react-core": "4.135.0",

--- a/test.sh
+++ b/test.sh
@@ -5,4 +5,10 @@ if [ ! -d node_modules ]; then
     npm install
 fi
 
+curl -Os https://uploader.codecov.io/latest/linux/codecov
+
+chmod +x codecov
+
 npm run verify
+./codecov --dir ./coverage
+


### PR DESCRIPTION
This PR enables the upload of coverage to codecov using the codecov's new bash uploader 

Signed off by msawood@redhat.com