### PR TITLE
Fix: Use IMAGE instead of component name

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -4,7 +4,8 @@
 # Export vars for helper scripts to use
 # --------------------------------------------
 # name of app-sre "application" folder this component lives in; needs to match for quay
-export COMPONENT="hac-dev"
+export COMPONENT="hac"
+export IMAGE="quay.io/cloudservices/hac-dev-frontend"
 export APP_ROOT=$(pwd)
 export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
 export NODE_BUILD_VERSION=14

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -4,7 +4,8 @@
 # Export vars for helper scripts to use
 # --------------------------------------------
 # name of app-sre "application" folder this component lives in; needs to match for quay
-export COMPONENT="hac-dev"
+export COMPONENT="hac"
+export IMAGE="quay.io/cloudservices/hac-dev-frontend"
 export APP_ROOT=$(pwd)
 # Because IMAGE_TAG from bonfire is going to prepend "pr-" we override it.
 export TAG=$(git rev-parse --short=7 HEAD)


### PR DESCRIPTION
To match feature parity with backed apps, we use `COMPONENT` as our app-interface folder and use the full `IMAGE` name.
