### PR TITLE
Add error boundary to namespaced pages

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { ErrorBoundaryFallback } from './ErrorBoundaryFallback';
+
+export type ErrorBoundaryFallbackProps = {
+  errorMessage: string;
+  componentStack: string;
+  stack: string;
+  title: string;
+};
+
+type ErrorBoundaryProps = {
+  FallbackComponent?: React.ComponentType<ErrorBoundaryFallbackProps>;
+};
+
+type ErrorBoundaryState = {
+  hasError: boolean;
+  error: Error;
+  errorInfo: React.ErrorInfo;
+};
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = {
+      hasError: false,
+      error: null,
+      errorInfo: null,
+    };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    this.setState({
+      hasError: true,
+      error,
+      errorInfo,
+    });
+
+    // eslint-disable-next-line no-console
+    console.error('Caught error in a child component:', error, errorInfo);
+  }
+
+  render() {
+    const { hasError, error, errorInfo } = this.state;
+    const FallbackComponent = this.props.FallbackComponent || ErrorBoundaryFallback;
+
+    return hasError ? (
+      <FallbackComponent
+        title={error.name}
+        componentStack={errorInfo.componentStack}
+        errorMessage={error.message}
+        stack={error.stack}
+      />
+    ) : (
+      <>{this.props.children}</>
+    );
+  }
+}

--- a/src/components/ErrorBoundary/ErrorBoundaryFallback.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundaryFallback.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import {
+  ClipboardCopy,
+  ClipboardCopyVariant,
+  ExpandableSection,
+  PageSection,
+  PageSectionVariants,
+  Text,
+  TextContent,
+  TextVariants,
+} from '@patternfly/react-core';
+import PageLayout from '../PageLayout/PageLayout';
+import { ErrorBoundaryFallbackProps } from './ErrorBoundary';
+
+export const ErrorBoundaryFallback: React.FC<ErrorBoundaryFallbackProps> = (props) => {
+  return (
+    <PageSection variant={PageSectionVariants.light}>
+      <PageLayout title="Oh no! Something went wrong.">
+        <PageSection>
+          <ExpandableSection toggleText="Show details">
+            <TextContent>
+              <Text component={TextVariants.h3}>{props.title}</Text>
+
+              <Text component={TextVariants.h4}>Description:</Text>
+              <Text component={TextVariants.pre}>{props.errorMessage}</Text>
+
+              <Text component={TextVariants.h4}>Component trace:</Text>
+              <ClipboardCopy
+                tabIndex={0}
+                variant={ClipboardCopyVariant.expansion}
+                hoverTip="Copy"
+                clickTip="Copied"
+                isReadOnly
+                isExpanded
+                isCode
+              >
+                {props.componentStack.trim()}
+              </ClipboardCopy>
+
+              <Text component={TextVariants.h4}>Stack trace:</Text>
+              <ClipboardCopy
+                variant={ClipboardCopyVariant.expansion}
+                hoverTip="Copy"
+                clickTip="Copied"
+                isReadOnly
+                isExpanded
+                isCode
+              >
+                {props.stack.trim()}
+              </ClipboardCopy>
+            </TextContent>
+          </ExpandableSection>
+        </PageSection>
+      </PageLayout>
+    </PageSection>
+  );
+};

--- a/src/components/NamespacedPage/NamespacedPage.tsx
+++ b/src/components/NamespacedPage/NamespacedPage.tsx
@@ -3,6 +3,7 @@ import { Bullseye, Spinner } from '@patternfly/react-core';
 import { useActiveNamespace } from '../../hooks';
 import { UserSignupStatus, useSignupStatus } from '../../hooks/useSignupStatus';
 import AppBanner from '../AppBanner/AppBanner';
+import { ErrorBoundary } from '../ErrorBoundary/ErrorBoundary';
 import SignupView from '../Signup/SignupView';
 
 import './NamespacedPage.scss';
@@ -41,7 +42,7 @@ const NamespacedPage: React.FunctionComponent<NamespacedPageProps> = ({ children
   return (
     <NamespaceContext.Provider value={{ namespace: activeNamepace }}>
       <AppBanner />
-      {children}
+      <ErrorBoundary>{children}</ErrorBoundary>
     </NamespaceContext.Provider>
   );
 };


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-1016
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Adds an error boundary to NamespacedPage.


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [x] Bugfix

## Screen shots / Gifs for design review 
![0](https://user-images.githubusercontent.com/20013884/165514548-e36b9a7c-7b0d-40c6-b097-271530e37370.png)
![1](https://user-images.githubusercontent.com/20013884/165514552-e445a40a-960e-41a4-94bf-7c6d21292e89.png)

<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
