### PR TITLE
Allow accessing regular console.dot app static files

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -11,4 +11,8 @@ server {
       alias /opt/app-root/src;
       try_files $1 $1/ /dist/$1 /dist/$1/;
     }
+    location ~* /apps/hac-dev(.*) {
+      alias /opt/app-root/src;
+      try_files $1 $1/ /dist/$1 /dist/$1/;
+    }
 }


### PR DESCRIPTION
## Description
Since we don't have regular connection to hac-core extension let's build regular console.dot application image. This way we can present the application on console.dev environment and prepare all the necessary piping.


## Type of change

- [x] Build related changes