### PR TITLE
Skip cookie disclaimers for all cypress tests

### DIFF
--- a/integration-tests/support/commands/hooks.ts
+++ b/integration-tests/support/commands/hooks.ts
@@ -5,16 +5,16 @@ before(() => {
   //Clear namespace before running the tests
   Common.cleanNamespace();
   Cypress.Cookies.debug(true);
+  
+  const url = new URL(Cypress.env('HAC_BASE_URL'));
+  cy.setCookie('notice_gdpr_prefs', '0,1,2:', { domain: url.hostname });
+  cy.setCookie('cmapi_cookie_privacy', 'permit 1,2,3', { domain: url.hostname });
+  cy.setCookie('notice_preferences', '2:', { domain: url.hostname });
 
   if (Cypress.env('PR_CHECK') === true) {
-    const url = new URL(Cypress.env('HAC_BASE_URL'));
-    cy.setCookie('notice_gdpr_prefs', '0,1,2:', { domain: url.hostname });
-    cy.setCookie('cmapi_cookie_privacy', 'permit 1,2,3', { domain: url.hostname });
-    cy.setCookie('notice_preferences', '2:', { domain: url.hostname });
     Login.prCheckLogin();
   } else {
     Login.login();
-    Common.clickOnConsentButton();
   }
 });
 


### PR DESCRIPTION
unifies cookie disclaimers handling for local/console.dev/CI env - by completely skipping them
