### PR TITLE
Bring back multi component checkbox in git options

### DIFF
--- a/src/components/AddComponent/GitOptions.tsx
+++ b/src/components/AddComponent/GitOptions.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ExpandableSection, Stack, StackItem } from '@patternfly/react-core';
-import { InputField } from '../../shared';
+import { CheckboxField, InputField } from '../../shared';
 
 export const GitOptions: React.FC = () => (
   <ExpandableSection isIndented toggleText="Git options">
@@ -19,6 +19,13 @@ export const GitOptions: React.FC = () => (
           label="Context dir"
           helpText="Optional subdirectory for the application source code."
           data-test="context-dir"
+        />
+      </StackItem>
+      <StackItem>
+        <CheckboxField
+          name="git.isMultiComponent"
+          label="Multi Component"
+          helpText="Whether the source contains multiple components."
         />
       </StackItem>
     </Stack>


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
- https://issues.redhat.com/browse/HAC-1434

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- We need the multi component checkbox in git options to support multi component import.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

https://user-images.githubusercontent.com/6041994/172453317-57e37d94-8ef1-414e-bc67-9b96dde74c83.mov

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

