### PR TITLE
Remove state from basic dropdown component

### DIFF
--- a/src/shared/components/dropdown/BasicDropdown.tsx
+++ b/src/shared/components/dropdown/BasicDropdown.tsx
@@ -24,10 +24,8 @@ const BasicDropdown: React.FC<BasicDropdownProps> = ({
   disabled,
 }) => {
   const [dropdownOpen, setDropdownOpen] = React.useState<boolean>(false);
-  const [currentSelection, setCurrentSelection] = React.useState<string>(selected || placeholder);
   const onToggle = (isOpen: boolean) => setDropdownOpen(isOpen);
   const onSelect = (event: React.SyntheticEvent<HTMLDivElement>) => {
-    setCurrentSelection(event.currentTarget.textContent);
     onChange && onChange(event.currentTarget.textContent);
     setDropdownOpen(false);
   };
@@ -48,7 +46,7 @@ const BasicDropdown: React.FC<BasicDropdownProps> = ({
       onSelect={onSelect}
       toggle={
         <DropdownToggle onToggle={onToggle} data-test="dropdown-toggle">
-          {currentSelection}
+          {selected || placeholder}
         </DropdownToggle>
       }
       isOpen={dropdownOpen}


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-1537
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
The basic dropdown component uses an additional state to manage the selected dropdown item, and ignores the prop value. This caused it to not show the correct value unless it was manually changed.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix

## Screen shots / Gifs for design review 
![0](https://user-images.githubusercontent.com/20013884/173381325-fcbf868f-fc91-4549-80fb-1ecd68cec07f.png)
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
Navigate to the review components page, unit dropdown should be preselected with value form CDQ.
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
