### PR TITLE
Add HACBS initial pipeline run list and details

### DIFF
--- a/config/remotePlugin.js
+++ b/config/remotePlugin.js
@@ -9,6 +9,7 @@ module.exports = {
       Applications: resolve(__dirname, '../src/pages/ApplicationsPage'),
       Import: resolve(__dirname, '../src/pages/ImportPage'),
       ComponentSettings: resolve(__dirname, '../src/pages/ComponentSettingsPage'),
+      PipelineRuns: resolve(__dirname, '../src/hacbs/pages/PipelineRunPage'),
       HACBSFlag: resolve(__dirname, '../src/hacbs/hacbsFeatureFlag'),
       WorkspaceSettings: resolve(__dirname, '../src/pages/WorkspaceSettingsPage'),
       CreateEnvironment: resolve(__dirname, '../src/pages/CreateEnvironmentPage'),
@@ -92,6 +93,26 @@ module.exports = {
         exact: true,
         component: {
           $codeRef: 'ComponentSettings',
+        },
+      },
+    },
+    {
+      type: 'console.page/route',
+      properties: {
+        path: '/app-studio/pipelineruns',
+        exact: true,
+        component: {
+          $codeRef: 'PipelineRuns',
+        },
+      },
+    },
+    {
+      type: 'core.page/route',
+      properties: {
+        path: '/app-studio/pipelineruns',
+        exact: true,
+        component: {
+          $codeRef: 'PipelineRuns',
         },
       },
     },

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 // /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
-  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!src/**/stories/*', '!src/hacbs/*'],
+  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!src/**/stories/*', '!src/hacbs/**/*'],
   coverageDirectory: './coverage/',
   moduleNameMapper: {
     '\\.(css|scss)$': 'identity-obj-proxy',

--- a/src/hacbs/components/ApplicationDetails/tabs/PipelineRunsTab.tsx
+++ b/src/hacbs/components/ApplicationDetails/tabs/PipelineRunsTab.tsx
@@ -1,46 +1,12 @@
 import * as React from 'react';
-import { Link } from 'react-router-dom';
-import {
-  EmptyState,
-  EmptyStateIcon,
-  Title,
-  EmptyStateBody,
-  Button,
-  EmptyStateSecondaryActions,
-} from '@patternfly/react-core';
-import { OutlinedFileImageIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-file-image-icon';
+import PipelineRunListView from '../../PipelineRunListView/PipelineRunsListView';
 
 type PipelineRunsTabProps = {
   applicationName: string;
 };
 
 const PipelineRunsTab: React.FC<PipelineRunsTabProps> = ({ applicationName }) => {
-  return (
-    <EmptyState>
-      <EmptyStateIcon icon={OutlinedFileImageIcon} />
-      <Title headingLevel="h4" size="lg">
-        Manage your components via pipelines. Monitor CI/CD activity.
-      </Title>
-      <EmptyStateBody>
-        No pipeline run triggered yet.
-        <br />
-        To get Started, create components and merge their pull request for build pipeline.
-      </EmptyStateBody>
-      <EmptyStateSecondaryActions>
-        <Button
-          component={(props) => (
-            <Link
-              {...props}
-              to={`/app-studio/applications?name=${applicationName}&activeTab=components&hacbs=true`}
-            />
-          )}
-          variant="secondary"
-        >
-          Go to components tab
-        </Button>
-      </EmptyStateSecondaryActions>
-    </EmptyState>
-  );
+  return <PipelineRunListView applicationName={applicationName} />;
 };
 
 export default PipelineRunsTab;

--- a/src/hacbs/components/PipelineRunDetailsView/PipelineRunDetailsView.tsx
+++ b/src/hacbs/components/PipelineRunDetailsView/PipelineRunDetailsView.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { Bullseye, Spinner } from '@patternfly/react-core';
+import { NamespaceContext } from '../../../components/NamespacedPage/NamespacedPage';
+import { PipelineRunGroupVersionKind } from '../../models';
+import { PipelineRunKind } from '../../types';
+import DetailsPage from '../ApplicationDetails/DetailsPage';
+import PipelineRunDetailsTab from './tabs/PipelineRunDetailsTab';
+import PipelineRunEnterpriseContractTab from './tabs/PipelineRunEnterpriseContractTab';
+import PipelineRunEventsTab from './tabs/PipelineRunEventsTab';
+import PipelineRunLogsTab from './tabs/PipelineRunLogsTab';
+import PipelineRunTaskRunsTab from './tabs/PipelineRunTaskRunsTab';
+import PipelineRunYamlTab from './tabs/PipelineRunYamlTab';
+
+type PipelineRunDetailsViewProps = {
+  pipelineRunName: string;
+};
+
+export const PipelineRunDetailsView: React.FC<PipelineRunDetailsViewProps> = ({
+  pipelineRunName,
+}) => {
+  const { namespace } = React.useContext(NamespaceContext);
+
+  const [pipelineRun, loaded] = useK8sWatchResource<PipelineRunKind>({
+    groupVersionKind: PipelineRunGroupVersionKind,
+    name: pipelineRunName,
+    namespace,
+  });
+
+  if (!loaded) {
+    return (
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    );
+  }
+
+  return (
+    <>
+      <React.Fragment>
+        <DetailsPage
+          breadcrumbs={[
+            { path: '/app-studio/applications', name: 'Applications' },
+            {
+              path: `/app-studio/applications/:${pipelineRunName}`,
+              name: pipelineRunName,
+            },
+          ]}
+          title={pipelineRunName}
+          actions={[
+            {
+              key: 'rerun',
+              label: 'Rerun',
+              href: '',
+              isDisabled: true,
+            },
+          ]}
+          tabs={[
+            {
+              key: 'detail',
+              label: 'Details',
+              component: <PipelineRunDetailsTab pipelineRun={pipelineRun} />,
+            },
+            {
+              key: 'yaml',
+              label: 'YAML',
+              component: <PipelineRunYamlTab pipelineRun={pipelineRun} />,
+            },
+            {
+              key: 'taskruns',
+              label: 'Task runs',
+              component: <PipelineRunTaskRunsTab pipelineRun={pipelineRun} />,
+            },
+            {
+              key: 'logs',
+              label: 'Logs',
+              component: <PipelineRunLogsTab pipelineRun={pipelineRun} />,
+            },
+            {
+              key: 'events',
+              label: 'Events',
+              component: <PipelineRunEventsTab pipelineRun={pipelineRun} />,
+            },
+            {
+              key: 'enterprisecontract',
+              label: 'Enterprise Contract',
+              component: <PipelineRunEnterpriseContractTab pipelineRun={pipelineRun} />,
+            },
+          ]}
+        />
+      </React.Fragment>
+    </>
+  );
+};
+
+export default PipelineRunDetailsView;

--- a/src/hacbs/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
+++ b/src/hacbs/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react';
+import {
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+  Title,
+} from '@patternfly/react-core';
+import { calculateDuration } from '../../../utils/pipeline-utils';
+
+type PipelineRunDetailsTabProps = {
+  pipelineRun: any;
+};
+
+const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({ pipelineRun }) => {
+  const duration = calculateDuration(
+    typeof pipelineRun.status?.startTime === 'string' ? pipelineRun.status?.startTime : '',
+    typeof pipelineRun.status?.completionTime === 'string'
+      ? pipelineRun.status?.completionTime
+      : '',
+  );
+  return (
+    <>
+      <Title headingLevel="h4" className="pf-c-title pf-u-mt-lg pf-u-mb-lg">
+        Pipelinerun details
+      </Title>
+      <DescriptionList
+        columnModifier={{
+          default: '2Col',
+        }}
+      >
+        <DescriptionListGroup>
+          <DescriptionListTerm>Name</DescriptionListTerm>
+          <DescriptionListDescription>{pipelineRun.metadata.name}</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Status</DescriptionListTerm>
+          <DescriptionListDescription>
+            {pipelineRun.status?.conditions[0].status === 'False' ? 'Failed' : 'Succeeded'}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Namespace</DescriptionListTerm>
+          <DescriptionListDescription>{pipelineRun.metadata.namespace}</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Message</DescriptionListTerm>
+          <DescriptionListDescription>
+            {pipelineRun.status?.conditions[0].message}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Labels</DescriptionListTerm>
+          <DescriptionListDescription>-</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Log snippet</DescriptionListTerm>
+          <DescriptionListDescription>-</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Created at</DescriptionListTerm>
+          <DescriptionListDescription>-</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Pipeline</DescriptionListTerm>
+          <DescriptionListDescription>-</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Owner</DescriptionListTerm>
+          <DescriptionListDescription>-</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Triggered by</DescriptionListTerm>
+          <DescriptionListDescription>-</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Duration</DescriptionListTerm>
+          <DescriptionListDescription>{duration}</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Application</DescriptionListTerm>
+          <DescriptionListDescription>-</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup />
+        <DescriptionListGroup>
+          <DescriptionListTerm>Component</DescriptionListTerm>
+          <DescriptionListDescription>
+            {pipelineRun.metadata.labels['build.appstudio.openshift.io/component']}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup />
+        <DescriptionListGroup>
+          <DescriptionListTerm>Source</DescriptionListTerm>
+          <DescriptionListDescription>-</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup />
+        <DescriptionListGroup>
+          <DescriptionListTerm>Workspace</DescriptionListTerm>
+          <DescriptionListDescription>-</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup />
+        <DescriptionListGroup>
+          <DescriptionListTerm>Compliance</DescriptionListTerm>
+          <DescriptionListDescription>-</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup />
+        <DescriptionListGroup>
+          <DescriptionListTerm>Environment</DescriptionListTerm>
+          <DescriptionListDescription>-</DescriptionListDescription>
+        </DescriptionListGroup>
+      </DescriptionList>
+    </>
+  );
+};
+
+export default PipelineRunDetailsTab;

--- a/src/hacbs/components/PipelineRunDetailsView/tabs/PipelineRunEnterpriseContractTab.tsx
+++ b/src/hacbs/components/PipelineRunDetailsView/tabs/PipelineRunEnterpriseContractTab.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { EmptyState, EmptyStateIcon, Title, EmptyStateBody } from '@patternfly/react-core';
+import { OutlinedFileImageIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-file-image-icon';
+
+type PipelineRunEnterpriseContractTabProps = {
+  pipelineRun: any;
+};
+
+const PipelineRunEnterpriseContractTab: React.FC<PipelineRunEnterpriseContractTabProps> = () => {
+  return (
+    <EmptyState>
+      <EmptyStateIcon icon={OutlinedFileImageIcon} />
+      <Title headingLevel="h4" size="lg">
+        View enterprise contracts for this pipelinerun
+      </Title>
+      <EmptyStateBody>
+        No enterprise contracts found yet.
+        <br />
+        To get Started, create a pipelinerun or connect to a pipelinerun environment.
+      </EmptyStateBody>
+    </EmptyState>
+  );
+};
+
+export default PipelineRunEnterpriseContractTab;

--- a/src/hacbs/components/PipelineRunDetailsView/tabs/PipelineRunEventsTab.tsx
+++ b/src/hacbs/components/PipelineRunDetailsView/tabs/PipelineRunEventsTab.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { EmptyState, EmptyStateIcon, Title, EmptyStateBody } from '@patternfly/react-core';
+import { OutlinedFileImageIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-file-image-icon';
+
+type PipelineRunEventsTabProps = {
+  pipelineRun: any;
+};
+
+const PipelineRunEventsTab: React.FC<PipelineRunEventsTabProps> = () => {
+  return (
+    <EmptyState>
+      <EmptyStateIcon icon={OutlinedFileImageIcon} />
+      <Title headingLevel="h4" size="lg">
+        Monitor your events for this pipelinerun
+      </Title>
+      <EmptyStateBody>
+        No pipelinerun events found yet.
+        <br />
+        To get Started, create a pipelinerun or connect to a pipelinerun environment.
+      </EmptyStateBody>
+    </EmptyState>
+  );
+};
+
+export default PipelineRunEventsTab;

--- a/src/hacbs/components/PipelineRunDetailsView/tabs/PipelineRunLogsTab.tsx
+++ b/src/hacbs/components/PipelineRunDetailsView/tabs/PipelineRunLogsTab.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { EmptyState, EmptyStateIcon, Title, EmptyStateBody } from '@patternfly/react-core';
+import { OutlinedFileImageIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-file-image-icon';
+
+type PipelineRunLogsTabProps = {
+  pipelineRun: any;
+};
+
+const PipelineRunLogsTab: React.FC<PipelineRunLogsTabProps> = () => {
+  return (
+    <EmptyState>
+      <EmptyStateIcon icon={OutlinedFileImageIcon} />
+      <Title headingLevel="h4" size="lg">
+        View logs for this pipelinerun
+      </Title>
+      <EmptyStateBody>
+        No logs found yet.
+        <br />
+        To get Started, create a pipelinerun or connect to a pipelinerun environment.
+      </EmptyStateBody>
+    </EmptyState>
+  );
+};
+
+export default PipelineRunLogsTab;

--- a/src/hacbs/components/PipelineRunDetailsView/tabs/PipelineRunTaskRunsTab.tsx
+++ b/src/hacbs/components/PipelineRunDetailsView/tabs/PipelineRunTaskRunsTab.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { EmptyState, EmptyStateIcon, Title, EmptyStateBody } from '@patternfly/react-core';
+import { OutlinedFileImageIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-file-image-icon';
+
+type PipelineRunTaskRunsTabProps = {
+  pipelineRun: any;
+};
+
+const PipelineRunTaskRunsTab: React.FC<PipelineRunTaskRunsTabProps> = () => {
+  return (
+    <EmptyState>
+      <EmptyStateIcon icon={OutlinedFileImageIcon} />
+      <Title headingLevel="h4" size="lg">
+        View task runs for this pipelinerun
+      </Title>
+      <EmptyStateBody>
+        No task runs found yet.
+        <br />
+        To get Started, create a pipelinerun or connect to a pipelinerun environment.
+      </EmptyStateBody>
+    </EmptyState>
+  );
+};
+
+export default PipelineRunTaskRunsTab;

--- a/src/hacbs/components/PipelineRunDetailsView/tabs/PipelineRunYamlTab.tsx
+++ b/src/hacbs/components/PipelineRunDetailsView/tabs/PipelineRunYamlTab.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { EmptyState, EmptyStateIcon, Title, EmptyStateBody } from '@patternfly/react-core';
+import { OutlinedFileImageIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-file-image-icon';
+
+type PipelineRunYamlTabProps = {
+  pipelineRun: any;
+};
+
+const PipelineRunYamlTab: React.FC<PipelineRunYamlTabProps> = () => {
+  return (
+    <EmptyState>
+      <EmptyStateIcon icon={OutlinedFileImageIcon} />
+      <Title headingLevel="h4" size="lg">
+        View YAML for this pipelinerun
+      </Title>
+      <EmptyStateBody>
+        No YAML markup found yet.
+        <br />
+        To get Started, create a pipelinerun or connect to a pipelinerun environment.
+      </EmptyStateBody>
+    </EmptyState>
+  );
+};
+
+export default PipelineRunYamlTab;

--- a/src/hacbs/components/PipelineRunListView/PipelineRunListHeader.ts
+++ b/src/hacbs/components/PipelineRunListView/PipelineRunListHeader.ts
@@ -1,0 +1,37 @@
+export const pipelineRunTableColumnClasses = {
+  name: 'pf-m-width-20',
+  status: 'pf-m-width-15',
+  started: 'pf-m-width-15',
+  type: 'pf-m-hidden pf-m-visible-on-xl',
+  duration: 'pf-m-width-15',
+  kebab: 'pf-c-table__action',
+};
+
+export const PipelineRunListHeader = () => {
+  return [
+    {
+      title: 'Name',
+      props: { className: pipelineRunTableColumnClasses.name },
+    },
+    {
+      title: 'Started',
+      props: { className: pipelineRunTableColumnClasses.started },
+    },
+    {
+      title: 'Duration',
+      props: { className: pipelineRunTableColumnClasses.duration },
+    },
+    {
+      title: 'Status',
+      props: { className: pipelineRunTableColumnClasses.status },
+    },
+    {
+      title: 'Type',
+      props: { className: pipelineRunTableColumnClasses.duration },
+    },
+    {
+      title: '',
+      props: { className: pipelineRunTableColumnClasses.kebab },
+    },
+  ];
+};

--- a/src/hacbs/components/PipelineRunListView/PipelineRunListRow.tsx
+++ b/src/hacbs/components/PipelineRunListView/PipelineRunListRow.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
+import { RowFunctionArgs, TableData } from '../../../shared/components/table';
+import { Timestamp } from '../../../shared/components/timestamp/Timestamp';
+import { PipelineRunKind } from '../../types';
+import { calculateDuration } from '../../utils/pipeline-utils';
+import { pipelineRunTableColumnClasses } from './PipelineRunListHeader';
+
+const PipelineListRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({ obj }) => {
+  const [kebabOpen, setKebabOpen] = useState(false);
+
+  const capitalize = (label: string) => {
+    return label.charAt(0).toUpperCase() + label.slice(1);
+  };
+  return (
+    <>
+      <TableData className={pipelineRunTableColumnClasses.name}>
+        <Link to={`/app-studio/pipelineruns?name=${obj.metadata.name}`} title={obj.metadata.name}>
+          {obj.metadata.name}
+        </Link>
+      </TableData>
+      <TableData className={pipelineRunTableColumnClasses.started}>
+        <Timestamp
+          timestamp={typeof obj.status?.startTime === 'string' ? obj.status.startTime : ''}
+        />
+      </TableData>
+      <TableData className={pipelineRunTableColumnClasses.duration}>
+        {calculateDuration(
+          typeof obj.status?.startTime === 'string' ? obj.status.startTime : '',
+          typeof obj.status?.completionTime === 'string' ? obj.status.completionTime : '',
+        )}
+      </TableData>
+      <TableData className={pipelineRunTableColumnClasses.status}>
+        {obj.status?.conditions[0].status === 'False' ? 'Failed' : 'Succeeded'}
+      </TableData>
+      <TableData className={pipelineRunTableColumnClasses.type}>
+        {capitalize(obj.metadata.labels['pipelines.appstudio.openshift.io/type'])}
+      </TableData>
+      <TableData className={pipelineRunTableColumnClasses.kebab}>
+        <Dropdown
+          toggle={<KebabToggle onToggle={setKebabOpen} />}
+          isOpen={kebabOpen}
+          isPlain
+          dropdownItems={[
+            <DropdownItem
+              key="rerunAction"
+              component="button"
+              onClick={() => {
+                setKebabOpen(false);
+              }}
+              isDisabled={true}
+            >
+              Rerun
+            </DropdownItem>,
+            <DropdownItem
+              key="stopAction"
+              component="button"
+              onClick={() => {
+                setKebabOpen(false);
+              }}
+              isDisabled={true}
+            >
+              Stop
+            </DropdownItem>,
+          ]}
+        />
+      </TableData>
+    </>
+  );
+};
+
+export default PipelineListRow;

--- a/src/hacbs/components/PipelineRunListView/PipelineRunsListView.tsx
+++ b/src/hacbs/components/PipelineRunListView/PipelineRunsListView.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import {
+  Bullseye,
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateSecondaryActions,
+  Spinner,
+  Title,
+} from '@patternfly/react-core';
+import { OutlinedFileImageIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-file-image-icon';
+import { NamespaceContext } from '../../../components/NamespacedPage/NamespacedPage';
+import { Table } from '../../../shared';
+import { PipelineRunGroupVersionKind } from '../../models';
+import { PipelineRunKind } from '../../types';
+import { PipelineRunListHeader } from './PipelineRunListHeader';
+import PipelineRunListRow from './PipelineRunListRow';
+
+type PipelineRunsListViewProps = { applicationName: string };
+const PipelineRunsListView: React.FC<PipelineRunsListViewProps> = ({ applicationName }) => {
+  const { namespace } = React.useContext(NamespaceContext);
+
+  const [pipelineRuns, loaded] = useK8sWatchResource<PipelineRunKind[]>({
+    groupVersionKind: PipelineRunGroupVersionKind,
+    namespace,
+    isList: true,
+    selector: {
+      matchLabels: {
+        'build.appstudio.openshift.io/application': applicationName,
+      },
+    },
+  });
+
+  if (!loaded) {
+    return (
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    );
+  }
+
+  if (!pipelineRuns || pipelineRuns.length === 0) {
+    return (
+      <EmptyState>
+        <EmptyStateIcon icon={OutlinedFileImageIcon} />
+        <Title headingLevel="h4" size="lg">
+          Manage your components via pipelines. Monitor CI/CD activity.
+        </Title>
+        <EmptyStateBody>
+          No pipeline run triggered yet.
+          <br />
+          To get Started, create components and merge their pull request for build pipeline.
+        </EmptyStateBody>
+        <EmptyStateSecondaryActions>
+          <Button
+            component={(props) => (
+              <Link
+                {...props}
+                to={`/app-studio/applications?name=${applicationName}&activeTab=components&hacbs=true`}
+              />
+            )}
+            variant="secondary"
+          >
+            Go to components tab
+          </Button>
+        </EmptyStateSecondaryActions>
+      </EmptyState>
+    );
+  }
+
+  pipelineRuns?.sort(
+    (app1, app2) =>
+      +new Date(app2.metadata.creationTimestamp) - +new Date(app1.metadata.creationTimestamp),
+  );
+
+  return (
+    <>
+      <Title headingLevel="h4" className="pf-c-title pf-u-mt-lg pf-u-mb-lg">
+        Pipelineruns
+      </Title>
+      <Table
+        data={pipelineRuns}
+        aria-label="Pipelinerun List"
+        Header={PipelineRunListHeader}
+        Row={PipelineRunListRow}
+        loaded={loaded}
+        getRowProps={(obj: PipelineRunKind) => ({
+          id: obj.metadata.name,
+        })}
+      />
+    </>
+  );
+};
+
+export default PipelineRunsListView;

--- a/src/hacbs/models/index.ts
+++ b/src/hacbs/models/index.ts
@@ -1,0 +1,1 @@
+export * from './pipelineruns';

--- a/src/hacbs/models/pipelineruns.ts
+++ b/src/hacbs/models/pipelineruns.ts
@@ -1,0 +1,16 @@
+import { K8sModelCommon } from '@openshift/dynamic-plugin-sdk-utils';
+import { K8sGroupVersionKind } from '../../dynamic-plugin-sdk';
+
+export const PipelineRunModel: K8sModelCommon = {
+  apiGroup: 'tekton.dev',
+  apiVersion: 'v1beta1',
+  kind: 'PipelineRun',
+  plural: 'pipelineruns',
+  namespaced: true,
+};
+
+export const PipelineRunGroupVersionKind: K8sGroupVersionKind = {
+  group: 'tekton.dev',
+  version: 'v1beta1',
+  kind: 'PipelineRun',
+};

--- a/src/hacbs/pages/PipelineRunPage.tsx
+++ b/src/hacbs/pages/PipelineRunPage.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import { PageSection, PageSectionVariants } from '@patternfly/react-core';
+import NamespacedPage from '../../components/NamespacedPage/NamespacedPage';
+import PageLayout from '../../components/PageLayout/PageLayout';
+import { useQuickstartCloseOnUnmount } from '../../hooks/useQuickstartCloseOnUnmount';
+import { getQueryArgument } from '../../shared/utils';
+import { PipelineRunDetailsView } from '../components/PipelineRunDetailsView/PipelineRunDetailsView';
+import PipelineRunsListView from '../components/PipelineRunListView/PipelineRunsListView';
+
+const PipelineRunPage = () => {
+  useQuickstartCloseOnUnmount();
+  const name = getQueryArgument('name');
+
+  return (
+    <NamespacedPage>
+      {name ? (
+        <React.Fragment>
+          <Helmet>
+            <title>Pipelinerun Details Page</title>
+          </Helmet>
+          <PipelineRunDetailsView pipelineRunName={name} />
+        </React.Fragment>
+      ) : (
+        <React.Fragment>
+          <Helmet>
+            <title>Pipelineruns</title>
+          </Helmet>
+          <PageLayout title="Pipelineruns" description="Pipelineruns are listed here.">
+            <PageSection
+              padding={{ default: 'noPadding' }}
+              variant={PageSectionVariants.light}
+              isFilled
+            >
+              <PipelineRunsListView applicationName={name} />
+            </PageSection>
+          </PageLayout>
+        </React.Fragment>
+      )}
+    </NamespacedPage>
+  );
+};
+
+export default PipelineRunPage;

--- a/src/hacbs/types/index.ts
+++ b/src/hacbs/types/index.ts
@@ -1,0 +1,2 @@
+export * from './pipeline';
+export * from './pipelineResource';

--- a/src/hacbs/types/pipeline.ts
+++ b/src/hacbs/types/pipeline.ts
@@ -1,0 +1,25 @@
+import { K8sModelCommon, K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
+import { K8sGroupVersionKind } from '../../dynamic-plugin-sdk';
+
+export type PipelineKind = K8sModelCommon & {
+  apiGroup: 'appstudio.redhat.com';
+  apiVersion: 'v1alpha1';
+  kind: 'Pipleline';
+  plural: 'pipelines';
+  namespaced: true;
+};
+
+export type PipelineRunKind = K8sModelCommon &
+  K8sResourceCommon & {
+    apiGroup: 'tekton.dev';
+    version: 'v1alpha1';
+    kind: 'PipelineRun';
+    plural: 'pipeline runs';
+    namespaced: true;
+  };
+
+export const PipelineGroupVersionKind: K8sGroupVersionKind = {
+  group: 'tekton.dev',
+  version: 'v1beta1',
+  kind: 'Pipeline',
+};

--- a/src/hacbs/types/pipelineResource.ts
+++ b/src/hacbs/types/pipelineResource.ts
@@ -1,0 +1,8 @@
+import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
+
+export type PipelineResourceKind = K8sResourceCommon & {
+  spec: {
+    params: { name: string; value: string }[];
+    type: string;
+  };
+};

--- a/src/hacbs/utils/pipeline-utils.ts
+++ b/src/hacbs/utils/pipeline-utils.ts
@@ -1,0 +1,39 @@
+import i18next from 'i18next';
+
+export const getDuration = (seconds: number, long?: boolean): string => {
+  if (seconds === 0) {
+    return i18next.t('pipelines-plugin~less than a sec');
+  }
+  let sec = Math.round(seconds);
+  let min = 0;
+  let hr = 0;
+  let duration = '';
+  if (sec >= 60) {
+    min = Math.floor(sec / 60);
+    sec %= 60;
+  }
+  if (min >= 60) {
+    hr = Math.floor(min / 60);
+    min %= 60;
+  }
+  if (hr > 0) {
+    duration += long ? `${hr} hour` : `${hr} h`;
+    duration += ' ';
+  }
+  if (min > 0) {
+    duration += long ? `${min} minute` : `${min} m`;
+    duration += ' ';
+  }
+  if (sec > 0) {
+    duration += long ? `${sec} second` : `${sec} s`;
+  }
+
+  return duration.trim();
+};
+
+export const calculateDuration = (startTime: string, endTime?: string) => {
+  const start = new Date(startTime).getTime();
+  const end = endTime ? new Date(endTime).getTime() : new Date().getTime();
+  const durationInSeconds = (end - start) / 1000;
+  return getDuration(durationInSeconds, true);
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 export * from './component';
 export * from './application';
 export * from './environment';
+export * from '../hacbs/types/pipeline';
 export * from './component-detection-query';
 export * from './service-provider-integration';
 export * from './routes';


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HACBS-381

## Description
With the decision to create one large monorepo for app studio and its features/plugins, I've added a hacbs subdir under hac-dev to contain all hacbs front end UI code. This particular PR creates the initial structure and includes the pipeline run list page that was demo'd in M5, so we can establish initial code in hac-dev and continue to build onto it for MVP and beyond.

## Type of change
- [x] Feature

## Screen shots / Gifs for design review 
Pipelinerun list:
![pipelinerun-list](https://user-images.githubusercontent.com/39063664/179807502-0983d701-3976-4a4f-80a9-29be09eda596.png)

Pipelinerun details:
![pipelinerun-details](https://user-images.githubusercontent.com/39063664/179807616-5048b457-e7fd-4e61-b031-4b6022dd4dc3.png)


## How to test or reproduce?
Pipelineruns will not appear by default. It was decided to hide hacbs in the UI until feature flags become available. To view pipelineruns, use /hac/hacbs in the URL to get the tabbed interface, then choose the pipelineruns tab.

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [x] Code follows the style guidelines
- [x] Self-reviewed the code
- [x] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [x] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [x] Any dependent changes have been merged and published in downstream modules 
-->
