### PR TITLE
Validate component name to match the correct format

### DIFF
--- a/src/components/ReviewComponents/ReviewComponentsForm.tsx
+++ b/src/components/ReviewComponents/ReviewComponentsForm.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Form, FormSection, PageSection } from '@patternfly/react-core';
 import { FormikProps } from 'formik';
+import isEmpty from 'lodash/isEmpty';
 import { FormFooter, RadioGroupField } from '../../shared';
 import { useFormValues } from '../form-context';
 import { useWizardContext } from '../Wizard/Wizard';
@@ -14,6 +15,7 @@ export const ReviewComponentsForm: React.FC<ReviewComponentsFormProps> = ({
   handleSubmit,
   handleReset,
   isSubmitting,
+  errors,
 }) => {
   const [formState, setFormState] = useFormValues();
   const { handleReset: wizardHandleReset } = useWizardContext();
@@ -60,7 +62,7 @@ export const ReviewComponentsForm: React.FC<ReviewComponentsFormProps> = ({
           }}
           handleSubmit={handleSubmit}
           isSubmitting={isSubmitting}
-          disableSubmit={isSubmitting}
+          disableSubmit={!isEmpty(errors) || isSubmitting}
           errorMessage={undefined}
         />
       </div>

--- a/src/components/ReviewComponents/ReviewComponentsPage.tsx
+++ b/src/components/ReviewComponents/ReviewComponentsPage.tsx
@@ -10,6 +10,7 @@ import { useWizardContext } from '../Wizard/Wizard';
 import { ReviewComponentsForm } from './ReviewComponentsForm';
 import { DeployMethod, Resources, ReviewComponentsFormValues } from './types';
 import { createResourceData, transformResources } from './utils';
+import { reviewFormSchema } from './validation-utils';
 
 export const ReviewComponentsPage: React.FC = () => {
   const { decreaseStepBy } = useWizardContext();
@@ -24,7 +25,7 @@ export const ReviewComponentsPage: React.FC = () => {
       (acc, val) => ({
         ...acc,
         [val.name]: {
-          name: val.name,
+          name: val.name.split(/ |\./).join('-').toLowerCase(),
           source: val.data?.source || val.attributes.git.remotes.origin,
           ...(isSample
             ? {}
@@ -129,6 +130,7 @@ export const ReviewComponentsPage: React.FC = () => {
           decreaseStepBy(isSample ? 1 : 2);
         }}
         initialValues={initialValues}
+        validationSchema={reviewFormSchema}
       >
         {(props) => <ReviewComponentsForm {...props} />}
       </Formik>

--- a/src/components/ReviewComponents/__tests__/validation-utils.spec.ts
+++ b/src/components/ReviewComponents/__tests__/validation-utils.spec.ts
@@ -1,0 +1,58 @@
+import { reviewFormSchema } from '../validation-utils';
+
+describe('Review form validation schema', () => {
+  it('should fail when component name is missing', async () => {
+    await expect(
+      reviewFormSchema.validate({
+        deployMethod: 1,
+        components: {
+          comp1: {
+            targetPort: 8000,
+          },
+        },
+      }),
+    ).rejects.toThrow('Required');
+  });
+
+  it('should fail when component name is invalid', async () => {
+    const values = {
+      deployMethod: 1,
+      components: {
+        comp1: {
+          name: 'test comp',
+          targetPort: 8000,
+        },
+      },
+    };
+    await expect(reviewFormSchema.validate(values)).rejects.toThrow('Invalid component name');
+    values.components.comp1.name = 'Test-';
+    await expect(reviewFormSchema.validate(values)).rejects.toThrow('Invalid component name');
+    values.components.comp1.name = 'test-@!';
+    await expect(reviewFormSchema.validate(values)).rejects.toThrow('Invalid component name');
+  });
+
+  it('should pass when target port is not provided', async () => {
+    const values = {
+      deployMethod: 1,
+      components: {
+        comp1: {
+          name: 'test-comp',
+        },
+      },
+    };
+    await expect(reviewFormSchema.validate(values)).resolves.toBe(values);
+  });
+
+  it('should fail when target port is invalid', async () => {
+    const values = {
+      deployMethod: 1,
+      components: {
+        comp1: {
+          name: 'test comp',
+          targetPort: 'test',
+        },
+      },
+    };
+    await expect(reviewFormSchema.validate(values)).rejects.toThrow('Must be an integer');
+  });
+});

--- a/src/components/ReviewComponents/validation-utils.ts
+++ b/src/components/ReviewComponents/validation-utils.ts
@@ -1,0 +1,22 @@
+import mapValues from 'lodash/mapValues';
+import { object, lazy, number, string } from 'yup';
+
+const componentNameRegex = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+
+export const reviewFormSchema = object({
+  deployMethod: number(),
+  components: lazy((obj) =>
+    object(
+      mapValues(obj, () =>
+        object({
+          name: string().matches(componentNameRegex, 'Invalid component name').required('Required'),
+          targetPort: number()
+            .typeError('Must be an integer')
+            .min(1, 'Port must be between 1 and 65535.')
+            .max(65535, 'Port must be between 1 and 65535.')
+            .optional(),
+        }),
+      ),
+    ),
+  ),
+});

--- a/src/shared/components/formik-fields/EditableLabelField.tsx
+++ b/src/shared/components/formik-fields/EditableLabelField.tsx
@@ -18,7 +18,7 @@ const EditableLabelField: React.FC<EditableLabelFieldProps> = ({
   type = TextInputTypes.text,
   ...props
 }) => {
-  const [, { value }, { setValue }] = useField({ name, type });
+  const [, { value, error }, { setValue }] = useField({ name, type });
   const [editing, setEditing] = React.useState(false);
   const [oldValue, setOldValue] = React.useState('');
   const fieldId = getFieldId(name, 'label-field');
@@ -43,6 +43,7 @@ const EditableLabelField: React.FC<EditableLabelFieldProps> = ({
             <ActionGroupWithIcons
               className="hacDev-editable-label-field__action-group"
               onSubmit={() => setEditing(false)}
+              isDisabled={!!error}
               onClose={() => {
                 setEditing(false);
                 setValue(oldValue);

--- a/src/utils/__tests__/create-utils.spec.ts
+++ b/src/utils/__tests__/create-utils.spec.ts
@@ -1,9 +1,15 @@
 import * as k8sUtil from '../../dynamic-plugin-sdk';
 import { ApplicationModel } from './../../models/application';
-import { ComponentModel } from './../../models/component';
-import { createApplication, createComponent } from './../create-utils';
+import { ComponentDetectionQueryModel, ComponentModel } from './../../models/component';
+import {
+  createApplication,
+  createComponent,
+  createComponentDetectionQuery,
+} from './../create-utils';
 
 jest.mock('../../dynamic-plugin-sdk');
+
+const createResourceMock = k8sUtil.k8sCreateResource as jest.Mock;
 
 const mockApplicationRequestData = {
   apiVersion: `${ApplicationModel.apiGroup}/${ApplicationModel.apiVersion}`,
@@ -35,9 +41,22 @@ const mockComponentData = {
   },
 };
 
+const mockCDQData = {
+  apiVersion: `${ComponentDetectionQueryModel.apiGroup}/${ComponentDetectionQueryModel.apiVersion}`,
+  kind: ComponentDetectionQueryModel.kind,
+  metadata: {
+    namespace: 'test-ns',
+    name: expect.any(String),
+  },
+  spec: {
+    git: { url: 'https://github.com/test/repository' },
+    isMultiComponent: true,
+  },
+};
+
 describe('Create Utils', () => {
-  it('Should call k8s create util with correct model and data for application', () => {
-    createApplication('Test Application', 'test-ns');
+  it('Should call k8s create util with correct model and data for application', async () => {
+    await createApplication('Test Application', 'test-ns');
 
     expect(k8sUtil.k8sCreateResource).toHaveBeenCalledWith({
       model: ApplicationModel,
@@ -45,12 +64,49 @@ describe('Create Utils', () => {
     });
   });
 
-  it('Should call k8s create util with correct model and data for component', () => {
-    createComponent(mockComponent, 'test-application', 'test-ns');
+  it('Should call k8s create util with correct model and data for component', async () => {
+    await createComponent(mockComponent, 'test-application', 'test-ns');
 
     expect(k8sUtil.k8sCreateResource).toHaveBeenCalledWith({
       model: ComponentModel,
       data: mockComponentData,
     });
+  });
+
+  it('Should call k8s create util with correct model and data for component detection query', async () => {
+    createResourceMock.mockImplementationOnce(() =>
+      Promise.resolve({
+        status: { conditions: [{ type: 'Completed', status: 'True' }], componentDetected: true },
+      }),
+    );
+
+    await createComponentDetectionQuery(
+      'test-application',
+      'https://github.com/test/repository',
+      'test-ns',
+      true,
+    );
+
+    expect(k8sUtil.k8sCreateResource).toHaveBeenCalledWith({
+      model: ComponentDetectionQueryModel,
+      data: expect.objectContaining(mockCDQData),
+    });
+  });
+
+  it('Should throw error when no components are detected', async () => {
+    createResourceMock.mockImplementationOnce(() =>
+      Promise.resolve({
+        status: { conditions: [{ type: 'Completed', status: 'False' }], componentDetected: false },
+      }),
+    );
+
+    await expect(
+      createComponentDetectionQuery(
+        'test-application',
+        'https://github.com/test/repository',
+        'test-ns',
+        true,
+      ),
+    ).rejects.toThrow();
   });
 });

--- a/src/utils/create-utils.ts
+++ b/src/utils/create-utils.ts
@@ -11,7 +11,7 @@ import { k8sCreateResource, k8sGetResource } from './../dynamic-plugin-sdk';
  * TODO: Return type any should be changed to a proper type like K8sResourceCommon
  */
 export const createApplication = (application: string, namespace: string): any => {
-  const name = application.split(' ').join('-').toLowerCase();
+  const name = application.split(/ |\./).join('-').toLowerCase();
   // const uniqueName = uniqueId(`${name}-`);
   const requestData = {
     apiVersion: `${ApplicationModel.apiGroup}/${ApplicationModel.apiVersion}`,
@@ -41,7 +41,7 @@ export const createApplication = (application: string, namespace: string): any =
  * TODO: Return type any should be changed to a proper type like K8sResourceCommon
  */
 export const createComponent = (component, application: string, namespace: string): any => {
-  const name = component.name.split(' ').join('-').toLowerCase();
+  const name = component.name.split(/ |\./).join('-').toLowerCase();
   // const uniqueName = uniqueId(name);
   const requestData = {
     apiVersion: `${ComponentModel.apiGroup}/${ComponentModel.apiVersion}`,
@@ -92,7 +92,7 @@ export const createComponentDetectionQuery = async (
   isMultiComponent?: boolean,
 ): Promise<ComponentDetectionQueryKind['status']['componentDetected']> => {
   // append name with uid for additional randomness
-  const name = `${appName.split(' ').join('-').toLowerCase()}-${uid()}`;
+  const name = `${appName.split(/ |\./).join('-').toLowerCase()}-${uid()}`;
   const uniqueName = uniqueId(name);
 
   const requestData = {


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-505
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
There was no validation for component name, which allowed adding any invalid value. This change adds a validation schema to component name to enforce the value to be of the format: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

https://user-images.githubusercontent.com/20013884/151558995-5a7e74db-2d6b-41dc-b140-1e696477a90d.mp4

<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
Enter an invalid component name in the review components section.
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
