### PR TITLE
applications list view

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -19,6 +19,13 @@ const ComponentListView = lazy(
     ),
 );
 
+const ApplicationList = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "ApplicationList" */ './components/ApplicationListView/ApplicationList'
+    ),
+);
+
 /**
  * the Switch component changes routes depending on the path.
  *
@@ -38,6 +45,7 @@ export const Routes: React.FC = () => (
     <Switch>
       <Route path="/" component={SamplesFlow} exact />
       <Route path="/components" component={ComponentListView} exact />
+      <Route path="/applications" component={ApplicationList} exact />
       <Route path="/sample-page" component={SamplePage} exact />
       <Route path="/k8s-util" component={K8sPage} exact />
       {/* Finally, catch all unmatched routes */}

--- a/src/components/AddComponent/AddComponentPage.tsx
+++ b/src/components/AddComponent/AddComponentPage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Formik } from 'formik';
+import { Page } from '../../shared';
 import { useFormValues } from '../form-context';
-import { Page } from '../Page/Page';
 import { useWizardContext } from '../Wizard/Wizard';
 import { AddComponentForm, AddComponentValues } from './AddComponentForm';
 import { validationSchema } from './validation-utils';
@@ -43,7 +43,7 @@ export const AddComponentPage = () => {
   return (
     <Page
       breadcrumbs={[
-        { path: '#', name: 'Applications' },
+        { path: '/applications', name: 'Applications' },
         { path: '#', name: 'Create your application' },
       ]}
       heading="Build your application"

--- a/src/components/ApplicationListView/ApplicationList.tsx
+++ b/src/components/ApplicationListView/ApplicationList.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateVariant,
+} from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons/dist/js/icons';
+import { useK8sWatchResource } from '../../dynamic-plugin-sdk';
+import { useActiveNamespace } from '../../hooks/useActiveNamespace';
+import { ApplicationGroupVersionKind } from '../../models';
+import { Page, Table } from '../../shared';
+import { LoadingBox } from '../../shared/components/status-box/StatusBox';
+import { ApplicationKind } from '../../types';
+import { ApplicationListHeader } from './ApplicationListHeader';
+import ApplicationListRow from './ApplicationListRow';
+
+const getRowProps = (obj: ApplicationKind) => ({
+  id: obj.metadata.name,
+});
+
+const ApplicationList: React.FC = () => {
+  const namespace = useActiveNamespace();
+
+  const [allApplications, allApplicationsLoaded] = useK8sWatchResource<ApplicationKind[]>({
+    groupVersionKind: ApplicationGroupVersionKind,
+    namespace,
+    isList: true,
+  });
+  const loaded = namespace && allApplicationsLoaded;
+
+  if (!loaded) {
+    return <LoadingBox />;
+  }
+
+  allApplications?.sort(
+    (app1, app2) =>
+      +new Date(app2.metadata.creationTimestamp) - +new Date(app1.metadata.creationTimestamp),
+  );
+
+  return (
+    <Page
+      heading="Applications"
+      customButton={
+        <Link className="pf-c-button pf-m-primary" to={`/`}>
+          Create Application
+        </Link>
+      }
+    >
+      {!allApplications || allApplications.length === 0 ? (
+        <EmptyState variant={EmptyStateVariant.full}>
+          <EmptyStateIcon icon={SearchIcon} />
+          <EmptyStateBody data-test="empty-state-body">
+            <p>No applications found</p>
+            <br />
+            <Link to={`/`}>Create an application</Link> to get started.
+          </EmptyStateBody>
+        </EmptyState>
+      ) : (
+        <Table
+          data={allApplications}
+          aria-label="Application List"
+          Header={ApplicationListHeader}
+          Row={ApplicationListRow}
+          loaded={loaded}
+          getRowProps={getRowProps}
+        />
+      )}
+    </Page>
+  );
+};
+
+export default ApplicationList;

--- a/src/components/ApplicationListView/ApplicationListHeader.ts
+++ b/src/components/ApplicationListView/ApplicationListHeader.ts
@@ -1,0 +1,33 @@
+export const applicationTableColumnClasses = {
+  name: 'pf-m-width-20',
+  components: 'pf-u-w-25-on-lg pf-u-w-25-on-sm pf-u-w-16-on-xs',
+  environments:
+    'pf-m-hidden pf-m-visible-on-sm pf-u-w-25-on-xl pf-u-w-25-on-lg pf-u-w-25-on-md pf-u-w-16-on-sm',
+  lastDeploy: 'pf-m-hidden pf-m-visible-on-md pf-u-w-25-on-xl pf-u-w-16-on-lg pf-u-w-16-on-md',
+  kebab: 'dropdown-kebab-pf pf-c-table__action',
+};
+
+export const ApplicationListHeader = () => {
+  return [
+    {
+      title: 'Name',
+      props: { className: applicationTableColumnClasses.name },
+    },
+    {
+      title: 'Components',
+      props: { className: applicationTableColumnClasses.components },
+    },
+    {
+      title: 'Environments',
+      props: { className: applicationTableColumnClasses.environments },
+    },
+    {
+      title: 'Last deploy',
+      props: { className: applicationTableColumnClasses.lastDeploy },
+    },
+    {
+      title: '',
+      props: { className: applicationTableColumnClasses.kebab },
+    },
+  ];
+};

--- a/src/components/ApplicationListView/ApplicationListRow.tsx
+++ b/src/components/ApplicationListView/ApplicationListRow.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { pluralize } from '@patternfly/react-core';
+import { EllipsisVIcon } from '@patternfly/react-icons/dist/js/icons';
+import { useK8sWatchResource } from '../../dynamic-plugin-sdk';
+import { ComponentGroupVersionKind } from '../../models';
+import { RowFunctionArgs, TableData } from '../../shared/components/table';
+import { Timestamp } from '../../shared/components/timestamp/Timestamp';
+import { ApplicationKind, ComponentKind } from '../../types';
+import { applicationTableColumnClasses } from './ApplicationListHeader';
+
+const ApplicationListRow: React.FC<RowFunctionArgs<ApplicationKind>> = ({ obj }) => {
+  const [allComponents] = useK8sWatchResource<ComponentKind[]>({
+    groupVersionKind: ComponentGroupVersionKind,
+    namespace: obj.metadata.namespace,
+    isList: true,
+  });
+
+  const components = allComponents?.filter((c) => c.spec.application === obj.metadata.name) ?? [];
+
+  return (
+    <>
+      <TableData className={applicationTableColumnClasses.name}>
+        <Link to={`/components?application=${obj.metadata.name}`} title={obj.metadata.name}>
+          {obj.metadata.name}
+        </Link>
+      </TableData>
+      <TableData className={applicationTableColumnClasses.components}>
+        {pluralize(components.length, 'Component', 'Components')}
+      </TableData>
+      <TableData className={applicationTableColumnClasses.environments}>-</TableData>
+      <TableData className={applicationTableColumnClasses.lastDeploy}>
+        <Timestamp timestamp={obj.metadata.creationTimestamp} />
+      </TableData>
+      <TableData className={applicationTableColumnClasses.kebab}>
+        <EllipsisVIcon />
+      </TableData>
+    </>
+  );
+};
+
+export default ApplicationListRow;

--- a/src/components/ApplicationListView/__tests__/ApplicationList.spec.tsx
+++ b/src/components/ApplicationListView/__tests__/ApplicationList.spec.tsx
@@ -1,0 +1,101 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useK8sWatchResource } from '../../../dynamic-plugin-sdk';
+import { ApplicationKind } from '../../../types';
+import ApplicationList from '../ApplicationList';
+
+jest.mock('../../../dynamic-plugin-sdk', () => ({
+  useK8sWatchResource: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useActiveNamespace', () => ({
+  useActiveNamespace: jest.fn(() => 'test-ns'),
+}));
+
+jest.mock('react-router-dom', () => ({
+  Link: (props) => <a href={props.to}>{props.children}</a>,
+}));
+
+const applications: ApplicationKind[] = [
+  {
+    kind: 'Application',
+    apiVersion: 'appstudio.redhat.com/v1alpha1',
+    metadata: {
+      creationTimestamp: '2022-02-03T19:34:28Z',
+      finalizers: Array['application.appstudio.redhat.com/finalizer'],
+      name: 'mno-app',
+      namespace: 'test',
+      resourceVersion: '187593762',
+      uid: '60725777-a545-4c54-bf25-19a3f231aed1',
+    },
+    spec: {
+      displayName: 'mno-app',
+    },
+  },
+  {
+    kind: 'Application',
+    apiVersion: 'appstudio.redhat.com/v1alpha1',
+    metadata: {
+      creationTimestamp: '2022-02-03T14:34:28Z',
+      finalizers: Array['application.appstudio.redhat.com/finalizer'],
+      name: 'mno-app1',
+      namespace: 'test',
+      resourceVersion: '187593762',
+      uid: '60725777-a545-4c54-bf25-19a3f231aed1',
+    },
+    spec: {
+      displayName: 'mno-app1',
+    },
+  },
+  {
+    kind: 'Application',
+    apiVersion: 'appstudio.redhat.com/v1alpha1',
+    metadata: {
+      creationTimestamp: '2022-01-03T14:34:28Z',
+      finalizers: Array['application.appstudio.redhat.com/finalizer'],
+      name: 'mno-app2',
+      namespace: 'test',
+      resourceVersion: '187593762',
+      uid: '60725777-a545-4c54-bf25-19a3f231aed1',
+    },
+    spec: {
+      displayName: 'mno-app2',
+    },
+  },
+  {
+    kind: 'Application',
+    apiVersion: 'appstudio.redhat.com/v1alpha1',
+    metadata: {
+      creationTimestamp: '2022-01-03T14:34:28Z',
+      finalizers: Array['application.appstudio.redhat.com/finalizer'],
+      name: 'xyz-app',
+      namespace: 'test2',
+      resourceVersion: '187593762',
+      uid: '60725777-a545-4c54-bf25-19a3f231aed1',
+    },
+    spec: {
+      displayName: 'xyz-app',
+    },
+  },
+];
+
+const watchResourceMock = useK8sWatchResource as jest.Mock;
+
+describe('Application List', () => {
+  it('renders empty state if no application is present', () => {
+    watchResourceMock.mockReturnValue([[], true]);
+    const { getByText } = render(<ApplicationList />);
+    expect(getByText('Create Application')).toBeInTheDocument();
+    expect(getByText('No applications found')).toBeInTheDocument();
+  });
+
+  it('renders application list when application(s) is(are) present', () => {
+    watchResourceMock.mockReturnValue([applications, true]);
+    const { getByText } = render(<ApplicationList />);
+    expect(getByText('Create Application')).toBeInTheDocument();
+    expect(getByText('Name')).toBeInTheDocument();
+    expect(getByText('Components')).toBeInTheDocument();
+    expect(getByText('Environments')).toBeInTheDocument();
+  });
+});

