### PR TITLE
Use console.dot deploy mechanism

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -17,8 +17,22 @@ objects:
     frontend:
       paths:
         - /api/plugins/hac-dev
+        - /apps/hac-dev
     image: ${IMAGE}:${IMAGE_TAG}
     title: hac-dev
+    module:
+      manifestLocation: /apps/hac-dev/fed-mods.json
+      moduleID: hacDev
+      modules:
+        - id: hacDev
+          module: ./RootApp
+          routes:
+            - pathname: /hac/app-studio
+    navItems:
+      - appId: hacDev
+        href: /hac/app-studio
+        product: Red Hat Insights
+        title: App Studio
 parameters:
   - name: IMAGE_TAG
     value: latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "hac-dev",
       "version": "0.0.1",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.9.0",


### PR DESCRIPTION
## Fixes 
Unable to access hac-dev on console.dev

## Description
Deployment of hac-dev is currently possible only with `console.dot` approach, let's update the deploy script to include navigation and module reference.


## Type of change
- [x] Bugfix
- [x] Build related changes