### PR TITLE
Import just the used lodash functions

### DIFF
--- a/src/dynamic-plugin-sdk.ts
+++ b/src/dynamic-plugin-sdk.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import * as React from 'react';
-import * as _ from 'lodash';
+import isEqual from 'lodash/isEqual';
 import { useDeepCompareMemoize } from './shared';
 import {
   k8sListResourceItems,
@@ -126,7 +126,7 @@ export const useK8sWatchResource = <R extends K8sResourceCommon | K8sResourceCom
               resourceRef.current = null;
               reRender();
             }
-          } else if (!_.isEqual(resourceRef.current, data)) {
+          } else if (!isEqual(resourceRef.current, data)) {
             resourceRef.current = data;
             reRender();
           }

--- a/src/shared/components/action-menu/ActionMenuItem.tsx
+++ b/src/shared/components/action-menu/ActionMenuItem.tsx
@@ -7,7 +7,8 @@ import {
   MenuItemProps,
 } from '@patternfly/react-core';
 import classNames from 'classnames';
-import * as _ from 'lodash-es';
+import isFunction from 'lodash/isFunction';
+import isObject from 'lodash/isObject';
 import { history } from '../../utils';
 import { Action } from './types';
 
@@ -35,9 +36,9 @@ const ActionItem: React.FC<ActionMenuItemProps & { isAllowed: boolean }> = ({
   const handleClick = React.useCallback(
     (event) => {
       event.preventDefault();
-      if (_.isFunction(cta)) {
+      if (isFunction(cta)) {
         cta();
-      } else if (_.isObject(cta)) {
+      } else if (isObject(cta)) {
         if (!cta.external) {
           history.push(cta.href);
         }

--- a/src/shared/components/catalog/CatalogController.tsx
+++ b/src/shared/components/catalog/CatalogController.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
-import * as _ from 'lodash-es';
+import sortBy from 'lodash/sortBy';
 import { useQueryParams } from '../../hooks';
 import { setQueryArgument } from '../../utils';
 import PageHeading from '../headings/PageHeading';
@@ -120,7 +120,7 @@ const CatalogController: React.FC<CatalogControllerProps> = ({
       description: extension.properties.typeDescription,
     }));
 
-    return _.sortBy(types, ({ label }) => label.toLowerCase());
+    return sortBy(types, ({ label }) => label.toLowerCase());
   }, [catalogExtensions]);
 
   const catalogItems = React.useMemo(

--- a/src/shared/components/catalog/CatalogTile.tsx
+++ b/src/shared/components/catalog/CatalogTile.tsx
@@ -5,7 +5,7 @@ import {
   CatalogTile as PfCatalogTile,
 } from '@patternfly/react-catalog-view-extension';
 import { Badge, LabelGroup } from '@patternfly/react-core';
-import * as _ from 'lodash-es';
+import find from 'lodash/find';
 import { history } from '../../utils/router';
 import { isModifiedEvent } from '../../utils/utils';
 import CatalogBadges from './CatalogBadges';
@@ -33,7 +33,7 @@ const CatalogTile: React.FC<CatalogTileProps> = ({
   const { name, title, provider, description, type, badges, tags } = item;
 
   const vendor = provider ? t(`Provided by ${provider}`) : null;
-  const catalogType = _.find(catalogTypes, ['value', type]);
+  const catalogType = find(catalogTypes, ['value', type]);
   const tagsBadge = tags
     ? [
         <LabelGroup key="tag-badges" data-test="tag-badges">

--- a/src/shared/components/catalog/catalog-view/CatalogCategories.tsx
+++ b/src/shared/components/catalog/catalog-view/CatalogCategories.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { VerticalTabs, VerticalTabsTab } from '@patternfly/react-catalog-view-extension';
 import cx from 'classnames';
-import * as _ from 'lodash-es';
+import has from 'lodash/has';
+import map from 'lodash/map';
 import { hasActiveDescendant, isActiveTab } from '../utils/category-utils';
 import { CatalogCategory } from '../utils/types';
 
@@ -18,7 +19,7 @@ const CatalogCategories: React.FC<CatalogCategoriesProp> = ({
   selectedCategory,
   onSelectCategory,
 }) => {
-  const activeTab = _.has(categories, selectedCategory);
+  const activeTab = has(categories, selectedCategory);
 
   const renderTabs = (
     category: CatalogCategory & { numItems?: number },
@@ -45,7 +46,7 @@ const CatalogCategories: React.FC<CatalogCategoriesProp> = ({
       >
         {subcategories && (
           <VerticalTabs restrictTabs activeTab={isActiveTab(selectedCategoryID, category)}>
-            {_.map(subcategories, (subcategory) =>
+            {map(subcategories, (subcategory) =>
               renderTabs(subcategory, selectedCategoryID, false),
             )}
           </VerticalTabs>
@@ -56,7 +57,7 @@ const CatalogCategories: React.FC<CatalogCategoriesProp> = ({
 
   return (
     <VerticalTabs restrictTabs activeTab={activeTab} data-test="catalog-categories">
-      {_.map(categories, (category) => renderTabs(category, selectedCategory, true))}
+      {map(categories, (category) => renderTabs(category, selectedCategory, true))}
     </VerticalTabs>
   );
 };

--- a/src/shared/components/catalog/catalog-view/CatalogFilters.tsx
+++ b/src/shared/components/catalog/catalog-view/CatalogFilters.tsx
@@ -4,7 +4,8 @@ import {
   FilterSidePanelCategory,
   FilterSidePanelCategoryItem,
 } from '@patternfly/react-catalog-view-extension';
-import * as _ from 'lodash-es';
+import kebabCase from 'lodash/kebabCase';
+import map from 'lodash/map';
 import { CatalogFilterCounts, CatalogFilters as FiltersType } from '../utils/types';
 
 type CatalogFiltersProps = {
@@ -37,7 +38,7 @@ const CatalogFilters: React.FC<CatalogFiltersProps> = ({
         onClick={(e: React.ChangeEvent<HTMLInputElement>) =>
           onFilterChange(groupName, filterName, e.target.checked)
         }
-        data-test={`${groupName}-${_.kebabCase(filterName)}`}
+        data-test={`${groupName}-${kebabCase(filterName)}`}
         {...dummyProps}
       >
         {label}
@@ -54,15 +55,13 @@ const CatalogFilters: React.FC<CatalogFiltersProps> = ({
         showAll={filterGroupsShowAll[groupName] ?? false}
         data-test-group-name={groupName}
       >
-        {_.map(filterGroup, (filter, filterName) =>
-          renderFilterItem(filter, filterName, groupName),
-        )}
+        {map(filterGroup, (filter, filterName) => renderFilterItem(filter, filterName, groupName))}
       </FilterSidePanelCategory>
     ) : null;
 
   return (
     <FilterSidePanel>
-      {_.map(activeFilters, (filterGroup, groupName) => renderFilterGroup(filterGroup, groupName))}
+      {map(activeFilters, (filterGroup, groupName) => renderFilterGroup(filterGroup, groupName))}
     </FilterSidePanel>
   );
 };

--- a/src/shared/components/catalog/catalog-view/CatalogGrid.tsx
+++ b/src/shared/components/catalog/catalog-view/CatalogGrid.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Title } from '@patternfly/react-core';
-import * as _ from 'lodash-es';
+import size from 'lodash/size';
 import { VirtualizedGrid } from '../../virtualized-grid';
 import { RenderCell } from '../../virtualized-grid/types';
 import { CatalogItem } from '../utils/types';
@@ -14,7 +14,7 @@ type CatalogGridProps = {
 const CatalogGrid: React.FC<CatalogGridProps> = ({ items, renderTile, isGrouped }) => {
   const renderGroupHeader = (heading) => (
     <Title className="co-catalog-page__group-title" headingLevel="h2" size="lg">
-      {heading} ({_.size(items[heading])})
+      {heading} ({size(items[heading])})
     </Title>
   );
 

--- a/src/shared/components/catalog/catalog-view/CatalogView.tsx
+++ b/src/shared/components/catalog/catalog-view/CatalogView.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import cx from 'classnames';
-import * as _ from 'lodash-es';
+import clone from 'lodash/clone';
+import each from 'lodash/each';
+import groupBy from 'lodash/groupBy';
+import has from 'lodash/has';
+import isEmpty from 'lodash/isEmpty';
+import orderBy from 'lodash/orderBy';
+import set from 'lodash/set';
 import { useQueryParams } from '../../../hooks';
 import { RenderCell } from '../../virtualized-grid/types';
 import { setURLParams, updateURLParams } from '../utils/catalog-utils';
@@ -74,10 +80,10 @@ const CatalogView: React.FC<CatalogViewProps> = ({
   const activeFilters = React.useMemo(() => {
     const attributeFilters = {};
 
-    _.each(filterGroups, (filterGroup) => {
+    each(filterGroups, (filterGroup) => {
       const attributeFilterParam = queryParams.get(filterGroup);
       try {
-        _.set(attributeFilters, filterGroup, JSON.parse(attributeFilterParam));
+        set(attributeFilters, filterGroup, JSON.parse(attributeFilterParam));
       } catch (e) {
         // eslint-disable-next-line no-console
         console.warn('could not update filters from url params: could not parse search params', e);
@@ -91,12 +97,12 @@ const CatalogView: React.FC<CatalogViewProps> = ({
   // const [filterGroupCounts, setFilterGroupCounts] = React.useState<CatalogFilterCounts>({});
   // const [catalogTypeCounts, setCatalogTypeCounts] = React.useState<CatalogTypeCounts>({});
 
-  const isGrouped = _.has(groupings, activeGrouping);
+  const isGrouped = has(groupings, activeGrouping);
 
   const catalogToolbarRef = React.useRef<HTMLInputElement>();
 
   const itemsSorter = React.useCallback(
-    (itemsToSort) => _.orderBy(itemsToSort, ({ name }) => name.toLowerCase(), [sortOrder]),
+    (itemsToSort) => orderBy(itemsToSort, ({ name }) => name.toLowerCase(), [sortOrder]),
     [sortOrder],
   );
 
@@ -118,7 +124,7 @@ const CatalogView: React.FC<CatalogViewProps> = ({
 
   const handleFilterChange = React.useCallback(
     (filterType, id, value) => {
-      const updatedFilters = _.set(activeFilters, [filterType, id, 'active'], value);
+      const updatedFilters = set(activeFilters, [filterType, id, 'active'], value);
       updateURLParams(filterType, getFilterSearchParam(updatedFilters[filterType]));
     },
     [activeFilters],
@@ -138,8 +144,8 @@ const CatalogView: React.FC<CatalogViewProps> = ({
 
   const handleShowAllToggle = React.useCallback((groupName) => {
     setFilterGroupsShowAll((showAll) => {
-      const updatedShowAll = _.clone(showAll);
-      _.set(updatedShowAll, groupName, !(showAll[groupName] ?? false));
+      const updatedShowAll = clone(showAll);
+      set(updatedShowAll, groupName, !(showAll[groupName] ?? false));
       return updatedShowAll;
     });
   }, []);
@@ -186,7 +192,7 @@ const CatalogView: React.FC<CatalogViewProps> = ({
   const showFilters = React.useMemo(
     () =>
       filterGroups?.length > 0 &&
-      !_.isEmpty(activeFilters) &&
+      !isEmpty(activeFilters) &&
       Object.values(activeFilters).some((filterGroup) => Object.keys(filterGroup).length > 1),
     [activeFilters, filterGroups?.length],
   );
@@ -204,7 +210,7 @@ const CatalogView: React.FC<CatalogViewProps> = ({
   const catalogItems = React.useMemo(() => {
     if (!isGrouped) return filteredItems;
 
-    return _.groupBy(filteredItems, (item) => item.attributes?.[activeGrouping]) as {
+    return groupBy(filteredItems, (item) => item.attributes?.[activeGrouping]) as {
       [key: string]: CatalogItem[];
     };
   }, [activeGrouping, filteredItems, isGrouped]);

--- a/src/shared/components/catalog/utils/catalog-utils.tsx
+++ b/src/shared/components/catalog/utils/catalog-utils.tsx
@@ -1,11 +1,11 @@
-import * as _ from 'lodash-es';
+import startsWith from 'lodash/startsWith';
 import * as catalogImg from '../../../../imgs/catalog-icon.svg';
 import { keywordFilter } from '../../../utils/keyword-filter';
 import { history } from '../../../utils/router';
 import { CatalogType, CatalogTypeCounts, CatalogItem } from './types';
 
 export const normalizeIconClass = (iconClass: string): string => {
-  return _.startsWith(iconClass, 'icon-') ? `font-icon ${iconClass}` : iconClass;
+  return startsWith(iconClass, 'icon-') ? `font-icon ${iconClass}` : iconClass;
 };
 
 const catalogItemCompare = (keyword: string, item: CatalogItem): boolean => {

--- a/src/shared/components/catalog/utils/category-utils.ts
+++ b/src/shared/components/catalog/utils/category-utils.ts
@@ -1,4 +1,7 @@
-import * as _ from 'lodash-es';
+import each from 'lodash/each';
+import has from 'lodash/has';
+import isEmpty from 'lodash/isEmpty';
+import some from 'lodash/some';
 import { CatalogCategory, CatalogSubcategory, CatalogItem } from './types';
 
 export const NO_GROUPING = 'none';
@@ -17,7 +20,7 @@ export const matchSubcategories = (
     const intersection = [category.tags, item.tags || []].reduce((a, b) =>
       a.filter((c) => b.includes(c)),
     );
-    if (!_.isEmpty(intersection)) {
+    if (!isEmpty(intersection)) {
       return [category];
     }
 
@@ -25,11 +28,11 @@ export const matchSubcategories = (
   }
 
   const matchedSubcategories: (CatalogCategory | CatalogSubcategory)[] = [];
-  _.each(category.subcategories, (subCategory) => {
+  each(category.subcategories, (subCategory) => {
     const valuesIntersection = [subCategory.tags, item.tags || []].reduce((a, b) =>
       a.filter((c) => b.includes(c)),
     );
-    if (!_.isEmpty(valuesIntersection)) {
+    if (!isEmpty(valuesIntersection)) {
       matchedSubcategories.push(subCategory, ...matchSubcategories(subCategory, item));
     }
   });
@@ -62,14 +65,14 @@ export const categorize = (
   const categorizedIds = {};
 
   // Categorize each item
-  _.each(items, (item) => {
+  each(items, (item) => {
     let itemCategorized = false;
 
     addItem(categorizedIds, item.uid, ALL_CATEGORY); // add each item to all category
 
-    _.each(categories, (category: CatalogCategory) => {
+    each(categories, (category: CatalogCategory) => {
       const matchedSubcategories = matchSubcategories(category, item);
-      _.each(matchedSubcategories, (subcategory) => {
+      each(matchedSubcategories, (subcategory) => {
         addItem(categorizedIds, item.uid, category.id);
         addItem(categorizedIds, item.uid, subcategory.id);
         itemCategorized = true;
@@ -89,7 +92,7 @@ export const findActiveCategory = (
   categories: CatalogCategory[],
 ): CatalogCategory => {
   let activeCategory = null;
-  _.each(categories, (category) => {
+  each(categories, (category) => {
     if (activeCategory) {
       return;
     }
@@ -104,15 +107,13 @@ export const findActiveCategory = (
 };
 
 export const hasActiveDescendant = (activeId: string, category: CatalogCategory): boolean => {
-  if (_.has(category.subcategories, activeId)) {
+  if (has(category.subcategories, activeId)) {
     return true;
   }
 
-  return _.some(category.subcategories, (subcategory) =>
-    hasActiveDescendant(activeId, subcategory),
-  );
+  return some(category.subcategories, (subcategory) => hasActiveDescendant(activeId, subcategory));
 };
 
 export const isActiveTab = (activeId: string, category: CatalogCategory): boolean => {
-  return _.has(category.subcategories, activeId);
+  return has(category.subcategories, activeId);
 };

--- a/src/shared/components/markdown-view/MarkdownView.tsx
+++ b/src/shared/components/markdown-view/MarkdownView.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import cx from 'classnames';
-import * as _ from 'lodash-es';
+import debounce from 'lodash/debounce';
+import includes from 'lodash/includes';
+import reduce from 'lodash/reduce';
+import truncate from 'lodash/truncate';
+import uniqueId from 'lodash/uniqueId';
 import * as sanitizeHtml from 'sanitize-html';
 import { Converter } from 'showdown';
 import { useForceRender, useResizeObserver } from '../../hooks';
@@ -132,7 +136,7 @@ const IFrameMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const updateDimensions = React.useCallback(
-    _.debounce(() => {
+    debounce(() => {
       if (!frame?.contentWindow?.document?.body?.firstElementChild) {
         return;
       }
@@ -152,10 +156,10 @@ const IFrameMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
 
   // Find the app's stylesheets and inject them into the frame to ensure consistent styling.
   const filteredLinks = Array.from(document.getElementsByTagName('link')).filter((l) =>
-    _.includes(l.href, 'app-bundle'),
+    includes(l.href, 'app-bundle'),
   );
 
-  const linkRefs = _.reduce(
+  const linkRefs = reduce(
     filteredLinks,
     (refs, link) => `${refs}
     <link rel="stylesheet" href="${link.href}">`,
@@ -213,7 +217,7 @@ const InlineMarkdownView: React.FC<InnerSyncMarkdownProps> = ({
   isEmpty,
   renderExtension,
 }) => {
-  const id = React.useMemo(() => _.uniqueId('markdown'), []);
+  const id = React.useMemo(() => uniqueId('markdown'), []);
   return (
     <div className={cx('co-markdown-view', { ['is-empty']: isEmpty })} id={id}>
       <div dangerouslySetInnerHTML={{ __html: markup }} />
@@ -234,7 +238,7 @@ export const SyncMarkdownView: React.FC<SyncMarkdownProps> = ({
   const { t } = useTranslation();
   const markup = React.useMemo(() => {
     const truncatedContent = truncateContent
-      ? _.truncate(content, {
+      ? truncate(content, {
           length: 256,
           separator: ' ',
           omission: '\u2026',

--- a/src/shared/components/pipeline-run-logs/PipelineRunLogs.tsx
+++ b/src/shared/components/pipeline-run-logs/PipelineRunLogs.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Nav, NavItem, NavList } from '@patternfly/react-core';
-import * as _ from 'lodash-es';
+import get from 'lodash/get';
 import { WatchK8sResource } from '../../../dynamic-plugin-sdk';
 import { ErrorDetailsWithStaticLog } from './logs/log-snippet-types';
 import { getDownloadAllLogsCallback } from './logs/logs-utils';
@@ -27,7 +27,7 @@ class PipelineRunLogs extends React.Component<PipelineRunLogsProps, PipelineRunL
 
   componentDidMount() {
     const { obj, activeTask } = this.props;
-    const taskRunFromYaml = _.get(obj, ['status', 'taskRuns'], {});
+    const taskRunFromYaml = get(obj, ['status', 'taskRuns'], {});
     const taskRuns = this.getSortedTaskRun(taskRunFromYaml);
     const activeItem = this.getActiveTaskRun(taskRuns, activeTask);
     this.setState({ activeItem });
@@ -36,7 +36,7 @@ class PipelineRunLogs extends React.Component<PipelineRunLogsProps, PipelineRunL
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (this.props.obj !== nextProps.obj) {
       const { obj, activeTask } = this.props;
-      const taskRunFromYaml = _.get(obj, ['status', 'taskRuns'], {});
+      const taskRunFromYaml = get(obj, ['status', 'taskRuns'], {});
       const taskRuns = this.getSortedTaskRun(taskRunFromYaml);
       const activeItem = this.getActiveTaskRun(taskRuns, activeTask);
       this.state.navUntouched && this.setState({ activeItem });
@@ -50,7 +50,7 @@ class PipelineRunLogs extends React.Component<PipelineRunLogsProps, PipelineRunL
 
   getSortedTaskRun = (taskRunFromYaml) => {
     const taskRuns = Object.keys(taskRunFromYaml).sort((a, b) => {
-      if (_.get(taskRunFromYaml, [a, 'status', 'completionTime'], false)) {
+      if (get(taskRunFromYaml, [a, 'status', 'completionTime'], false)) {
         return taskRunFromYaml[b].status?.completionTime &&
           new Date(taskRunFromYaml[a].status.completionTime) >
             new Date(taskRunFromYaml[b].status.completionTime)
@@ -76,7 +76,7 @@ class PipelineRunLogs extends React.Component<PipelineRunLogsProps, PipelineRunL
   render() {
     const { obj } = this.props;
     const { activeItem } = this.state;
-    const taskRunFromYaml = _.get(obj, ['status', 'taskRuns'], {});
+    const taskRunFromYaml = get(obj, ['status', 'taskRuns'], {});
     const taskRuns = this.getSortedTaskRun(taskRunFromYaml);
     const logDetails = getPLRLogSnippet(obj) as ErrorDetailsWithStaticLog;
 
@@ -114,12 +114,10 @@ class PipelineRunLogs extends React.Component<PipelineRunLogsProps, PipelineRunL
                     >
                       <span>
                         <ColoredStatusIcon
-                          status={pipelineRunFilterReducer(
-                            _.get(obj, ['status', 'taskRuns', task]),
-                          )}
+                          status={pipelineRunFilterReducer(get(obj, ['status', 'taskRuns', task]))}
                         />
                         <span className="hacDev-pipeline-run-logs__namespan">
-                          {_.get(taskRunFromYaml, [task, `pipelineTaskName`], '-')}
+                          {get(taskRunFromYaml, [task, `pipelineTaskName`], '-')}
                         </span>
                       </span>
                     </NavItem>
@@ -135,14 +133,14 @@ class PipelineRunLogs extends React.Component<PipelineRunLogsProps, PipelineRunL
           {activeItem && resource ? (
             <LogsWrapperComponent
               resource={resource}
-              taskName={_.get(taskRunFromYaml, [activeItem, 'pipelineTaskName'], '-')}
+              taskName={get(taskRunFromYaml, [activeItem, 'pipelineTaskName'], '-')}
               downloadAllLabel={'Download all task logs'}
               onDownloadAll={downloadAllCallback}
             />
           ) : (
             <div className="hacDev-pipeline-run-logs__log">
               <div className="hacDev-pipeline-run-logs__logtext">
-                {_.get(obj, ['status', 'conditions', 0, 'message'], 'No logs found')}
+                {get(obj, ['status', 'conditions', 0, 'message'], 'No logs found')}
                 {logDetails && (
                   <div className="hacDev-pipeline-run-logs__logsnippet">
                     {logDetails.staticMessage}

--- a/src/shared/components/status-box/StatusBox.tsx
+++ b/src/shared/components/status-box/StatusBox.tsx
@@ -2,7 +2,9 @@ import * as React from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { Alert, Button } from '@patternfly/react-core';
 import classNames from 'classnames';
-import * as _ from 'lodash-es';
+import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
+import isString from 'lodash/isString';
 import * as restrictedSignImg from '../../../imgs/restricted-sign.svg';
 import { TimeoutError } from '../../utils/error/http-error';
 
@@ -22,7 +24,7 @@ export const LoadError: React.FC<LoadErrorProps> = ({
   return (
     <Box className={className}>
       <div className="pf-u-text-align-center cos-error-title">
-        {_.isString(message)
+        {isString(message)
           ? t('public~Error Loading {{label}}: {{message}}', {
               label,
               message,
@@ -111,7 +113,7 @@ export const AccessDenied: React.FC<AccessDeniedProps> = ({ message }) => {
           detail={t("public~You don't have access to this section due to cluster policy.")}
         />
       </Box>
-      {_.isString(message) && (
+      {isString(message) && (
         <Alert isInline className="co-alert" variant="danger" title={t('public~Error details')}>
           {message}
         </Alert>
@@ -129,7 +131,7 @@ const Data: React.FC<DataProps> = ({
   unfilteredData,
   children,
 }) => {
-  if (NoDataEmptyMsg && _.isEmpty(unfilteredData)) {
+  if (NoDataEmptyMsg && isEmpty(unfilteredData)) {
     return (
       <div className="loading-box loading-box__loaded">
         {NoDataEmptyMsg ? <NoDataEmptyMsg /> : <EmptyBox label={label} />}
@@ -137,7 +139,7 @@ const Data: React.FC<DataProps> = ({
     );
   }
 
-  if (!data || _.isEmpty(data)) {
+  if (!data || isEmpty(data)) {
     return (
       <div className="loading-box loading-box__loaded">
         {EmptyMsg ? <EmptyMsg /> : <EmptyBox label={label} />}
@@ -153,7 +155,7 @@ export const StatusBox: React.FC<StatusBoxProps> = (props) => {
   const { t } = useTranslation();
 
   if (loadError) {
-    const status = _.get(loadError, 'response.status');
+    const status = get(loadError, 'response.status');
     if (status === 404) {
       return (
         <div className="co-m-pane__body">

--- a/src/shared/components/timestamp/datetime.ts
+++ b/src/shared/components/timestamp/datetime.ts
@@ -1,5 +1,7 @@
 import { pluralize } from '@patternfly/react-core';
-import * as _ from 'lodash-es';
+import each from 'lodash/each';
+import isFinite from 'lodash/isFinite';
+import sumBy from 'lodash/sumBy';
 
 // The maximum allowed clock skew in milliseconds where we show a date as "Just now" even if it is from the future.
 export const maxClockSkewMS = -60000;
@@ -130,7 +132,7 @@ export const fromNow = (dateTime: string | Date, now?: Date, options?) => {
   return relativeTimeFormatter.format(-minutes, 'minute');
 };
 
-export const isValid = (dateTime: Date) => dateTime instanceof Date && !_.isNaN(dateTime.valueOf());
+export const isValid = (dateTime: Date) => dateTime instanceof Date && !isNaN(dateTime.valueOf());
 
 // Conversions between units and milliseconds
 const s = 1000;
@@ -142,19 +144,19 @@ const units = { w, d, h, m, s };
 
 // Formats a duration in milliseconds like "1h 10m"
 export const formatPrometheusDuration = (ms: number) => {
-  if (!_.isFinite(ms) || ms < 0) {
+  if (!isFinite(ms) || ms < 0) {
     return '';
   }
   let remaining = ms;
   let str = '';
-  _.each(units, (factor, unit) => {
+  each(units, (factor, unit) => {
     const n = Math.floor(remaining / factor);
     if (n > 0) {
       str += `${n}${unit} `;
       remaining -= n * factor;
     }
   });
-  return _.trim(str);
+  return str.trim();
 };
 
 // Converts a duration like "1h 10m 23s" to milliseconds or returns 0 if the duration could not be
@@ -165,7 +167,7 @@ export const parsePrometheusDuration = (duration: string): number => {
       .trim()
       .split(/\s+/)
       .map((p) => p.match(/^(\d+)([wdhms])$/));
-    return _.sumBy(parts, (p) => parseInt(p[1], 10) * units[p[2]]);
+    return sumBy(parts, (p) => parseInt(p[1], 10) * units[p[2]]);
   } catch (ignored) {
     // Invalid duration format
     return 0;

--- a/src/shared/utils/keyword-filter.ts
+++ b/src/shared/utils/keyword-filter.ts
@@ -1,4 +1,4 @@
-import * as _ from 'lodash-es';
+import uniq from 'lodash/uniq';
 
 export const keywordFilter = <T>(
   filterText: string,
@@ -8,7 +8,7 @@ export const keywordFilter = <T>(
   if (!filterText) {
     return items;
   }
-  const keywords = _.uniq(filterText.match(/\S+/g)).map((w) => w.toLowerCase());
+  const keywords = uniq(filterText.match(/\S+/g)).map((w) => w.toLowerCase());
 
   // Sort the longest keyword fist
   keywords.sort(function (a: string, b: string) {

--- a/src/shared/utils/line-buffer.ts
+++ b/src/shared/utils/line-buffer.ts
@@ -1,4 +1,5 @@
-import * as _ from 'lodash-es';
+import truncate from 'lodash/truncate';
+
 export const LINE_PATTERN = /^.*(\n|$)/gm;
 const TRUNCATE_LENGTH = 1024;
 
@@ -22,7 +23,7 @@ export class LineBuffer {
         this._hasTruncated = true;
       }
       if (/\n$/.test(line)) {
-        this._buffer.push(_.truncate(next, { length: TRUNCATE_LENGTH }).trimEnd());
+        this._buffer.push(truncate(next, { length: TRUNCATE_LENGTH }).trimEnd());
         lineCount++;
         this._tail = '';
       } else {
@@ -51,7 +52,7 @@ export class LineBuffer {
   }
 
   getTail() {
-    return _.truncate(this._tail, { length: TRUNCATE_LENGTH });
+    return truncate(this._tail, { length: TRUNCATE_LENGTH });
   }
 
   length(): number {

--- a/src/shared/utils/router.ts
+++ b/src/shared/utils/router.ts
@@ -1,5 +1,6 @@
 import { createBrowserHistory, createMemoryHistory, History } from 'history';
-import * as _ from 'lodash-es';
+import each from 'lodash/each';
+import startsWith from 'lodash/startsWith';
 
 type AppHistory = History & { pushPath: History['push'] };
 
@@ -20,7 +21,7 @@ try {
 export const history: AppHistory = createHistory({ basename: basePath });
 
 const removeBasePath = (url = '/') =>
-  _.startsWith(url, basePath) ? url.slice(basePath.length - 1) : url;
+  startsWith(url, basePath) ? url.slice(basePath.length - 1) : url;
 
 // Monkey patch history to slice off the base path
 (history as any).__replace__ = history.replace;
@@ -45,7 +46,7 @@ export const setQueryArgument = (k: string, v: string) => {
 export const setQueryArguments = (newParams: { [k: string]: string }) => {
   const params = new URLSearchParams(window.location.search);
   let update = false;
-  _.each(newParams, (v, k) => {
+  each(newParams, (v, k) => {
     if (params.get(k) !== v) {
       update = true;
       params.set(k, v);
@@ -60,7 +61,7 @@ export const setQueryArguments = (newParams: { [k: string]: string }) => {
 export const setAllQueryArguments = (newParams: { [k: string]: string }) => {
   const params = new URLSearchParams();
   let update = false;
-  _.each(newParams, (v, k) => {
+  each(newParams, (v, k) => {
     if (params.get(k) !== v) {
       update = true;
       params.set(k, v);


### PR DESCRIPTION
## Fixes 
Static assets are too large.


## Description
Since local development doesn't have tree shaking and other optimization tools enabled we have to care how libraries are loaded. One problematic place is lodash, importing the entire library means that we'll be adding 0.6MB to our bundles. We can either use `lodash-es` or directly importing each function. Since we don't want to overlook any mistakes I adopted importing just the function.


## Type of change
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)

### Before
```
assets by path js/*.js 8.76 MiB
  assets by chunk 7.78 MiB (id hint: vendors) 9 assets
  10 assets
assets by path css/*.css 44 KiB 8 assets
assets by path fonts/*.svg 5.08 KiB
  asset fonts/restricted-sign.svg 2.38 KiB [emitted] [from: src/imgs/restricted-sign.svg]
  asset fonts/skeleton-chart.svg 1.72 KiB [emitted] [from: src/imgs/skeleton-chart.svg] (auxiliary name: exposed-Create)
  asset fonts/catalog-icon.svg 1000 bytes [emitted] [from: src/imgs/catalog-icon.svg] (auxiliary name: exposed-Create)
assets by path *.json 1.58 KiB
  asset plugin-manifest.json 1.58 KiB [emitted]
  asset fed-mods.json 2 bytes [emitted]
asset plugin-entry.js 260 KiB [emitted] (name: hac-dev)
asset index.html 295 bytes [emitted]
orphan modules 2.5 MiB [orphan] 1788 modules
runtime modules 49 KiB 38 modules
modules by path ./node_modules/ 5.63 MiB (javascript) 332 bytes (css/mini-extract) 2830 modules
modules by path ./src/ 293 KiB (javascript) 43.4 KiB (css/mini-extract) 3.36 KiB (asset) 228 modules
modules by path ./*.css (ignored) 765 bytes 51 modules
consume-shared-module modules 588 bytes
  modules by path *.0 (singleton) 252 bytes 6 modules
modules by path @patternfly/react-styles/css/components/Popper/*.css (ignored) 30 bytes
  @patternfly/react-styles/css/components/Popper/Popper.css (ignored) 15 bytes [built] [code generated]
  @patternfly/react-styles/css/components/Popper/Popper.css (ignored) 15 bytes [built] [code generated]
provide shared module (default) react-router-dom@5.2.0 = ./node_modules/react-router-dom/esm/react-router-dom.js 42 bytes [built] [code generated]
container entry 42 bytes [built] [code generated]

```

### After
```
assets by path js/*.js 8.13 MiB
  assets by chunk 7.15 MiB (id hint: vendors) 7 assets
assets by path css/*.css 44 KiB 8 assets
assets by path fonts/*.svg 5.08 KiB
  asset fonts/restricted-sign.svg 2.38 KiB [emitted] [from: src/imgs/restricted-sign.svg]
  asset fonts/skeleton-chart.svg 1.72 KiB [emitted] [from: src/imgs/skeleton-chart.svg] (auxiliary name: exposed-Create)
  asset fonts/catalog-icon.svg 1000 bytes [emitted] [from: src/imgs/catalog-icon.svg] (auxiliary name: exposed-Create)
assets by path *.json 1.58 KiB
  asset plugin-manifest.json 1.58 KiB [emitted]
  asset fed-mods.json 2 bytes [emitted]
asset plugin-entry.js 260 KiB [emitted] (name: hac-dev)
asset index.html 295 bytes [emitted]
orphan modules 2.59 MiB [orphan] 1889 modules
runtime modules 49 KiB 38 modules
modules by path ./node_modules/ 5.06 MiB (javascript) 332 bytes (css/mini-extract) 2771 modules
modules by path ./src/ 293 KiB (javascript) 43.4 KiB (css/mini-extract) 3.36 KiB (asset) 228 modules
modules by path ./*.css (ignored) 765 bytes 51 modules
consume-shared-module modules 588 bytes
  modules by path *.0 (singleton) 252 bytes 6 modules
modules by path @patternfly/react-styles/css/components/Popper/*.css (ignored) 30 bytes
  @patternfly/react-styles/css/components/Popper/Popper.css (ignored) 15 bytes [built] [code generated]
  @patternfly/react-styles/css/components/Popper/Popper.css (ignored) 15 bytes [built] [code generated]
provide shared module (default) react-router-dom@5.2.0 = ./node_modules/react-router-dom/esm/react-router-dom.js 42 bytes [built] [code generated]
container entry 42 bytes [built] [code generated]
```