### PR TITLE
Show component count only after load

### DIFF
--- a/src/components/ApplicationListView/ApplicationListRow.tsx
+++ b/src/components/ApplicationListView/ApplicationListRow.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
-import { pluralize } from '@patternfly/react-core';
+import { pluralize, Skeleton } from '@patternfly/react-core';
 import { ComponentGroupVersionKind } from '../../models';
 import ActionMenu from '../../shared/components/action-menu/ActionMenu';
 import { RowFunctionArgs, TableData } from '../../shared/components/table';
@@ -11,7 +11,7 @@ import { useApplicationActions } from './application-actions';
 import { applicationTableColumnClasses } from './ApplicationListHeader';
 
 const ApplicationListRow: React.FC<RowFunctionArgs<ApplicationKind>> = ({ obj }) => {
-  const [allComponents] = useK8sWatchResource<ComponentKind[]>({
+  const [allComponents, loaded] = useK8sWatchResource<ComponentKind[]>({
     groupVersionKind: ComponentGroupVersionKind,
     namespace: obj.metadata.namespace,
     isList: true,
@@ -31,7 +31,11 @@ const ApplicationListRow: React.FC<RowFunctionArgs<ApplicationKind>> = ({ obj })
         </Link>
       </TableData>
       <TableData className={applicationTableColumnClasses.components}>
-        {pluralize(components.length, 'Component', 'Components')}
+        {loaded ? (
+          pluralize(components.length, 'Component')
+        ) : (
+          <Skeleton width="50%" screenreaderText="Loading component count" />
+        )}
       </TableData>
       <TableData className={applicationTableColumnClasses.environments}>-</TableData>
       <TableData className={applicationTableColumnClasses.lastDeploy}>

--- a/src/components/ApplicationListView/__tests__/ApplicationListRow.spec.tsx
+++ b/src/components/ApplicationListView/__tests__/ApplicationListRow.spec.tsx
@@ -88,4 +88,10 @@ describe('Application List Row', () => {
     const { getByText } = render(<ApplicationListRow columns={null} obj={application} />);
     expect(getByText('0 Components')).toBeInTheDocument();
   });
+
+  it('renders skeleton in the component column if the components are not loaded', () => {
+    watchResourceMock.mockReturnValue([[], false]);
+    const { getByText } = render(<ApplicationListRow columns={null} obj={application} />);
+    expect(getByText('Loading component count')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-1419
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
Show a skeleton if the component count has not loaded.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

https://user-images.githubusercontent.com/20013884/173863593-2b31129b-ba94-475f-a423-af682fbd5609.mp4

<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
Navigate to applications list view.
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