--- a/src/components/ApplicationListView/__tests__/ApplicationListRow.spec.tsx
+++ b/src/components/ApplicationListView/__tests__/ApplicationListRow.spec.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useK8sWatchResource } from '../../../dynamic-plugin-sdk';
+import * as dateTime from '../../../shared/components/timestamp/datetime';
+import { ApplicationKind, ComponentKind } from '../../../types';
+import ApplicationListRow from '../ApplicationListRow';
+
+jest.mock('../../../dynamic-plugin-sdk', () => ({
+  useK8sWatchResource: jest.fn(),
+}));
+
+jest.mock('react-router-dom', () => ({
+  Link: (props) => <a href={props.to}>{props.children}</a>,
+}));
+
+const application: ApplicationKind = {
+  kind: 'Application',
+  apiVersion: 'appstudio.redhat.com/v1alpha1',
+  metadata: {
+    creationTimestamp: '2022-02-03T19:34:28Z',
+    finalizers: Array['application.appstudio.redhat.com/finalizer'],
+    name: 'mno-app',
+    namespace: 'test',
+    resourceVersion: '187593762',
+    uid: '60725777-a545-4c54-bf25-19a3f231aed1',
+  },
+  spec: {
+    displayName: 'mno-app',
+  },
+};
+
+const components: ComponentKind[] = [
+  {
+    kind: 'Component',
+    apiVersion: 'appstudio.redhat.com/v1alpha1',
+    metadata: {
+      creationTimestamp: '2022-02-03T19:34:28Z',
+      finalizers: Array['application.appstudio.redhat.com/finalizer'],
+      name: 'component1',
+      namespace: 'test',
+      resourceVersion: '187593762',
+      uid: '60725777-a545-4c54-bf25-19a3f231aed1',
+    },
+    spec: {
+      application: 'mno-app',
+      componentName: 'component1',
+      source: null,
+    },
+  },
+  {
+    kind: 'Component',
+    apiVersion: 'appstudio.redhat.com/v1alpha1',
+    metadata: {
+      creationTimestamp: '2022-02-03T19:34:28Z',
+      finalizers: Array['application.appstudio.redhat.com/finalizer'],
+      name: 'component2',
+      namespace: 'test',
+      resourceVersion: '187593762',
+      uid: '60725777-a545-4c54-bf25-19a3f231aed1',
+    },
+    spec: {
+      application: 'mno-app',
+      componentName: 'component2',
+      source: null,
+    },
+  },
+];
+
+const watchResourceMock = useK8sWatchResource as jest.Mock;
+
+describe('Application List Row', () => {
+  it('renders application list row', () => {
+    watchResourceMock.mockReturnValue([components, true]);
+    const { getByText, container } = render(
+      <ApplicationListRow columns={null} obj={application} />,
+    );
+    const expectedDate = dateTime.dateTimeFormatter.format(
+      new Date(application.metadata.creationTimestamp),
+    );
+    expect(getByText(application.metadata.name)).toBeInTheDocument();
+    expect(getByText('2 Components')).toBeInTheDocument();
+    expect(container).toHaveTextContent(expectedDate.toString());
+  });
+
+  it('renders 0 components in the component column if the application has none available', () => {
+    watchResourceMock.mockReturnValue([[], true]);
+    const { getByText } = render(<ApplicationListRow columns={null} obj={application} />);
+    expect(getByText('0 Components')).toBeInTheDocument();
+  });
+});

