### PR TITLE
Consume scalprum core to use chrome's context

### DIFF
--- a/config/remotePlugin.js
+++ b/config/remotePlugin.js
@@ -68,5 +68,6 @@ module.exports = {
     'react-router-dom': { singleton: true },
     'react-redux': { singleton: true, import: false },
     '@openshift/dynamic-plugin-sdk-utils': { singleton: true, import: false },
+    '@scalprum/react-core': { singleton: true, import: false },
   },
 };


### PR DESCRIPTION
## Fixes 
Chrome's context is inaccessible


## Description
Since we are using slightly different shared module scope than chrome is using scalprum provider is not accessible and that causes loading of new provider if `useChrome` is used. This PR fixes such issue by including it in shared modules consumed from `hac-core` application.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix
- [ ] 
## Requires
* [ ] merge after https://github.com/openshift/hac-core/pull/59 otherwise it will be broken