### PR TITLE
Add delete action in the Component list page

### DIFF
--- a/src/components/ComponentListView/ComponentListItem.tsx
+++ b/src/components/ComponentListView/ComponentListItem.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  DataListAction,
   DataListContent,
   DataListItem,
   DataListItemCells,
@@ -12,8 +13,11 @@ import {
   DescriptionListTermHelpText,
   DescriptionListTermHelpTextButton,
 } from '@patternfly/react-core';
+import ActionMenu from '../../shared/components/action-menu/ActionMenu';
 import ExternalLink from '../../shared/components/links/ExternalLink';
 import { ComponentKind } from '../../types';
+import { deleteComponent } from '../../utils/delete-utils';
+
 import './ComponentListItem.scss';
 
 type ComponentListViewPageProps = {
@@ -48,6 +52,25 @@ export const ComponentListItem: React.FC<ComponentListViewPageProps> = ({ compon
             </DescriptionList>,
           ]}
         />
+        <DataListAction
+          aria-labelledby={`${name.toLowerCase()}-actions`}
+          data-testid={`${name.toLowerCase()}-actions`}
+          id={`${name.toLowerCase()}-actions`}
+          aria-label={`${name.toLowerCase()}-actions`}
+          isPlainButtonAction
+        >
+          <ActionMenu
+            actions={[
+              {
+                cta: () => {
+                  deleteComponent(name, component.metadata.namespace);
+                },
+                id: `delete-${name.toLowerCase()}`,
+                label: 'Delete',
+              },
+            ]}
+          />
+        </DataListAction>
       </DataListItemRow>
       <DataListContent
         className="hacDev-component-list-item__details"

--- a/src/components/ComponentListView/ComponentListViewPage.tsx
+++ b/src/components/ComponentListView/ComponentListViewPage.tsx
@@ -1,16 +1,14 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import {
+  Button,
   DataList,
-  DataListCell,
   DataListItem,
-  DataListItemCells,
   DataListItemRow,
   Toolbar,
   ToolbarContent,
   ToolbarItem,
   TextInput,
-  Button,
 } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons/dist/js/icons';
 import { useK8sWatchResource } from '../../dynamic-plugin-sdk';
@@ -31,6 +29,7 @@ export const ComponentListViewPage: React.FC<ComponentListViewPageProps> = ({ ap
     namespace,
     isList: true,
   });
+  const [nameFilter, setNameFilter] = React.useState<string>('');
   const loaded = namespace && componentsLoaded;
 
   // TODO: handle empty state / components not found
@@ -38,8 +37,6 @@ export const ComponentListViewPage: React.FC<ComponentListViewPageProps> = ({ ap
     () => (loaded ? allComponents?.filter((c) => c.spec.application === application) : []),
     [allComponents, application, loaded],
   );
-
-  const [nameFilter, setNameFilter] = React.useState<string>('');
 
   const filteredComponents = React.useMemo(
     () =>
@@ -54,41 +51,37 @@ export const ComponentListViewPage: React.FC<ComponentListViewPageProps> = ({ ap
 
   return (
     <StatusBox data={allComponents} loaded={loaded}>
-      <Toolbar data-testid="component-list-filter-toolbar" clearAllFilters={onClearFilters}>
-        <ToolbarContent>
-          <ToolbarItem>
-            <Button variant="control">
-              <FilterIcon /> {'Name'}
-            </Button>
-          </ToolbarItem>
-          <ToolbarItem>
-            <TextInput
-              name="nameInput"
-              data-testid="nameInput1"
-              type="search"
-              aria-label="name filter"
-              placeholder="Filter by name..."
-              onChange={(name) => onNameInput(name)}
-            />
-          </ToolbarItem>
-        </ToolbarContent>
-      </Toolbar>
-
       <DataList aria-label="Components" data-testid="component-list">
         <DataListItem>
           <DataListItemRow>
-            <DataListItemCells
-              dataListCells={[
-                <DataListCell key="add component">
+            <Toolbar data-testid="component-list-toolbar" clearAllFilters={onClearFilters}>
+              <ToolbarContent>
+                <ToolbarItem>
+                  <Button variant="control">
+                    <FilterIcon /> {'Name'}
+                  </Button>
+                </ToolbarItem>
+                <ToolbarItem>
+                  <TextInput
+                    name="nameInput"
+                    data-testid="name-input-filter"
+                    type="search"
+                    aria-label="name filter"
+                    placeholder="Filter by name..."
+                    onChange={(name) => onNameInput(name)}
+                  />
+                </ToolbarItem>
+                <ToolbarItem>
                   <Link
+                    data-testid="add-component"
                     className="pf-c-button pf-m-primary"
                     to={`/create?application=${application}`}
                   >
                     Add Component
                   </Link>
-                </DataListCell>,
-              ]}
-            />
+                </ToolbarItem>
+              </ToolbarContent>
+            </Toolbar>
           </DataListItemRow>
         </DataListItem>
         {filteredComponents?.map((component) => (

--- a/src/components/ComponentListView/__tests__/ComponentListViewPage.spec.tsx
+++ b/src/components/ComponentListView/__tests__/ComponentListViewPage.spec.tsx
@@ -56,7 +56,7 @@ describe('ComponentListViewPage', () => {
       true,
     ]);
     render(<ComponentListViewPage application="test-app" />);
-    expect(screen.getByTestId('component-list-filter-toolbar')).toBeInTheDocument();
+    expect(screen.getByTestId('component-list-toolbar')).toBeInTheDocument();
   });
   it('renders 3 component entries', () => {
     watchResourceMock.mockReturnValue([
@@ -77,7 +77,7 @@ describe('ComponentListViewPage', () => {
       true,
     ]);
     render(<ComponentListViewPage application="test-app" />);
-    const searchInput = screen.getByTestId('nameInput1');
+    const searchInput = screen.getByTestId('name-input-filter');
     fireEvent.change(searchInput, { target: { value: 'test' } });
     const componentList = screen.getByTestId('component-list');
     const componentListItems = within(componentList).getAllByTestId('component-list-item');
@@ -103,7 +103,7 @@ describe('ComponentListViewPage', () => {
       true,
     ]);
     render(<ComponentListViewPage application="test-app" />);
-    const searchInput = screen.getByTestId('nameInput1');
+    const searchInput = screen.getByTestId('name-input-filter');
     fireEvent.change(searchInput, { target: { value: 'aa' } });
     const componentList = screen.getByTestId('component-list');
     const componentListItems = within(componentList).getAllByTestId('component-list-item');

--- a/src/shared/components/action-menu/ActionMenu.tsx
+++ b/src/shared/components/action-menu/ActionMenu.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+import { Menu, Popper, MenuContent, MenuList } from '@patternfly/react-core';
+import ActionMenuContent from './ActionMenuContent';
+import ActionMenuToggle from './ActionMenuToggle';
+import { ActionMenuVariant, MenuOption } from './types';
+
+type ActionMenuProps = {
+  actions: MenuOption[];
+  variant?: ActionMenuVariant;
+  label?: string;
+  isDisabled?: boolean;
+};
+
+type MenuRendererProps = {
+  isOpen: boolean;
+  containerRef: React.RefObject<HTMLDivElement>;
+  menuRef: React.RefObject<HTMLDivElement>;
+  toggleRef: React.RefObject<HTMLButtonElement>;
+} & React.ComponentProps<typeof ActionMenuContent>;
+
+const MenuRenderer: React.FC<MenuRendererProps> = ({
+  isOpen,
+  containerRef,
+  menuRef,
+  toggleRef,
+  ...restProps
+}) => {
+  const menu = (
+    <Menu ref={menuRef} containsFlyout onSelect={restProps.onClick}>
+      <MenuContent data-testid="action-menu" translate="no">
+        <MenuList>
+          <ActionMenuContent {...restProps} />
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+
+  return (
+    <Popper
+      reference={toggleRef}
+      popper={menu}
+      placement="bottom-end"
+      isVisible={isOpen}
+      appendTo={containerRef.current}
+      popperMatchesTriggerWidth={false}
+    />
+  );
+};
+
+const ActionMenu: React.FC<ActionMenuProps> = ({
+  variant = ActionMenuVariant.KEBAB,
+  label,
+  isDisabled,
+  actions,
+}) => {
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
+  const menuRef = React.useRef<HTMLDivElement>(null);
+  const toggleRef = React.useRef<HTMLButtonElement>(null);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  const hideMenu = () => {
+    setIsOpen(false);
+  };
+
+  return (
+    <div ref={containerRef}>
+      <ActionMenuToggle
+        isOpen={isOpen}
+        isDisabled={isDisabled}
+        toggleRef={toggleRef}
+        toggleVariant={variant}
+        toggleTitle={label}
+        menuRef={menuRef}
+        onToggleClick={setIsOpen}
+      />
+      <MenuRenderer
+        isOpen={isOpen}
+        options={actions}
+        containerRef={containerRef}
+        menuRef={menuRef}
+        toggleRef={toggleRef}
+        onClick={hideMenu}
+        focusItem={actions[0]}
+      />
+    </div>
+  );
+};
+
+export default ActionMenu;

--- a/src/shared/components/action-menu/ActionMenuContent.tsx
+++ b/src/shared/components/action-menu/ActionMenuContent.tsx
@@ -1,0 +1,93 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import * as React from 'react';
+import { Menu, MenuContent, MenuGroup, MenuItem, MenuList, Divider } from '@patternfly/react-core';
+import { getMenuOptionType } from './action-menu-utils';
+import ActionMenuItem from './ActionMenuItem';
+import { Action, GroupedMenuOption, MenuOption, MenuOptionType } from './types';
+
+type GroupMenuContentProps = {
+  option: GroupedMenuOption;
+  onClick: () => void;
+};
+
+type ActionMenuContentProps = {
+  options: MenuOption[];
+  onClick: () => void;
+  focusItem?: MenuOption;
+};
+
+export const GroupMenuContent: React.FC<GroupMenuContentProps> = ({ option, onClick }) => (
+  <>
+    <Divider />
+    <MenuGroup label={option.label} translate="no">
+      <MenuList>
+        <ActionMenuContent
+          options={option.children}
+          onClick={onClick}
+          focusItem={option.children[0]}
+        />
+      </MenuList>
+    </MenuGroup>
+  </>
+);
+
+// Need to keep this in the same file to avoid circular dependency.
+export const SubMenuContent: React.FC<GroupMenuContentProps> = ({ option, onClick }) => (
+  <MenuItem
+    data-testid={option.id}
+    flyoutMenu={
+      <Menu containsFlyout>
+        <MenuContent data-testid="action-items" translate="no">
+          <MenuList>
+            <ActionMenuContent
+              options={option.children}
+              onClick={onClick}
+              focusItem={option.children[0]}
+            />
+          </MenuList>
+        </MenuContent>
+      </Menu>
+    }
+  >
+    {option.label}
+  </MenuItem>
+);
+
+const ActionMenuContent: React.FC<ActionMenuContentProps> = ({ options, onClick, focusItem }) => {
+  return (
+    <>
+      {options.map((option) => {
+        const optionType = getMenuOptionType(option);
+        switch (optionType) {
+          case MenuOptionType.SUB_MENU:
+            return (
+              <SubMenuContent
+                key={option.id}
+                option={option as GroupedMenuOption}
+                onClick={onClick}
+              />
+            );
+          case MenuOptionType.GROUP_MENU:
+            return (
+              <GroupMenuContent
+                key={option.id}
+                option={option as GroupedMenuOption}
+                onClick={onClick}
+              />
+            );
+          default:
+            return (
+              <ActionMenuItem
+                key={option.id}
+                action={option as Action}
+                onClick={onClick}
+                autoFocus={focusItem ? option === focusItem : undefined}
+              />
+            );
+        }
+      })}
+    </>
+  );
+};
+
+export default ActionMenuContent;

--- a/src/shared/components/action-menu/ActionMenuItem.tsx
+++ b/src/shared/components/action-menu/ActionMenuItem.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import {
+  KEY_CODES,
+  MenuItem,
+  Tooltip,
+  DropdownItemProps,
+  MenuItemProps,
+} from '@patternfly/react-core';
+import classNames from 'classnames';
+import * as _ from 'lodash-es';
+import { history } from '../../utils';
+import { Action } from './types';
+
+export type ActionMenuItemProps = {
+  action: Action;
+  component?: React.ComponentType<MenuItemProps | DropdownItemProps>;
+  autoFocus?: boolean;
+  onClick?: () => void;
+  onEscape?: () => void;
+};
+
+const ActionItem: React.FC<ActionMenuItemProps & { isAllowed: boolean }> = ({
+  action,
+  onClick,
+  onEscape,
+  autoFocus,
+  isAllowed,
+  component,
+}) => {
+  const { label, icon, disabled, cta } = action;
+  const { href, external } = cta as { href: string; external?: boolean };
+  const isDisabled = !isAllowed || disabled;
+  const classes = classNames({ 'pf-m-disabled': isDisabled });
+
+  const handleClick = React.useCallback(
+    (event) => {
+      event.preventDefault();
+      if (_.isFunction(cta)) {
+        cta();
+      } else if (_.isObject(cta)) {
+        if (!cta.external) {
+          history.push(cta.href);
+        }
+      }
+      onClick && onClick();
+    },
+    [cta, onClick],
+  );
+
+  const handleKeyDown = (event) => {
+    if (event.keyCode === KEY_CODES.ESCAPE_KEY) {
+      onEscape && onEscape();
+    }
+
+    if (event.keyCode === KEY_CODES.ENTER) {
+      handleClick(event);
+    }
+  };
+  const Component = component ?? MenuItem;
+
+  const props = {
+    icon,
+    autoFocus,
+    isDisabled,
+    className: classes,
+    onClick: handleClick,
+    'data-testid': label,
+  };
+
+  const extraProps = {
+    onKeyDown: handleKeyDown,
+    ...(external ? { to: href, isExternalLink: external } : {}),
+  };
+
+  return (
+    <Component {...props} {...(component ? {} : extraProps)}>
+      {label}
+    </Component>
+  );
+};
+
+const ActionMenuItem: React.FC<ActionMenuItemProps> = (props) => {
+  const { action } = props;
+  const item = <ActionItem {...props} isAllowed />;
+
+  return action.tooltip ? (
+    <Tooltip position="left" content={action.tooltip}>
+      {item}
+    </Tooltip>
+  ) : (
+    item
+  );
+};
+
+export default ActionMenuItem;

--- a/src/shared/components/action-menu/ActionMenuToggle.tsx
+++ b/src/shared/components/action-menu/ActionMenuToggle.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+import { MenuToggle } from '@patternfly/react-core';
+import { EllipsisVIcon } from '@patternfly/react-icons/dist/js/icons';
+import { ActionMenuVariant } from './types';
+
+type ActionMenuToggleProps = {
+  isOpen: boolean;
+  isDisabled: boolean;
+  menuRef: React.RefObject<HTMLElement>;
+  toggleRef: React.RefObject<HTMLButtonElement>;
+  toggleVariant?: ActionMenuVariant;
+  toggleTitle?: string;
+  onToggleClick: (state: React.SetStateAction<boolean>) => void;
+  onToggleHover?: () => void;
+};
+
+const ActionMenuToggle: React.FC<ActionMenuToggleProps> = ({
+  isOpen,
+  isDisabled,
+  menuRef,
+  toggleRef,
+  toggleVariant = ActionMenuVariant.KEBAB,
+  toggleTitle,
+  onToggleClick,
+  onToggleHover,
+}) => {
+  const isKebabVariant = toggleVariant === ActionMenuVariant.KEBAB;
+  const toggleLabel = toggleTitle || 'Actions';
+
+  const handleMenuKeys = (event) => {
+    if (!isOpen) {
+      return;
+    }
+    if (menuRef.current) {
+      if (event.key === 'Escape') {
+        onToggleClick(false);
+        toggleRef.current.focus();
+      }
+      if (!menuRef.current?.contains(event.target) && event.key === 'Tab') {
+        onToggleClick(false);
+      }
+    }
+  };
+
+  const handleClickOutside = (event) => {
+    if (isOpen && !menuRef.current?.contains(event.target)) {
+      onToggleClick(false);
+    }
+  };
+
+  React.useEffect(() => {
+    window.addEventListener('keydown', handleMenuKeys);
+    window.addEventListener('click', handleClickOutside);
+    return () => {
+      window.removeEventListener('keydown', handleMenuKeys);
+      window.removeEventListener('click', handleClickOutside);
+    }; // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]); // This needs to be run only on component mount/unmount
+
+  const handleToggleClick = (ev) => {
+    ev.stopPropagation(); // Stop handleClickOutside from handling
+    setTimeout(() => {
+      const firstElement = menuRef?.current?.querySelector<HTMLElement>(
+        'li > button:not(:disabled)',
+      );
+      firstElement?.focus();
+    }, 0);
+    onToggleClick((open) => !open);
+  };
+
+  return (
+    <MenuToggle
+      variant={toggleVariant}
+      innerRef={toggleRef}
+      isExpanded={isOpen}
+      isDisabled={isDisabled}
+      aria-expanded={isOpen}
+      aria-label={toggleLabel}
+      aria-haspopup="true"
+      data-testid={isKebabVariant ? 'kebab-button' : toggleLabel}
+      onClick={handleToggleClick}
+      onFocus={onToggleHover}
+      onMouseOver={onToggleHover}
+    >
+      {isKebabVariant ? <EllipsisVIcon /> : toggleLabel}
+    </MenuToggle>
+  );
+};
+
+export default ActionMenuToggle;

--- a/src/shared/components/action-menu/__tests__/ActionMenu.spec.tsx
+++ b/src/shared/components/action-menu/__tests__/ActionMenu.spec.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ActionMenu from '../ActionMenu';
+
+describe('Action Menu', () => {
+  it('should render the actions when clicked on the kebab menu', async () => {
+    render(
+      <ActionMenu
+        actions={[
+          {
+            cta: () => {},
+            id: 'action-1',
+            label: 'Action 1',
+          },
+          {
+            cta: () => {},
+            id: 'action-2',
+            label: 'Action 2',
+          },
+        ]}
+      />,
+    );
+    expect(screen.queryByTestId('Action 1')).toBeNull();
+    expect(screen.queryByTestId('Action 2')).toBeNull();
+    fireEvent.click(screen.getByTestId('kebab-button'));
+    await waitFor(() => {
+      expect(screen.getByTestId('Action 1').textContent).toBe('Action 1');
+      expect(screen.getByTestId('Action 2').textContent).toBe('Action 2');
+    });
+  });
+});

--- a/src/shared/components/action-menu/action-menu-utils.ts
+++ b/src/shared/components/action-menu/action-menu-utils.ts
@@ -1,0 +1,18 @@
+import { GroupedMenuOption, MenuOption, MenuOptionType } from './types';
+
+export const getMenuOptionType = (option: MenuOption) => {
+  // a grouped menu has children
+  const isGroupMenu = Array.isArray((option as GroupedMenuOption).children);
+  // a submenu menu has children and submenu property true
+  const isSubMenu = isGroupMenu && (option as GroupedMenuOption).submenu;
+
+  if (isSubMenu) {
+    return MenuOptionType.SUB_MENU;
+  }
+
+  if (isGroupMenu) {
+    return MenuOptionType.GROUP_MENU;
+  }
+
+  return MenuOptionType.ATOMIC_MENU;
+};

--- a/src/shared/components/action-menu/types.ts
+++ b/src/shared/components/action-menu/types.ts
@@ -1,0 +1,36 @@
+import * as React from 'react';
+
+export type Action = {
+  id: string;
+  label: React.ReactNode;
+  description?: string;
+  cta: (() => void) | { href: string; external?: boolean };
+  disabled?: boolean;
+  tooltip?: string;
+  icon?: string | React.ReactNode;
+  path?: string;
+};
+
+/** ActionGroup contributes an action group that can also be a submenu */
+export type ActionGroup = {
+  id: string;
+  label?: string;
+  submenu?: boolean;
+};
+
+export type MenuOption = Action | GroupedMenuOption;
+
+export type GroupedMenuOption = ActionGroup & {
+  children?: MenuOption[];
+};
+
+export enum MenuOptionType {
+  GROUP_MENU,
+  SUB_MENU,
+  ATOMIC_MENU,
+}
+
+export enum ActionMenuVariant {
+  KEBAB = 'plain',
+  DROPDOWN = 'default',
+}

--- a/src/utils/delete-utils.ts
+++ b/src/utils/delete-utils.ts
@@ -1,0 +1,27 @@
+import { ComponentModel } from '../models';
+import { k8sDeleteResource } from './../dynamic-plugin-sdk';
+
+/**
+ * Delete Component CR
+ *
+ * @param component component data TODO: Data might change based on the API requirements
+ * @param application application name
+ * @returns A promise
+ *
+ * TODO: Return type any should be changed to a proper type like K8sResourceCommon
+ */
+export const deleteComponent = (componentName: string, namespace: string): any => {
+  const componentData = {
+    apiVersion: `${ComponentModel.apiGroup}/${ComponentModel.apiVersion}`,
+    kind: 'Component',
+    metadata: {
+      name: componentName,
+      namespace,
+    },
+  };
+  // TODO: Make Api Calls here
+  return k8sDeleteResource({
+    model: ComponentModel,
+    resource: componentData,
+  });
+};


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-544

## Description
- Added Delete action in the kebab menu which on clicked will delete the component CR
- Added tests

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
![delete-components](https://user-images.githubusercontent.com/22490998/155385969-31f86f29-c2b7-4a5b-b9c7-f8ed647f7939.gif)


## How to test or reproduce?
Goto: https://prod.foo.redhat.com:1337/beta/hac/app-studio/components?application=<application-name>

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
