### PR TITLE
Start using core extensions in favor of console

### DIFF
--- a/config/remotePlugin.js
+++ b/config/remotePlugin.js
@@ -22,7 +22,27 @@ module.exports = {
       },
     },
     {
+      type: 'core.page/route',
+      properties: {
+        path: '/app-studio',
+        exact: true,
+        component: {
+          $codeRef: 'Applications',
+        },
+      },
+    },
+    {
       type: 'console.page/route',
+      properties: {
+        path: '/app-studio/applications',
+        exact: true,
+        component: {
+          $codeRef: 'Applications',
+        },
+      },
+    },
+    {
+      type: 'core.page/route',
       properties: {
         path: '/app-studio/applications',
         exact: true,
@@ -42,7 +62,24 @@ module.exports = {
       },
     },
     {
+      type: 'core.page/route',
+      properties: {
+        path: '/app-studio/import',
+        exact: true,
+        component: {
+          $codeRef: 'Import',
+        },
+      },
+    },
+    {
       type: 'console.navigation/href',
+      properties: {
+        href: '/app-studio',
+        name: 'Applications',
+      },
+    },
+    {
+      type: 'core.navigation/href',
       properties: {
         href: '/app-studio',
         name: 'Applications',


### PR DESCRIPTION
## Fixes 
There will be in near future adjustment to extension types from `console.` to `core.` ones.


## Description
Let's duplicate all extensions with type `core.` for some time until we remove the PoC code from `hac-core`.


## Type of change
- [x] Code style update (formatting, renaming)