### PR TITLE
Fix: use hac-dev as COMPONENT

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -4,7 +4,7 @@
 # Export vars for helper scripts to use
 # --------------------------------------------
 # name of app-sre "application" folder this component lives in; needs to match for quay
-export COMPONENT="hac"
+export COMPONENT="hac-dev"
 export IMAGE="quay.io/cloudservices/hac-dev-frontend"
 export APP_ROOT=$(pwd)
 export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -4,7 +4,7 @@
 # Export vars for helper scripts to use
 # --------------------------------------------
 # name of app-sre "application" folder this component lives in; needs to match for quay
-export COMPONENT="hac"
+export COMPONENT="hac-dev"
 export IMAGE="quay.io/cloudservices/hac-dev-frontend"
 export APP_ROOT=$(pwd)
 # Because IMAGE_TAG from bonfire is going to prepend "pr-" we override it.


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
Quick fix for PR checks that are breaking `hac-core` deploys.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Fixes an issue that causes bonfire to deploy hac-core incorrectly in PR checks for e2e.
