### PR TITLE
Fix: Use IMAGE instead of component name

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -4,7 +4,8 @@
 # Export vars for helper scripts to use
 # --------------------------------------------
 # name of app-sre "application" folder this component lives in; needs to match for quay
-export COMPONENT="hac-dev"
+export COMPONENT="hac"
+export IMAGE="quay.io/cloudservices/hac-dev-frontend"
 export APP_ROOT=$(pwd)
 # Because IMAGE_TAG from bonfire is going to prepend "pr-" we override it.
 export TAG=$(git rev-parse --short=7 HEAD)


### PR DESCRIPTION

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
The build pipeline is now using `IMAGE` rather than `COMPONENT` to create parity with bonfire's requirements.

