### PR TITLE
Use default entry callback settings

### DIFF
--- a/config/remotePlugin.js
+++ b/config/remotePlugin.js
@@ -2,10 +2,6 @@ const { resolve } = require('path');
 const packageInfo = require('../package.json');
 
 module.exports = {
-  entryCallbackSettings: {
-    name: 'loadPluginEntry',
-    pluginID: `${packageInfo.insights.appname}@${packageInfo.version}`,
-  },
   pluginMetadata: {
     name: packageInfo.name,
     version: packageInfo.version,


### PR DESCRIPTION
## Fixes 
Inaccessible UI due to error `Uncaught ReferenceError: loadPluginEntry is not defined`

## Description
There's a new usage of default entry callback available and it's not compatible with the old one. Let's use the first the new one so we don't break the UI.

## Type of change

- [x] Bugfix