--- a/src/components/ComponentListView/ComponentListView.tsx
+++ b/src/components/ComponentListView/ComponentListView.tsx
@@ -2,10 +2,9 @@ import * as React from 'react';
 import { useK8sWatchResource } from '../../dynamic-plugin-sdk';
 import { useActiveNamespace } from '../../hooks/useActiveNamespace';
 import { ApplicationGroupVersionKind } from '../../models';
-import { useQueryParams } from '../../shared';
+import { useQueryParams, Page } from '../../shared';
 import { StatusBox } from '../../shared/components/status-box/StatusBox';
 import { ApplicationKind } from '../../types';
-import { Page } from '.././Page/Page';
 import { ComponentListViewPage } from './ComponentListViewPage';
 
 const ComponentListView: React.FC = () => {

--- a/src/components/ComponentSamples/ComponentSamplesPage.tsx
+++ b/src/components/ComponentSamples/ComponentSamplesPage.tsx
@@ -15,7 +15,7 @@ import {
   TextVariants,
   Title,
 } from '@patternfly/react-core';
-import { FormFooter } from '../../shared';
+import { FormFooter, Page } from '../../shared';
 import CatalogView from '../../shared/components/catalog/catalog-view/CatalogView';
 import CatalogTile from '../../shared/components/catalog/CatalogTile';
 import { skeletonCatalog } from '../../shared/components/catalog/utils/skeleton-catalog';
@@ -23,7 +23,6 @@ import { CatalogItem } from '../../shared/components/catalog/utils/types';
 import { StatusBox } from '../../shared/components/status-box/StatusBox';
 import { getDevfileSamples } from '../../utils/devfile-utils';
 import { useFormValues } from '../form-context';
-import { Page } from '../Page/Page';
 import { useWizardContext } from '../Wizard/Wizard';
 
 export const ComponentSamplesPage = () => {
@@ -126,7 +125,7 @@ export const ComponentSamplesPage = () => {
         <DrawerContentBody>
           <Page
             breadcrumbs={[
-              { path: '#', name: 'Applications' },
+              { path: '/applications', name: 'Applications' },
               { path: '#', name: 'Create your application' },
             ]}
             heading="Start with a sample"

--- a/src/components/CreateApplication/CreateApplicationPage.tsx
+++ b/src/components/CreateApplication/CreateApplicationPage.tsx
@@ -2,9 +2,8 @@ import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import { Formik, FormikProps } from 'formik';
 import { useActiveNamespace } from '../../hooks/useActiveNamespace';
-import { useQueryParams } from '../../shared';
+import { useQueryParams, Page } from '../../shared';
 import { useFormValues } from '../form-context';
-import { Page } from '../Page/Page';
 import { useWizardContext } from '../Wizard/Wizard';
 import { CreateApplicationForm, CreateApplicationValues } from './CreateApplicationForm';
 
@@ -47,7 +46,7 @@ export const CreateApplicationPage = () => {
   return (
     <Page
       breadcrumbs={[
-        { path: '#', name: 'Applications' },
+        { path: '/applications', name: 'Applications' },
         { path: '#', name: 'Create your application' },
       ]}
       heading="Create your application"

--- a/src/components/ReviewComponents/ReviewComponentsPage.tsx
+++ b/src/components/ReviewComponents/ReviewComponentsPage.tsx
@@ -3,9 +3,9 @@ import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { Formik } from 'formik';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
+import { Page } from '../../shared';
 import { createApplication, createComponent } from '../../utils/create-utils';
 import { useFormValues } from '../form-context';
-import { Page } from '../Page/Page';
 import { useWizardContext } from '../Wizard/Wizard';
 import { ReviewComponentsForm } from './ReviewComponentsForm';
 import { DeployMethod, Resources, ReviewComponentsFormValues } from './types';
@@ -118,7 +118,7 @@ export const ReviewComponentsPage: React.FC = () => {
   return (
     <Page
       breadcrumbs={[
-        { path: '#', name: 'Applications' },
+        { path: '/applications', name: 'Applications' },
         { path: '#', name: 'Create your application' },
       ]}
       heading="Review your new components"

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -8,3 +8,5 @@ export * from './spinner';
 export * from './status';
 export * from './name-value-editor';
 export * from './help-tooltip';
+export * from './page';
+export * from './table';

--- a/src/shared/components/page/Page.scss
+++ b/src/shared/components/page/Page.scss
@@ -15,6 +15,11 @@
   }
 
   &__section {
-    padding: var(--pf-global--spacer--xs) var(--pf-global--spacer--lg);
+    padding: var(--pf-global--spacer--xs) var(--pf-global--spacer--md);
+  }
+
+  &__custom-button {
+    margin-top: var(--pf-global--spacer--lg);
+    margin-bottom: var(--pf-global--spacer--xl);
   }
 }

--- a/src/shared/components/page/Page.tsx
+++ b/src/shared/components/page/Page.tsx
@@ -1,23 +1,30 @@
 import * as React from 'react';
 import { Text, TextVariants, Title } from '@patternfly/react-core';
 import classNames from 'classnames';
-import BreadCrumbs from '../../shared/components/breadcrumbs/BreadCrumbs';
+import BreadCrumbs from '../breadcrumbs/BreadCrumbs';
 import './Page.scss';
 
 type PageProps = {
   breadcrumbs?: { path: string; name: string }[];
-  heading: string;
+  className?: string;
+  heading?: string;
+  headingLevel?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  titleSize?: 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl';
   description?: string;
   isSection?: boolean;
   children: React.ReactNode;
+  customButton?: React.ReactNode;
 };
 
-export const Page: React.FC<PageProps> = ({
+const Page: React.FC<PageProps> = ({
   breadcrumbs,
   heading,
+  headingLevel,
+  titleSize,
   description,
   children,
   isSection,
+  customButton = null,
 }) => {
   return (
     <div className="hacDev-page">
@@ -25,9 +32,18 @@ export const Page: React.FC<PageProps> = ({
         {breadcrumbs && (
           <BreadCrumbs className="hacDev-page__breadcrumb" breadcrumbs={breadcrumbs} />
         )}
-        <Title className="hacDev-page__heading" headingLevel="h1" size="4xl">
-          {heading}
-        </Title>
+        <div>
+          {heading && (
+            <Title
+              className="hacDev-page__heading"
+              headingLevel={headingLevel || 'h1'}
+              size={titleSize || '4xl'}
+            >
+              {heading}
+            </Title>
+          )}
+          {<div className="hacDev-page__custom-button">{customButton}</div>}
+        </div>
         {description && (
           <Text className="hacDev-page__description" component={TextVariants.p}>
             {description}
@@ -38,3 +54,5 @@ export const Page: React.FC<PageProps> = ({
     </div>
   );
 };
+
+export default Page;

--- a/src/shared/components/page/__tests__/Page.spec.tsx
+++ b/src/shared/components/page/__tests__/Page.spec.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { Router } from 'react-router';
 import { render, screen } from '@testing-library/react';
 import { createBrowserHistory } from 'history';
-import { Page } from '../Page';
 import '@testing-library/jest-dom';
+import Page from '../Page';
 
 describe('Page', () => {
   it('should render children and heading', () => {

--- a/src/shared/components/page/index.ts
+++ b/src/shared/components/page/index.ts
@@ -1,0 +1,1 @@
+export { default as Page } from './Page';

--- a/src/shared/components/table/Table.tsx
+++ b/src/shared/components/table/Table.tsx
@@ -1,0 +1,182 @@
+import * as React from 'react';
+import { match as RMatch } from 'react-router-dom';
+import {
+  Table as PfTable,
+  TableHeader,
+  TableGridBreakpoint,
+  OnSelect,
+  TableBody,
+} from '@patternfly/react-table';
+import { AutoSizer, WindowScroller } from '@patternfly/react-virtualized-extension';
+import classNames from 'classnames';
+import { useDeepCompareMemoize } from '../../hooks';
+import { WithScrollContainer } from '../../utils';
+import { StatusBox } from '../status-box/StatusBox';
+import { RowFunctionArgs, VirtualBody, VirtualBodyProps } from './VirtualBody';
+
+export type Filter = { key: string; value: string };
+
+export type TableWrapperProps = {
+  virtualize: boolean;
+  ariaLabel: string;
+  ariaRowCount: number;
+};
+
+export type TableProps<D = any, C = any> = Partial<ComponentProps<D>> & {
+  customData?: C;
+  Header: HeaderFunc;
+  loadError?: string | Object;
+  Row?: React.FC<RowFunctionArgs<D, C>>;
+  'aria-label': string;
+  onSelect?: OnSelect;
+  NoDataEmptyMsg?: React.ComponentType<{}>;
+  EmptyMsg?: React.ComponentType<{}>;
+  loaded?: boolean;
+  reduxID?: string;
+  reduxIDs?: string[];
+  label?: string;
+  columnManagementID?: string;
+  isPinned?: (val: D) => boolean;
+  staticFilters?: Filter[];
+  activeColumns?: Set<string>;
+  gridBreakPoint?: TableGridBreakpoint;
+  selectedResourcesForKind?: string[];
+  expand?: boolean;
+  getRowProps?: VirtualBodyProps<D>['getRowProps'];
+  virtualize?: boolean;
+};
+
+export type ComponentProps<D = any> = {
+  data: D[];
+  filters: Filter[];
+  selected: boolean;
+  match: RMatch<any>;
+  kindObj: any;
+};
+
+const TableWrapper: React.FC<TableWrapperProps> = ({
+  virtualize,
+  ariaLabel,
+  ariaRowCount,
+  ...props
+}) => {
+  return virtualize ? (
+    <div {...props} role="grid" aria-label={ariaLabel} aria-rowcount={ariaRowCount} />
+  ) : (
+    <React.Fragment {...props} />
+  );
+};
+
+type HeaderFunc = (componentProps: ComponentProps) => any[];
+
+const getActiveColumns = (Header: HeaderFunc, componentProps: ComponentProps) => {
+  const columns = Header(componentProps);
+
+  return columns;
+};
+
+const getComponentProps = (
+  data: any[],
+  filters: Filter[],
+  selected: boolean,
+  match: RMatch<any>,
+  kindObj: any,
+): ComponentProps => ({
+  data,
+  filters,
+  selected,
+  match,
+  kindObj,
+});
+
+const Table: React.FC<TableProps> = ({
+  filters: initFilters,
+  selected,
+  match,
+  kindObj,
+  Header: initHeader,
+  Row,
+  expand,
+  label,
+  'aria-label': ariaLabel,
+  customData,
+  gridBreakPoint = TableGridBreakpoint.none,
+  loaded,
+  loadError,
+  NoDataEmptyMsg,
+  EmptyMsg,
+  data,
+  getRowProps,
+  virtualize = true,
+}) => {
+  const filters = useDeepCompareMemoize(initFilters);
+  const Header = useDeepCompareMemoize(initHeader);
+  //const [, setWindowWidth] = React.useState(window.innerWidth);
+  const [columns] = React.useMemo(() => {
+    const cProps = getComponentProps(data, filters, selected, match, kindObj);
+    return [getActiveColumns(Header, cProps), cProps];
+  }, [Header, data, filters, selected, match, kindObj]);
+
+  const ariaRowCount = data && data.length;
+  const renderVirtualizedTable = (scrollContainer) => (
+    <WindowScroller scrollElement={scrollContainer}>
+      {({ height, isScrolling, registerChild, onChildScroll, scrollTop }) => (
+        <AutoSizer disableHeight>
+          {({ width }) => (
+            <div ref={registerChild}>
+              <VirtualBody
+                Row={Row}
+                customData={customData}
+                height={height}
+                isScrolling={isScrolling}
+                onChildScroll={onChildScroll}
+                data={data}
+                columns={columns}
+                scrollTop={scrollTop}
+                width={width}
+                expand={expand}
+                getRowProps={getRowProps}
+              />
+            </div>
+          )}
+        </AutoSizer>
+      )}
+    </WindowScroller>
+  );
+  const children = (
+    <div className={classNames({ 'co-virtualized-table': virtualize })}>
+      <TableWrapper virtualize={virtualize} ariaLabel={ariaLabel} ariaRowCount={ariaRowCount}>
+        <PfTable
+          cells={columns}
+          gridBreakPoint={gridBreakPoint}
+          role={virtualize ? 'presentation' : 'grid'}
+          aria-label={virtualize ? null : ariaLabel}
+          variant="compact"
+          borders={false}
+        >
+          <TableHeader role="rowgroup" />
+          {!virtualize && <TableBody />}
+        </PfTable>
+        {virtualize && <WithScrollContainer>{renderVirtualizedTable}</WithScrollContainer>}
+      </TableWrapper>
+    </div>
+  );
+  return (
+    <div className="co-m-table-grid co-m-table-grid--bordered">
+      <StatusBox
+        skeleton={<div className="loading-skeleton--table" />}
+        data={data}
+        loaded={loaded}
+        loadError={loadError}
+        unfilteredData={data}
+        label={label}
+        NoDataEmptyMsg={NoDataEmptyMsg}
+        EmptyMsg={EmptyMsg}
+      >
+        {children}
+      </StatusBox>
+    </div>
+  );
+};
+
+export default Table;

--- a/src/shared/components/table/TableData.tsx
+++ b/src/shared/components/table/TableData.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+
+export type TableDataProps = {
+  className?: string;
+  columnID?: string;
+  columns?: Set<string>;
+  id?: string;
+};
+
+export const TableData: React.FC<TableDataProps> = ({ className, ...props }) => (
+  <td {...props} className={className} role="gridcell" />
+);

--- a/src/shared/components/table/TableRow.tsx
+++ b/src/shared/components/table/TableRow.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+
+export type TableRowProps = {
+  id: React.ReactText;
+  index: number;
+  title?: string;
+  trKey: string;
+  style: object;
+  className?: string;
+};
+
+export const TableRow: React.FC<TableRowProps> = ({
+  id,
+  index,
+  trKey,
+  style,
+  className,
+  ...props
+}) => {
+  return (
+    <tr
+      {...props}
+      data-id={id}
+      data-index={index}
+      data-test-rows="resource-row"
+      data-key={trKey}
+      style={style}
+      className={className}
+      role="row"
+    />
+  );
+};

--- a/src/shared/components/table/VirtualBody.tsx
+++ b/src/shared/components/table/VirtualBody.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import { CellMeasurerCache, CellMeasurer } from 'react-virtualized';
+import { VirtualTableBody } from '@patternfly/react-virtualized-extension';
+import { Scroll } from '@patternfly/react-virtualized-extension/dist/js/components/Virtualized/types';
+import { TableRow, TableRowProps } from './TableRow';
+
+export type VirtualBodyProps<D = any, C = any> = {
+  customData?: C;
+  Row: React.FC<RowFunctionArgs>;
+  height: number;
+  isScrolling: boolean;
+  onChildScroll: (params: Scroll) => void;
+  data: D[];
+  columns: any[];
+  scrollTop: number;
+  width: number;
+  expand: boolean;
+  getRowProps?: (obj: D) => Partial<Pick<TableRowProps, 'id' | 'className' | 'title'>>;
+};
+
+export type RowFunctionArgs<T = any, C = any> = {
+  obj: T;
+  columns: any[];
+  customData?: C;
+};
+
+const RowMemo = React.memo<RowFunctionArgs & { Row: React.FC<RowFunctionArgs> }>(
+  ({ Row, ...props }) => <Row {...props} />,
+);
+
+export const VirtualBody: React.FC<VirtualBodyProps> = (props) => {
+  const {
+    customData,
+    Row,
+    height,
+    isScrolling,
+    onChildScroll,
+    data,
+    columns,
+    scrollTop,
+    width,
+    getRowProps,
+  } = props;
+
+  const cellMeasurementCache = new CellMeasurerCache({
+    fixedWidth: true,
+    minHeight: 44,
+    keyMapper: (rowIndex) => props?.data?.[rowIndex]?.metadata.uid ?? rowIndex,
+  });
+
+  const rowRenderer = ({ index, isVisible, key, style, parent }) => {
+    const rowArgs = {
+      obj: data[index],
+      columns,
+      customData,
+    };
+
+    // do not render non visible elements (this excludes overscan)
+    if (!isVisible) {
+      return null;
+    }
+
+    const rowProps = getRowProps?.(rowArgs.obj);
+    const rowId = rowProps?.id ?? key;
+    return (
+      <CellMeasurer
+        cache={cellMeasurementCache}
+        columnIndex={0}
+        key={key}
+        parent={parent}
+        rowIndex={index}
+      >
+        <TableRow {...rowProps} id={rowId} index={index} trKey={key} style={style}>
+          <RowMemo Row={Row} {...rowArgs} />
+        </TableRow>
+      </CellMeasurer>
+    );
+  };
+
+  return (
+    <VirtualTableBody
+      autoHeight
+      className="pf-c-table pf-m-compact pf-m-border-rows pf-c-window-scroller"
+      deferredMeasurementCache={cellMeasurementCache}
+      rowHeight={cellMeasurementCache.rowHeight}
+      height={height || 0}
+      isScrolling={isScrolling}
+      onScroll={onChildScroll}
+      overscanRowCount={10}
+      columns={columns}
+      rows={data}
+      rowCount={data.length}
+      rowRenderer={rowRenderer}
+      scrollTop={scrollTop}
+      width={width}
+    />
+  );
+};

--- a/src/shared/components/table/index.ts
+++ b/src/shared/components/table/index.ts
@@ -1,0 +1,4 @@
+export { default as Table } from './Table';
+export { TableRow } from './TableRow';
+export { TableData } from './TableData';
+export * from './VirtualBody';

--- a/src/shared/components/timestamp/Timestamp.tsx
+++ b/src/shared/components/timestamp/Timestamp.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import { Tooltip } from '@patternfly/react-core';
+import { GlobeAmericasIcon } from '@patternfly/react-icons/dist/js/icons';
+import classNames from 'classnames';
+import * as dateTime from './datetime';
+
+export type TimestampProps = {
+  timestamp: string | number;
+  isUnix?: boolean;
+  simple?: boolean;
+  omitSuffix?: boolean;
+  className?: string;
+};
+
+const timestampFor = (mdate: Date, now: Date, omitSuffix: boolean) => {
+  if (!dateTime.isValid(mdate)) {
+    return '-';
+  }
+
+  const timeDifference = now.getTime() - mdate.getTime();
+  if (omitSuffix) {
+    return dateTime.fromNow(mdate, undefined, { omitSuffix: true });
+  }
+
+  // Show a relative time if within 10.5 minutes in the past from the current time.
+  if (timeDifference > dateTime.maxClockSkewMS && timeDifference < 630000) {
+    return dateTime.fromNow(mdate);
+  }
+
+  // Apr 23, 2021, 4:33 PM
+  return dateTime.dateTimeFormatter.format(mdate);
+};
+
+export const Timestamp: React.FC<TimestampProps> = ({
+  timestamp,
+  isUnix,
+  omitSuffix,
+  simple,
+  className,
+}) => {
+  // Check for null. If props.timestamp is null, it returns incorrect date and time of Wed Dec 31 1969 19:00:00 GMT-0500 (Eastern Standard Time)
+  if (!timestamp) {
+    return <div>-</div>;
+  }
+
+  const mdate = isUnix ? new Date((timestamp as number) * 1000) : new Date(timestamp);
+
+  const timeStamp = timestampFor(mdate, new Date(), omitSuffix);
+
+  if (!dateTime.isValid(mdate)) {
+    return <div>-</div>;
+  }
+
+  if (simple) {
+    return <>{timeStamp}</>;
+  }
+
+  return (
+    <div className={classNames('co-icon-and-text', className)}>
+      <GlobeAmericasIcon className="co-icon-and-text__icon" />
+      <Tooltip
+        content={[
+          <span className="co-nowrap" key={timestamp}>
+            {dateTime.utcDateTimeFormatter.format(mdate)}
+          </span>,
+        ]}
+      >
+        <span data-test="timestamp">{timeStamp}</span>
+      </Tooltip>
+    </div>
+  );
+};
+
+Timestamp.displayName = 'Timestamp';

--- a/src/shared/components/timestamp/__tests__/Timestamp.spec.tsx
+++ b/src/shared/components/timestamp/__tests__/Timestamp.spec.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import * as dateTime from '../datetime';
+import { Timestamp } from '../Timestamp';
+
+describe('Timestamp', () => {
+  it('renders - when the timestamp is invalid', () => {
+    const { getByText } = render(<Timestamp timestamp="xyz" />);
+    expect(getByText('-')).toBeInTheDocument();
+  });
+
+  it('renders correct timestamp when valid string is passed', () => {
+    const expectedDate = dateTime.dateTimeFormatter.format(new Date('2022-02-03T19:34:28Z'));
+    const { getByText } = render(<Timestamp timestamp="2022-02-03T19:34:28Z" />);
+    expect(getByText(expectedDate.toString())).toBeInTheDocument();
+  });
+});

--- a/src/shared/components/timestamp/datetime.ts
+++ b/src/shared/components/timestamp/datetime.ts
@@ -1,0 +1,186 @@
+import { pluralize } from '@patternfly/react-core';
+import * as _ from 'lodash-es';
+
+// The maximum allowed clock skew in milliseconds where we show a date as "Just now" even if it is from the future.
+export const maxClockSkewMS = -60000;
+
+// https://tc39.es/ecma402/#datetimeformat-objects
+export const timeFormatter = new Intl.DateTimeFormat(undefined, {
+  hour: 'numeric',
+  minute: 'numeric',
+});
+
+export const timeFormatterWithSeconds = new Intl.DateTimeFormat(undefined, {
+  hour: 'numeric',
+  minute: 'numeric',
+  second: 'numeric',
+});
+
+export const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+});
+
+export const dateFormatterNoYear = new Intl.DateTimeFormat(undefined, {
+  month: 'short',
+  day: 'numeric',
+});
+
+export const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
+  month: 'short',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  year: 'numeric',
+});
+
+export const dateTimeFormatterWithSeconds = new Intl.DateTimeFormat(undefined, {
+  month: 'short',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  second: 'numeric',
+  year: 'numeric',
+});
+
+export const utcDateTimeFormatter = new Intl.DateTimeFormat(undefined, {
+  month: 'short',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  year: 'numeric',
+  timeZone: 'UTC',
+  timeZoneName: 'short',
+});
+
+export const relativeTimeFormatter = Intl.RelativeTimeFormat
+  ? new Intl.RelativeTimeFormat(undefined)
+  : null;
+
+export const getDuration = (ms: number) => {
+  if (!ms || ms < 0) {
+    ms = 0;
+  }
+  let seconds = Math.floor(ms / 1000);
+  let minutes = Math.floor(seconds / 60);
+  seconds = seconds % 60;
+  let hours = Math.floor(minutes / 60);
+  minutes = minutes % 60;
+  const days = Math.floor(hours / 24);
+  hours = hours % 24;
+  return { days, hours, minutes, seconds };
+};
+
+export const fromNow = (dateTime: string | Date, now?: Date, options?) => {
+  // Check for null. If dateTime is null, it returns incorrect date Jan 1 1970.
+  if (!dateTime) {
+    return '-';
+  }
+
+  if (!now) {
+    now = new Date();
+  }
+
+  const d = new Date(dateTime);
+  const ms = now.getTime() - d.getTime();
+  const justNow = 'Just now';
+
+  // If the event occurred less than one minute in the future, assume it's clock drift and show "Just now."
+  if (!options?.omitSuffix && ms < 60000 && ms > maxClockSkewMS) {
+    return justNow;
+  }
+
+  // Do not attempt to handle other dates in the future.
+  if (ms < 0) {
+    return '-';
+  }
+
+  const { days, hours, minutes } = getDuration(ms);
+
+  if (options?.omitSuffix) {
+    if (days) {
+      return pluralize(days, 'day', 'days');
+    }
+    if (hours) {
+      return pluralize(hours, 'hour', 'hours');
+    }
+    return pluralize(minutes, 'minute', 'minutes');
+  }
+
+  // Fallback to normal date/time formatting if Intl.RelativeTimeFormat is not
+  // available. This is the case for older Safari versions.
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat#browser_compatibility
+  if (!relativeTimeFormatter) {
+    return dateTimeFormatter.format(d);
+  }
+
+  if (!days && !hours && !minutes) {
+    return justNow;
+  }
+
+  if (days) {
+    return relativeTimeFormatter.format(-days, 'day');
+  }
+
+  if (hours) {
+    return relativeTimeFormatter.format(-hours, 'hour');
+  }
+
+  return relativeTimeFormatter.format(-minutes, 'minute');
+};
+
+export const isValid = (dateTime: Date) => dateTime instanceof Date && !_.isNaN(dateTime.valueOf());
+
+// Conversions between units and milliseconds
+const s = 1000;
+const m = s * 60;
+const h = m * 60;
+const d = h * 24;
+const w = d * 7;
+const units = { w, d, h, m, s };
+
+// Formats a duration in milliseconds like "1h 10m"
+export const formatPrometheusDuration = (ms: number) => {
+  if (!_.isFinite(ms) || ms < 0) {
+    return '';
+  }
+  let remaining = ms;
+  let str = '';
+  _.each(units, (factor, unit) => {
+    const n = Math.floor(remaining / factor);
+    if (n > 0) {
+      str += `${n}${unit} `;
+      remaining -= n * factor;
+    }
+  });
+  return _.trim(str);
+};
+
+// Converts a duration like "1h 10m 23s" to milliseconds or returns 0 if the duration could not be
+// parsed
+export const parsePrometheusDuration = (duration: string): number => {
+  try {
+    const parts = duration
+      .trim()
+      .split(/\s+/)
+      .map((p) => p.match(/^(\d+)([wdhms])$/));
+    return _.sumBy(parts, (p) => parseInt(p[1], 10) * units[p[2]]);
+  } catch (ignored) {
+    // Invalid duration format
+    return 0;
+  }
+};
+
+const zeroPad = (number: number) => (number < 10 ? `0${number}` : number);
+
+// Get YYYY-MM-DD date string for a date object
+export const toISODateString = (date: Date): string =>
+  `${date.getFullYear()}-${zeroPad(date.getMonth() + 1)}-${zeroPad(date.getDate())}`;
+
+export const twentyFourHourTime = (date: Date, showSeconds?: boolean): string => {
+  const hours = zeroPad(date.getHours() ?? 0);
+  const minutes = `:${zeroPad(date.getMinutes() ?? 0)}`;
+  const seconds = showSeconds ? `:${zeroPad(date.getSeconds() ?? 0)}` : '';
+  return `${hours}${minutes}${seconds}`;
+};

--- a/src/shared/style/_common.scss
+++ b/src/shared/style/_common.scss
@@ -151,3 +151,17 @@ $co-external-link-padding-right: 15px;
     align-items: flex-start;
   }
 }
+
+.co-icon-and-text {
+  align-items: baseline;
+  display: inline-block;
+
+  &__icon {
+    flex-shrink: 0;
+    margin-right: 5px;
+  }
+}
+
+.co-nowrap {
+  white-space: nowrap;
+}


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-542


## Description
- the Applications list page lists all the applications if available otherwise the empty state is being shown, the most recently deployed application is listed first
- user can create a new app by clicking on the `Create Application` button on the list page
- clicking on the application name will take the user to the Composition view page
- added tests


## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Gifs & screenshots for design review 
![applistpage](https://user-images.githubusercontent.com/22490998/153030311-98fc59c7-0337-42da-9cb9-0a428e807484.gif)
![emptystate](https://user-images.githubusercontent.com/22490998/153368178-67da4a89-7dd6-46c3-ae77-812fb82ba0a3.png)

## How to test or reproduce?
Goto URL : https://prod.foo.redhat.com:1337/beta/hac/app-studio/applications

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
