### PR TITLE
Remove rhopp from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,7 +8,6 @@ reviewers:
   - jrichter1
   - karthikjeeyar
   - nemesis09
-  - rhopp
   - rohitkrai03
   - rottencandy
   - sahil143


### PR DESCRIPTION
## Fixes 
No fix


## Description
Please remove me from the OWNERS file - I don't have enough understanding for reviewing random PRs in this repo. 
Once we have for example e2e tests subfolder, I'm fine being included in the OWNERS file in there, but being in root OWNERS makes no sense for me. Thx.
