### PR TITLE
Fix route utils when no route is available for the component

### DIFF
--- a/src/utils/__tests__/route-utils.spec.ts
+++ b/src/utils/__tests__/route-utils.spec.ts
@@ -7,4 +7,10 @@ describe('Route Utils', () => {
 
     expect(result).toEqual('http://elnodejs-test.apps.appstudio-stage.x99m.p1.openshiftapps.com/');
   });
+
+  it('Should return undefined if route is not created for given component', async () => {
+    const result = getComponentRouteWebURL(mockRoutes, 'nodejs-1');
+
+    expect(result).toBeUndefined();
+  });
 });

--- a/src/utils/route-utils.ts
+++ b/src/utils/route-utils.ts
@@ -38,5 +38,5 @@ export const getComponentRouteWebURL = (routes: RouteKind[], component: string):
     (r) => r.metadata?.annotations?.['build.appstudio.openshift.io/component'] === component,
   );
 
-  return getRouteWebURL(componentRoute);
+  return componentRoute && getRouteWebURL(componentRoute);
 };


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/HAC-833

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
UI crashed if there was no route available for a component. Added a null check in route utils to avoid it.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

