### PR TITLE
Use watch hook for component detection

### DIFF
--- a/src/components/AddComponent/__tests__/SourceField.spec.tsx
+++ b/src/components/AddComponent/__tests__/SourceField.spec.tsx
@@ -1,34 +1,30 @@
 import * as React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { useField } from 'formik';
-import { createComponentDetectionQuery } from '../../../utils/create-utils';
 import { SourceField } from '../SourceField';
+import { useComponentDetection } from '../utils';
 import '@testing-library/jest-dom';
 
 jest.mock('formik', () => ({
   useField: jest.fn(),
+  useFormikContext: () => ({
+    setFieldValue: jest.fn(),
+  }),
 }));
 
-jest.mock('../../../utils/create-utils', () => ({
-  createComponentDetectionQuery: jest.fn(),
-}));
-
-jest.mock('../../../shared/hooks', () => ({
-  useFormikValidationFix: jest.fn(),
+jest.mock('../utils', () => ({
+  useComponentDetection: jest.fn(),
 }));
 
 const useFieldMock = useField as jest.Mock;
-const createComponentMock = createComponentDetectionQuery as jest.Mock;
+const useComponentDetectionMock = useComponentDetection as jest.Mock;
 
 afterEach(jest.resetAllMocks);
 
 describe('SourceField', () => {
   it('renders input field and sample button', () => {
-    useFieldMock.mockReturnValue([
-      { value: '' },
-      { value: '', touched: false, error: null },
-      { setValue: jest.fn() },
-    ]);
+    useFieldMock.mockReturnValue([{ value: '' }, { value: '' }]);
+    useComponentDetectionMock.mockReturnValue([null, null]);
 
     render(<SourceField onSamplesClick={jest.fn()} />);
     expect(screen.getByPlaceholderText('Enter your source')).toBeInTheDocument();
@@ -37,30 +33,34 @@ describe('SourceField', () => {
 
   it('fires callback on sample button click', () => {
     const onClick = jest.fn();
-    useFieldMock.mockReturnValue([
-      { value: '' },
-      { value: '', touched: false, error: null },
-      { setValue: jest.fn() },
-    ]);
+    useFieldMock.mockReturnValue([{ value: '' }, { value: '' }]);
+    useComponentDetectionMock.mockReturnValue([null, null]);
 
     render(<SourceField onSamplesClick={onClick} />);
     fireEvent.click(screen.getByText('Start with a sample.'));
     expect(onClick).toHaveBeenCalled();
   });
 
-  it('creates component detection query on input', async () => {
+  it('displays error when components cannot be detected', async () => {
     const onClick = jest.fn();
-    useFieldMock.mockReturnValue([
-      { value: '', onChange: jest.fn() },
-      { value: 'https://github.com/example/repo', touched: false, error: null },
-      { setValue: jest.fn() },
-    ]);
-    createComponentMock.mockReturnValue({ then: () => ({ catch: () => ({ finally: () => {} }) }) });
+    useFieldMock.mockReturnValue([{ value: '' }, { value: '' }]);
+    useComponentDetectionMock.mockReturnValue([null, 'Error']);
 
     render(<SourceField onSamplesClick={onClick} />);
-    fireEvent.input(screen.getByPlaceholderText('Enter your source'), {
-      target: { value: 'https://github.com/example/repo' },
-    });
-    await waitFor(() => expect(createComponentMock).toHaveBeenCalled());
+    expect(screen.getByPlaceholderText('Enter your source')).toBeInvalid();
+    expect(screen.getByText('Unable to detect components')).toBeVisible();
+  });
+
+  it('validates input field when components are detected', async () => {
+    const onClick = jest.fn();
+    useFieldMock.mockReturnValue([{ value: '' }, { value: '' }]);
+    useComponentDetectionMock.mockReturnValue([
+      { comp: { componentStub: { componentName: 'test' } } },
+      null,
+    ]);
+
+    render(<SourceField onSamplesClick={onClick} />);
+    expect(screen.getByPlaceholderText('Enter your source')).toBeValid();
+    expect(screen.getByText('Validated')).toBeVisible();
   });
 });

--- a/src/components/AddComponent/__tests__/utils.spec.ts
+++ b/src/components/AddComponent/__tests__/utils.spec.ts
@@ -1,0 +1,46 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useK8sWatchResource } from '../../../dynamic-plugin-sdk';
+import { createComponentDetectionQuery } from '../../../utils/create-utils';
+import { useComponentDetection } from '../utils';
+
+jest.mock('../../../dynamic-plugin-sdk', () => ({
+  useK8sWatchResource: jest.fn(),
+}));
+
+jest.mock('../../../utils/create-utils', () => ({
+  createComponentDetectionQuery: jest.fn(),
+}));
+
+const useK8sWatchMock = useK8sWatchResource as jest.Mock;
+const createCDQMock = createComponentDetectionQuery as jest.Mock;
+
+describe('useComponentDetection', () => {
+  afterEach(jest.resetAllMocks);
+
+  it('creates CDQ when source is provided', () => {
+    useK8sWatchMock.mockReturnValue([{}, true, null]);
+    createCDQMock.mockResolvedValue({ metadata: { name: 'test-cdq' } });
+
+    renderHook(() =>
+      useComponentDetection('https://github.com/test/repo', 'test-app', 'test-ns', true, 'token'),
+    );
+
+    expect(createCDQMock).toHaveBeenCalledTimes(1);
+    expect(createCDQMock).toHaveBeenCalledWith(
+      'test-app',
+      'https://github.com/test/repo',
+      'test-ns',
+      true,
+      'token',
+    );
+  });
+
+  it('should not create CDQ when source is not available', () => {
+    useK8sWatchMock.mockReturnValue([{}, true, null]);
+    createCDQMock.mockResolvedValue({ metadata: { name: 'test-cdq' } });
+
+    renderHook(() => useComponentDetection('', 'test-app', 'test-ns'));
+
+    expect(createCDQMock).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/dynamic-plugin-sdk.ts
+++ b/src/dynamic-plugin-sdk.ts
@@ -61,6 +61,15 @@ export type WatchK8sResult<R extends K8sResourceCommon | K8sResourceCommon[]> = 
  * ------------------ */
 
 /**
+* Temporary workaround to use the correct plural form for kinds
+*/
+const getPlural = (kind: string) => {
+  const kindsLookupTable = { ComponentDetectionQuery: 'ComponentDetectionQueries' };
+  const pluralKind = kindsLookupTable[kind] || kind + 's';
+  return pluralKind.toLowerCase();
+}
+
+/**
  * This makes an assumption that the model will have a plural of `${kind}s` -- which is obv not ideal.
  * Without apiDiscovery & the hook interface being sorta fixed, our options are limited.
  */
@@ -72,7 +81,7 @@ const makeGetCall = (resourceData: WatchK8sResource) => (
         apiGroup: resourceData.groupVersionKind.group,
         kind: resourceData.groupVersionKind.kind,
         // TODO: no dictionary... solution?
-        plural: resourceData.groupVersionKind.kind.toLowerCase() + 's',
+        plural: getPlural(resourceData.groupVersionKind.kind),
       },
       queryOptions: {
         name: resourceData.name,
@@ -92,7 +101,7 @@ const makeListCall = (resourceData: WatchK8sResource) => (
         apiGroup: resourceData.groupVersionKind.group,
         kind: resourceData.groupVersionKind.kind,
         // TODO: no dictionary... solution?
-        plural: resourceData.groupVersionKind.kind.toLowerCase() + 's',
+        plural: getPlural(resourceData.groupVersionKind.kind),
       },
       queryOptions: {
         ns: resourceData.namespace,

--- a/src/types/component-detection-query.ts
+++ b/src/types/component-detection-query.ts
@@ -1,5 +1,37 @@
 import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 
+export type DetectedComponents = {
+  [key: string]: {
+    componentStub: {
+      componentName: string;
+      context: string;
+      targetPort: number;
+      replicas?: number;
+      devfileFound?: boolean;
+      route?: string;
+      build?: {
+        containerImage: string;
+      };
+      resources: {
+        limits?: {
+          cpu?: string;
+          memory?: string;
+        };
+        requests?: {
+          cpu?: string;
+          memory?: string;
+        };
+      };
+      source: {
+        git: {
+          url: string;
+        };
+      };
+      env?: { name: string; value: string }[];
+    };
+  };
+};
+
 export type ComponentDetectionQueryKind = K8sResourceCommon & {
   spec: {
     git: {
@@ -8,37 +40,7 @@ export type ComponentDetectionQueryKind = K8sResourceCommon & {
   };
   isMultiComponent?: boolean;
   status?: {
-    componentDetected?: {
-      [key: string]: {
-        componentStub: {
-          componentName: string;
-          context: string;
-          targetPort: number;
-          replicas?: number;
-          devfileFound?: boolean;
-          route?: string;
-          build?: {
-            containerImage: string;
-          };
-          resources: {
-            limits?: {
-              cpu?: string;
-              memory?: string;
-            };
-            requests?: {
-              cpu?: string;
-              memory?: string;
-            };
-          };
-          source: {
-            git: {
-              url: string;
-            };
-          };
-          env?: { name: string; value: string }[];
-        };
-      };
-    };
+    componentDetected?: DetectedComponents;
     conditions?: any[];
   };
 };

--- a/src/utils/__tests__/create-utils.spec.ts
+++ b/src/utils/__tests__/create-utils.spec.ts
@@ -136,12 +136,6 @@ describe('Create Utils', () => {
   });
 
   it('Should call k8s create util with correct model and data for component detection query', async () => {
-    createResourceMock.mockImplementationOnce(() =>
-      Promise.resolve({
-        status: { conditions: [{ type: 'Completed', status: 'True' }], componentDetected: true },
-      }),
-    );
-
     await createComponentDetectionQuery(
       'test-application',
       'https://github.com/test/repository',
@@ -157,23 +151,6 @@ describe('Create Utils', () => {
       },
       resource: expect.objectContaining(mockCDQData),
     });
-  });
-
-  it('Should throw error when no components are detected', async () => {
-    createResourceMock.mockImplementationOnce(() =>
-      Promise.resolve({
-        status: { conditions: [{ type: 'Completed', status: 'False' }], componentDetected: false },
-      }),
-    );
-
-    await expect(
-      createComponentDetectionQuery(
-        'test-application',
-        'https://github.com/test/repository',
-        'test-ns',
-        true,
-      ),
-    ).rejects.toThrow();
   });
 
   it('Should call k8s create util with correct model and data for access token binding', async () => {


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-556
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
The CDQ was being constantly fetched with a 200ms delay asynchronously inside a loop,
and would not stop until the detection was completed.
This caused the fetching to continue even after the section was unmounted.

This PR replaces the fetch with a watch hook that only updates when the CDQ has changed.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
(No UI changes)

https://user-images.githubusercontent.com/20013884/162475561-4b506d7f-69ed-4a69-a738-f476615c4d20.mp4

<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
