### PR TITLE
Replace samples catalog with simple tile selector

### DIFF
--- a/src/components/ComponentSamples/ComponentSamplesPage.scss
+++ b/src/components/ComponentSamples/ComponentSamplesPage.scss
@@ -1,0 +1,10 @@
+.hac-catalog {
+  margin: var(--pf-global--spacer--lg);
+  --pf-l-gallery--m-gutter--GridGap: var(--pf-global--gutter--md);
+
+  &__tile {
+    height: 100%;
+    width: 260px;
+    color: black;
+  }
+}

--- a/src/components/ComponentSamples/SamplesEmptyState.tsx
+++ b/src/components/ComponentSamples/SamplesEmptyState.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import {
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateSecondaryActions,
+  EmptyStateVariant,
+  Title,
+} from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons/dist/js/icons';
+
+type SamplesEmptyStateProps = {
+  onClear?: () => void;
+};
+
+const SamplesEmptyState: React.FC<SamplesEmptyStateProps> = ({ onClear }) => {
+  return (
+    <EmptyState variant={EmptyStateVariant.full}>
+      <EmptyStateIcon icon={SearchIcon} />
+      <Title headingLevel="h2" size="lg">
+        No results found
+      </Title>
+      <EmptyStateBody>
+        No results match the filter criteria. Remove filters or clear all filters to show results.
+      </EmptyStateBody>
+      <EmptyStateSecondaryActions>
+        <Button variant="link" onClick={onClear} data-test-id="catalog-clear-filters">
+          Clear all filters
+        </Button>
+      </EmptyStateSecondaryActions>
+    </EmptyState>
+  );
+};
+
+export default SamplesEmptyState;

--- a/src/components/ComponentSamples/__tests__/ComponentSamplesPage.spec.tsx
+++ b/src/components/ComponentSamples/__tests__/ComponentSamplesPage.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { configure, render, screen } from '@testing-library/react';
+import { configure, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { mockCatalogItem } from '../../../utils/__data__/mock-devfile-data';
 import { getDevfileSamples } from '../../../utils/devfile-utils';
@@ -60,5 +60,16 @@ describe('ComponentSamplesPage', () => {
     render(<ComponentSamplesPage />);
     await screen.findByText('4 items');
     await screen.findByTestId('search-catalog');
+  });
+
+  it('filters samples with provided keyword', async () => {
+    getDevfileMock.mockReturnValue(Promise.resolve(mockCatalogItem));
+    render(<ComponentSamplesPage />);
+    await screen.findByTestId('search-catalog');
+    await screen.findByText('4 items');
+    fireEvent.change(await screen.findByPlaceholderText('Filter by keyword...'), {
+      target: { value: 'node' },
+    });
+    await screen.findByText('1 item');
   });
 });


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-1239
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
Replace the use of `CatalogView` with a simple tile selector.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Refactoring (no functional changes, no api changes)

## Screen shots / Gifs for design review 
![0](https://user-images.githubusercontent.com/20013884/167448853-721fc536-1bff-4cc5-9211-87515328754e.png)

<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
Navigate to sample selection page.
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
