### PR TITLE
Add data model for pipelinerun visualization

### DIFF
--- a/src/hacbs/components/topology/__data__/pipeline-test-data.ts
+++ b/src/hacbs/components/topology/__data__/pipeline-test-data.ts
@@ -1,0 +1,738 @@
+import {
+  PipelineKind,
+  PipelineRunKind,
+} from '../../../../shared/components/pipeline-run-logs/types';
+
+export const testPipeline: PipelineKind = {
+  apiVersion: 'tekton.dev/v1beta1',
+  kind: 'Pipeline',
+  metadata: {
+    creationTimestamp: '2022-06-21T04:33:49Z',
+    generation: 6,
+    name: 'sum-and-multiply-pipeline',
+    namespace: 'karthik',
+    resourceVersion: '183483',
+    uid: 'e8ad59b3-7228-40cc-9ef8-eda28ba67b2f',
+  },
+  spec: {
+    params: [
+      {
+        default: '1',
+        name: 'a',
+        type: 'string',
+      },
+      {
+        default: '1',
+        name: 'b',
+        type: 'string',
+      },
+    ],
+    tasks: [
+      {
+        name: 'task1',
+        params: [
+          {
+            name: 'a',
+            value: '$(params.a)',
+          },
+          {
+            name: 'b',
+            value: '$(params.b)',
+          },
+        ],
+        taskRef: {
+          kind: 'Task',
+          name: 'sum',
+        },
+      },
+      {
+        name: 'task2',
+        params: [
+          {
+            name: 'a',
+            value: '$(params.a)',
+          },
+          {
+            name: 'b',
+            value: '$(params.a)',
+          },
+        ],
+        taskRef: {
+          kind: 'Task',
+          name: 'multiply',
+        },
+      },
+      {
+        name: 'task3',
+        params: [
+          {
+            name: 'a',
+            value: '1',
+          },
+          {
+            name: 'b',
+            value: '1',
+          },
+        ],
+        taskRef: {
+          kind: 'Task',
+          name: 'sum',
+        },
+        runAfter: ['task1', 'task2'],
+      },
+      {
+        name: 'task4',
+        params: [
+          {
+            name: 'a',
+            value: '1',
+          },
+          {
+            name: 'b',
+            value: '1',
+          },
+        ],
+        runAfter: ['task3'],
+        taskRef: {
+          kind: 'Task',
+          name: 'sum',
+        },
+      },
+      {
+        name: 'task5',
+        when: [
+          {
+            input: 'test',
+            operator: 'IN',
+            values: ['$(tasks.task1.results.sum)$(tasks.task2.results.product)'],
+          },
+        ],
+        params: [
+          {
+            name: 'a',
+            value: '1',
+          },
+          {
+            name: 'b',
+            value: '1',
+          },
+        ],
+        taskRef: {
+          kind: 'Task',
+          name: 'sum',
+        },
+      },
+      {
+        name: 'task6',
+        params: [
+          {
+            name: 'a',
+            value: '1',
+          },
+          {
+            name: 'b',
+            value: '1',
+          },
+        ],
+        runAfter: ['task5'],
+        taskRef: {
+          kind: 'Task',
+          name: 'sum',
+        },
+      },
+    ],
+    resources: [],
+    workspaces: [],
+    finally: [],
+  },
+};
+
+export const testPipelineRun: PipelineRunKind = {
+  apiVersion: 'tekton.dev/v1beta1',
+  kind: 'PipelineRun',
+  metadata: {
+    annotations: {
+      'pipeline.openshift.io/started-by': 'kube:admin',
+    },
+    resourceVersion: '192148',
+    name: 'sum-and-multiply-pipeline-ybpufp',
+    uid: '7a32b583-56e2-43b2-ad54-ce7487972839',
+    creationTimestamp: '2022-06-29T13:02:03Z',
+    generation: 1,
+    namespace: 'dev',
+    labels: {
+      'tekton.dev/pipeline': 'sum-and-multiply-pipeline',
+    },
+  },
+  spec: {
+    params: [
+      {
+        name: 'a',
+        value: '1',
+      },
+      {
+        name: 'b',
+        value: '1',
+      },
+    ],
+    pipelineRef: {
+      name: 'sum-and-multiply-pipeline',
+    },
+    serviceAccountName: 'pipeline',
+    timeout: '1h0m0s',
+  },
+  status: {
+    conditions: [
+      {
+        lastTransitionTime: '2022-06-29T13:02:34Z',
+        message: 'Tasks Completed: 2 (Failed: 0, Cancelled 0), Incomplete: 2, Skipped: 2',
+        reason: 'Running',
+        status: 'Unknown',
+        type: 'Succeeded',
+      },
+    ],
+    pipelineSpec: {
+      params: [
+        {
+          default: '1',
+          name: 'a',
+          type: 'string',
+        },
+        {
+          default: '1',
+          name: 'b',
+          type: 'string',
+        },
+      ],
+      tasks: [
+        {
+          name: 'task1',
+          params: [
+            {
+              name: 'a',
+              value: '$(params.a)',
+            },
+            {
+              name: 'b',
+              value: '$(params.b)',
+            },
+          ],
+          taskRef: {
+            kind: 'Task',
+            name: 'sum',
+          },
+          status: {
+            completionTime: '2022-06-29T13:02:20Z',
+            conditions: [
+              {
+                lastTransitionTime: '2022-06-29T13:02:20Z',
+                message: 'All Steps have completed executing',
+                reason: 'Succeeded',
+                status: 'True',
+                type: 'Succeeded',
+              },
+            ],
+            podName: 'sum-and-multiply-pipeline-ybpufp-task1-pod',
+            startTime: '2022-06-29T13:02:03Z',
+            steps: [
+              {
+                container: 'step-sum',
+                imageID:
+                  'docker.io/library/bash@sha256:8f89b1dbb035d830be70ce827a76a3d1a06ab838332ce9b1ba30a415bb53d856',
+                name: 'sum',
+                terminated: {
+                  containerID:
+                    'cri-o://311b9bb0897a97fbc8f7653a90355f9a821d492a7a112bf9a4eb57ed858d3346',
+                  exitCode: 0,
+                  finishedAt: '2022-06-29T13:02:20Z',
+                  message: '[{"key":"sum","value":"2","type":1}]',
+                  reason: 'Completed',
+                  startedAt: '2022-06-29T13:02:20Z',
+                },
+              },
+            ],
+            taskResults: [
+              {
+                name: 'sum',
+                value: '2',
+              },
+            ],
+            taskSpec: {
+              params: [
+                {
+                  default: '1',
+                  description: 'The first integer',
+                  name: 'a',
+                  type: 'string',
+                },
+                {
+                  default: '1',
+                  description: 'The second integer',
+                  name: 'b',
+                  type: 'string',
+                },
+              ],
+              results: [
+                {
+                  description: 'The sum of the two provided integers',
+                  name: 'sum',
+                },
+              ],
+              steps: [
+                {
+                  image: 'bash:latest',
+                  name: 'sum',
+                  resources: {},
+                  script:
+                    '#!/usr/bin/env bash\necho -n $(( "$(params.a)" + "$(params.b)" )) | tee $(results.sum.path)\n',
+                },
+              ],
+            },
+            duration: '17s',
+            reason: 'Succeeded',
+          },
+        },
+        {
+          name: 'task2',
+          params: [
+            {
+              name: 'a',
+              value: '$(params.a)',
+            },
+            {
+              name: 'b',
+              value: '$(params.a)',
+            },
+          ],
+          taskRef: {
+            kind: 'Task',
+            name: 'multiply',
+          },
+          status: {
+            completionTime: '2022-06-29T13:02:34Z',
+            conditions: [
+              {
+                lastTransitionTime: '2022-06-29T13:02:34Z',
+                message: 'All Steps have completed executing',
+                reason: 'Succeeded',
+                status: 'True',
+                type: 'Succeeded',
+              },
+            ],
+            podName: 'sum-and-multiply-pipeline-ybpufp-task2-pod',
+            startTime: '2022-06-29T13:02:03Z',
+            steps: [
+              {
+                container: 'step-product',
+                imageID:
+                  'docker.io/library/bash@sha256:8f89b1dbb035d830be70ce827a76a3d1a06ab838332ce9b1ba30a415bb53d856',
+                name: 'product',
+                terminated: {
+                  containerID:
+                    'cri-o://eeeac678d235948941e9a931ee440bc17192fdd5bfcbb14729446fbd8d482d4f',
+                  exitCode: 0,
+                  finishedAt: '2022-06-29T13:02:33Z',
+                  message: '[{"key":"product","value":"1","type":1}]',
+                  reason: 'Completed',
+                  startedAt: '2022-06-29T13:02:33Z',
+                },
+              },
+            ],
+            taskResults: [
+              {
+                name: 'product',
+                value: '1',
+              },
+            ],
+            taskSpec: {
+              params: [
+                {
+                  default: '1',
+                  description: 'The first integer',
+                  name: 'a',
+                  type: 'string',
+                },
+                {
+                  default: '1',
+                  description: 'The second integer',
+                  name: 'b',
+                  type: 'string',
+                },
+              ],
+              results: [
+                {
+                  description: 'The product of the two provided integers',
+                  name: 'product',
+                },
+              ],
+              steps: [
+                {
+                  image: 'bash:latest',
+                  name: 'product',
+                  resources: {},
+                  script:
+                    '#!/usr/bin/env bash\necho -n $(( "$(params.a)" * "$(params.b)" )) | tee $(results.product.path)\n',
+                },
+              ],
+            },
+            duration: '31s',
+            reason: 'Succeeded',
+          },
+        },
+        {
+          name: 'task3',
+          params: [
+            {
+              name: 'a',
+              value: '1',
+            },
+            {
+              name: 'b',
+              value: '1',
+            },
+          ],
+          runAfter: ['task1', 'task2'],
+          taskRef: {
+            kind: 'Task',
+            name: 'sum',
+          },
+          status: {
+            conditions: [
+              {
+                lastTransitionTime: '2022-06-29T13:02:34Z',
+                message:
+                  'pod status "Initialized":"False"; message: "containers with incomplete status: [prepare place-scripts]"',
+                reason: 'Pending',
+                status: 'Unknown',
+                type: 'Succeeded',
+              },
+            ],
+            podName: 'sum-and-multiply-pipeline-ybpufp-task3-pod',
+            startTime: '2022-06-29T13:02:34Z',
+            steps: [
+              {
+                container: 'step-sum',
+                name: 'sum',
+                waiting: {
+                  reason: 'PodInitializing',
+                },
+              },
+            ],
+            taskSpec: {
+              params: [
+                {
+                  default: '1',
+                  description: 'The first integer',
+                  name: 'a',
+                  type: 'string',
+                },
+                {
+                  default: '1',
+                  description: 'The second integer',
+                  name: 'b',
+                  type: 'string',
+                },
+              ],
+              results: [
+                {
+                  description: 'The sum of the two provided integers',
+                  name: 'sum',
+                },
+              ],
+              steps: [
+                {
+                  image: 'bash:latest',
+                  name: 'sum',
+                  resources: {},
+                  script:
+                    '#!/usr/bin/env bash\necho -n $(( "$(params.a)" + "$(params.b)" )) | tee $(results.sum.path)\n',
+                },
+              ],
+            },
+            reason: 'Running',
+          },
+        },
+        {
+          name: 'task4',
+          params: [
+            {
+              name: 'a',
+              value: '1',
+            },
+            {
+              name: 'b',
+              value: '1',
+            },
+          ],
+          runAfter: ['task3'],
+          taskRef: {
+            kind: 'Task',
+            name: 'sum',
+          },
+          status: {
+            reason: 'Idle',
+          },
+        },
+        {
+          name: 'task5',
+          params: [
+            {
+              name: 'a',
+              value: '1',
+            },
+            {
+              name: 'b',
+              value: '1',
+            },
+          ],
+          taskRef: {
+            kind: 'Task',
+            name: 'sum',
+          },
+          when: [
+            {
+              input: 'test',
+              operator: 'in',
+              values: ['$(tasks.task1.results.sum)$(tasks.task2.results.product)'],
+            },
+          ],
+          status: {
+            reason: 'Skipped',
+          },
+        },
+        {
+          name: 'task6',
+          params: [
+            {
+              name: 'a',
+              value: '1',
+            },
+            {
+              name: 'b',
+              value: '1',
+            },
+          ],
+          runAfter: ['task5'],
+          taskRef: {
+            kind: 'Task',
+            name: 'sum',
+          },
+          status: {
+            reason: 'Skipped',
+          },
+        },
+      ],
+    },
+    skippedTasks: [
+      {
+        name: 'task5',
+        whenExpressions: [
+          {
+            input: 'test',
+            operator: 'in',
+            values: ['21'],
+          },
+        ],
+      },
+      {
+        name: 'task6',
+      },
+    ],
+    startTime: '2022-06-29T13:02:03Z',
+    taskRuns: {
+      'sum-and-multiply-pipeline-ybpufp-task1': {
+        pipelineTaskName: 'task1',
+        status: {
+          completionTime: '2022-06-29T13:02:20Z',
+          conditions: [
+            {
+              lastTransitionTime: '2022-06-29T13:02:20Z',
+              message: 'All Steps have completed executing',
+              reason: 'Succeeded',
+              status: 'True',
+              type: 'Succeeded',
+            },
+          ],
+          podName: 'sum-and-multiply-pipeline-ybpufp-task1-pod',
+          startTime: '2022-06-29T13:02:03Z',
+          steps: [
+            {
+              container: 'step-sum',
+              imageID:
+                'docker.io/library/bash@sha256:8f89b1dbb035d830be70ce827a76a3d1a06ab838332ce9b1ba30a415bb53d856',
+              name: 'sum',
+              terminated: {
+                containerID:
+                  'cri-o://311b9bb0897a97fbc8f7653a90355f9a821d492a7a112bf9a4eb57ed858d3346',
+                exitCode: 0,
+                finishedAt: '2022-06-29T13:02:20Z',
+                message: '[{"key":"sum","value":"2","type":1}]',
+                reason: 'Completed',
+                startedAt: '2022-06-29T13:02:20Z',
+              },
+            },
+          ],
+          taskResults: [
+            {
+              name: 'sum',
+              value: '2',
+            },
+          ],
+          taskSpec: {
+            params: [
+              {
+                default: '1',
+                description: 'The first integer',
+                name: 'a',
+                type: 'string',
+              },
+              {
+                default: '1',
+                description: 'The second integer',
+                name: 'b',
+                type: 'string',
+              },
+            ],
+            results: [
+              {
+                description: 'The sum of the two provided integers',
+                name: 'sum',
+              },
+            ],
+            steps: [
+              {
+                image: 'bash:latest',
+                name: 'sum',
+                resources: {},
+              },
+            ],
+          },
+        },
+      },
+      'sum-and-multiply-pipeline-ybpufp-task2': {
+        pipelineTaskName: 'task2',
+        status: {
+          completionTime: '2022-06-29T13:02:34Z',
+          conditions: [
+            {
+              lastTransitionTime: '2022-06-29T13:02:34Z',
+              message: 'All Steps have completed executing',
+              reason: 'Succeeded',
+              status: 'True',
+              type: 'Succeeded',
+            },
+          ],
+          podName: 'sum-and-multiply-pipeline-ybpufp-task2-pod',
+          startTime: '2022-06-29T13:02:03Z',
+          steps: [
+            {
+              container: 'step-product',
+              imageID:
+                'docker.io/library/bash@sha256:8f89b1dbb035d830be70ce827a76a3d1a06ab838332ce9b1ba30a415bb53d856',
+              name: 'product',
+              terminated: {
+                containerID:
+                  'cri-o://eeeac678d235948941e9a931ee440bc17192fdd5bfcbb14729446fbd8d482d4f',
+                exitCode: 0,
+                finishedAt: '2022-06-29T13:02:33Z',
+                message: '[{"key":"product","value":"1","type":1}]',
+                reason: 'Completed',
+                startedAt: '2022-06-29T13:02:33Z',
+              },
+            },
+          ],
+          taskResults: [
+            {
+              name: 'product',
+              value: '1',
+            },
+          ],
+          taskSpec: {
+            params: [
+              {
+                default: '1',
+                description: 'The first integer',
+                name: 'a',
+                type: 'string',
+              },
+              {
+                default: '1',
+                description: 'The second integer',
+                name: 'b',
+                type: 'string',
+              },
+            ],
+            results: [
+              {
+                description: 'The product of the two provided integers',
+                name: 'product',
+              },
+            ],
+            steps: [
+              {
+                image: 'bash:latest',
+                name: 'product',
+                resources: {},
+              },
+            ],
+          },
+        },
+      },
+      'sum-and-multiply-pipeline-ybpufp-task3': {
+        pipelineTaskName: 'task3',
+        status: {
+          conditions: [
+            {
+              lastTransitionTime: '2022-06-29T13:02:34Z',
+              message:
+                'pod status "Initialized":"False"; message: "containers with incomplete status: [prepare place-scripts]"',
+              reason: 'Pending',
+              status: 'Unknown',
+              type: 'Succeeded',
+            },
+          ],
+          podName: 'sum-and-multiply-pipeline-ybpufp-task3-pod',
+          startTime: '2022-06-29T13:02:34Z',
+          steps: [
+            {
+              container: 'step-sum',
+              name: 'sum',
+              waiting: {
+                reason: 'PodInitializing',
+              },
+            },
+          ],
+          taskSpec: {
+            params: [
+              {
+                default: '1',
+                description: 'The first integer',
+                name: 'a',
+                type: 'string',
+              },
+              {
+                default: '1',
+                description: 'The second integer',
+                name: 'b',
+                type: 'string',
+              },
+            ],
+            results: [
+              {
+                description: 'The sum of the two provided integers',
+                name: 'sum',
+              },
+            ],
+            steps: [
+              {
+                image: 'bash:latest',
+                name: 'sum',
+                resources: {},
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/hacbs/components/topology/__tests__/dag.spec.ts
+++ b/src/hacbs/components/topology/__tests__/dag.spec.ts
@@ -1,0 +1,102 @@
+import { DAG } from '../dag';
+
+describe('dag', () => {
+  describe('addVertex:', () => {
+    it('should add the vertex to the graph', () => {
+      const dag = new DAG();
+
+      dag.addVertex('task1');
+      dag.addVertex('task2');
+
+      expect(dag.names).toHaveLength(2);
+    });
+
+    it('should skip the duplicate vertex added to the graph', () => {
+      const dag = new DAG();
+
+      dag.addVertex('task1');
+      dag.addVertex('task1');
+
+      expect(dag.names).toHaveLength(1);
+    });
+  });
+
+  describe('AddEdge:', () => {
+    it('should add the vertex if it not available in the graph', () => {
+      const dag = new DAG();
+
+      dag.addEdge('task1', 'task2');
+      expect(dag.names).toHaveLength(2);
+    });
+
+    it('should add the edges to the graph', () => {
+      const dag = new DAG();
+
+      dag.addVertex('task1');
+      dag.addVertex('task2');
+
+      dag.addEdge('task1', 'task2');
+      expect(dag.vertices.get('task2').dependancyNames).toContain('task1');
+    });
+
+    it('should skip the duplicate edges added to the graph', () => {
+      const dag = new DAG();
+
+      dag.addVertex('task1');
+      dag.addVertex('task2');
+
+      dag.addEdge('task1', 'task2');
+      dag.addEdge('task1', 'task2');
+      expect(dag.vertices.get('task2').dependancyNames).toContain('task1');
+    });
+  });
+
+  describe('AddEdges', () => {
+    it('should form the dependancies when addEdges is called with multiple before and after tasks', () => {
+      const dag = new DAG();
+
+      dag.addVertex('task1');
+      dag.addVertex('task2');
+      dag.addVertex('task3');
+      dag.addVertex('task4');
+      dag.addVertex('task5');
+
+      const runAfter = ['task1', 'task2'];
+      const runBefore = ['task4', 'task5'];
+
+      dag.addEdges('task3', { id: 'task3' }, runBefore, runAfter);
+
+      expect(dag.printGraph()).toEqual('task1 --> task2 --> task3 --> task4 --> task5');
+    });
+
+    it('should throw an error if there is any cycle detected', () => {
+      const dag = new DAG();
+
+      dag.addVertex('task1');
+      dag.addVertex('task2');
+      dag.addVertex('task3');
+
+      const runAfter = ['task1', 'task2'];
+      const runBefore = ['task1'];
+
+      expect(() => dag.addEdges('task3', { id: 'task3' }, runBefore, runAfter)).toThrow(
+        'cycle detected: task3 --> task1 --> task3',
+      );
+    });
+  });
+
+  it('should print the tasks in topological sort order ', () => {
+    const dag = new DAG();
+
+    dag.addVertex('task1');
+    dag.addVertex('task2');
+    dag.addVertex('task3');
+    dag.addVertex('task4');
+
+    dag.addEdge('task1', 'task2');
+    dag.addEdge('task2', 'task3');
+    dag.addEdge('task3', 'task4');
+
+    expect(dag.printGraph()).toEqual('task1 --> task2 --> task3 --> task4');
+  });
+});

--- a/src/hacbs/components/topology/__tests__/topology-utils.spec.ts
+++ b/src/hacbs/components/topology/__tests__/topology-utils.spec.ts
@@ -1,0 +1,85 @@
+import omit from 'lodash/omit';
+import { testPipeline, testPipelineRun } from '../__data__/pipeline-test-data';
+import {
+  extractDepsFromContextVariables,
+  getPipelineDataModel,
+  getPipelineFromPipelineRun,
+  getPipelineRunDataModel,
+} from '../topology-utils';
+
+describe('topology-utils: ', () => {
+  describe('extractDepsFromContextVariables: ', () => {
+    it('should return emtpy array for invalid values', () => {
+      expect(extractDepsFromContextVariables('')).toEqual([]);
+      expect(extractDepsFromContextVariables(null)).toEqual([]);
+      expect(extractDepsFromContextVariables(undefined)).toEqual([]);
+    });
+
+    it('should return empty array if the context variable string does not contain results', () => {
+      expect(extractDepsFromContextVariables('$(context.pipeline.name)')).toEqual([]);
+      expect(extractDepsFromContextVariables('$(context.pipelinerun.name)')).toEqual([]);
+    });
+
+    it('should return a task name if the context variable string contains results', () => {
+      const contextVariable = '$(tasks.task1.results.sum)';
+      expect(extractDepsFromContextVariables(contextVariable)).toEqual(['task1']);
+    });
+
+    it('should return a list of task names if the context variable string contains multiple results', () => {
+      const contextVariable = '$(tasks.task1.results.sum)  $(tasks.task2.results.sum)';
+
+      expect(extractDepsFromContextVariables(contextVariable)).toEqual(['task1', 'task2']);
+    });
+  });
+
+  describe('getPipelineFromPipelineRun', () => {
+    it('should return null, if pipelinerun does not have a pipelineSpec field in status or spec', () => {
+      const plrWithoutPipelineSpec = omit(testPipelineRun, ['status']);
+      const pipeline = getPipelineFromPipelineRun(plrWithoutPipelineSpec);
+      expect(pipeline).toEqual(null);
+    });
+
+    it('should return null, if pipelinerun does not have pipeline labels or name in the metadata field', () => {
+      const pipeline = getPipelineFromPipelineRun(
+        omit(testPipelineRun, 'metadata.labels', 'metadata.name'),
+      );
+      expect(pipeline).toBe(null);
+    });
+
+    it('should return the pipeline, if pipelinerun has pipelineSpec in status field', () => {
+      const executedPipeline = getPipelineFromPipelineRun(testPipelineRun);
+      expect(executedPipeline).not.toBe(null);
+      expect(executedPipeline.kind).toBe('Pipeline');
+    });
+  });
+
+  describe('getPipelineDataModel:', () => {
+    it('should return null for invalid values ', () => {
+      expect(getPipelineDataModel(null)).toBe(null);
+      expect(getPipelineDataModel(undefined)).toBe(null);
+    });
+
+    it('should return a nodes and edges for a given pipeline ', () => {
+      const { nodes, edges } = getPipelineDataModel(testPipeline);
+      expect(nodes).toHaveLength(6);
+      expect(edges).toHaveLength(6);
+    });
+  });
+
+  describe('getPipelineRunDataModel:', () => {
+    it('should return null for invalid values ', () => {
+      expect(getPipelineRunDataModel(null)).toBe(null);
+      expect(getPipelineRunDataModel(undefined)).toBe(null);
+    });
+
+    it('should return null if the pipelinerun does not contain status ', () => {
+      expect(getPipelineRunDataModel(omit(testPipelineRun, 'status'))).toBe(null);
+    });
+
+    it('should return a nodes and edges for a given pipeline ', () => {
+      const { nodes, edges } = getPipelineRunDataModel(testPipelineRun);
+      expect(nodes).toHaveLength(6);
+      expect(edges).toHaveLength(6);
+    });
+  });
+});

--- a/src/hacbs/components/topology/dag.ts
+++ b/src/hacbs/components/topology/dag.ts
@@ -1,0 +1,147 @@
+interface Vertex {
+  name: string;
+  level: number;
+  dependancy: {};
+  dependancyNames: string[];
+  hasOutgoing: boolean;
+  data: any;
+}
+
+type Vertices = Map<string, Vertex>;
+
+export class DAG {
+  names: string[];
+  vertices: Vertices;
+
+  constructor() {
+    this.names = [];
+    this.vertices = new Map();
+  }
+
+  private visit(
+    vertex: Vertex,
+    fn: (v: Vertex, path: string[]) => void,
+    visited?: any,
+    path?: string[],
+  ) {
+    const name = vertex.name;
+    const vertices = vertex.dependancy;
+    const names = vertex.dependancyNames;
+    const len = names.length;
+
+    if (!visited) {
+      visited = new Map();
+    }
+    if (!path) {
+      path = [];
+    }
+    if (visited.has(name)) {
+      return;
+    }
+    path.push(name);
+    visited.set(name, true);
+    for (let i = 0; i < len; i++) {
+      this.visit(vertices[names[i]], fn, visited, path);
+    }
+    fn(vertex, path);
+    path.pop();
+  }
+
+  private map(name: string, data: any) {
+    const vertex = this.addVertex(name);
+    vertex.data = data;
+  }
+
+  addVertex(name: string) {
+    if (!name) {
+      return null;
+    }
+    if (this.vertices.has(name)) {
+      return this.vertices.get(name);
+    }
+
+    const vertex: Vertex = {
+      name,
+      level: 0,
+      dependancy: {},
+      dependancyNames: [],
+      hasOutgoing: false,
+      data: {},
+    };
+    this.vertices.set(name, vertex);
+    this.names.push(name);
+    return vertex;
+  }
+
+  addEdge(source: string, target: string): void {
+    if (!source || !target || source === target) {
+      return;
+    }
+    const fromNode = this.addVertex(source);
+    const toNode = this.addVertex(target);
+
+    if (toNode.dependancy[source]) {
+      return;
+    }
+
+    const checkCycle = (vertex: Vertex, path: string[]) => {
+      if (vertex.name === target) {
+        throw new Error(`cycle detected: ${path.reverse().join(' --> ')} --> ${target}`);
+      } else {
+        vertex.level = path.length;
+      }
+    };
+    this.visit(fromNode, checkCycle);
+    fromNode.hasOutgoing = true;
+    toNode.dependancy[source] = fromNode;
+    toNode.dependancyNames.push(source);
+  }
+
+  addEdges(name: string, data: any, before: string | string[], after: string | string[]): void {
+    this.map(name, data);
+
+    if (before) {
+      if (typeof before === 'string') {
+        this.addEdge(name, before);
+      } else {
+        for (let i = 0; i < before.length; i++) {
+          this.addEdge(name, before[i]);
+        }
+      }
+    }
+    if (after) {
+      if (typeof after === 'string') {
+        this.addEdge(after, name);
+      } else {
+        for (let i = 0; i < after.length; i++) {
+          this.addEdge(after[i], name);
+        }
+      }
+    }
+  }
+
+  topologicalSort(fn: any): void {
+    const visited = new Map();
+    const vertices = this.vertices;
+    const names = this.names;
+    const len = names.length;
+
+    for (let i = 0; i < len; i++) {
+      const vertex: Vertex = vertices.get(names[i]);
+      if (!vertex.hasOutgoing) {
+        this.visit(vertex, fn, visited);
+      }
+    }
+  }
+
+  printGraph() {
+    const orderedNodes = [];
+    this.topologicalSort((v, t) => {
+      v.data.stage = this.names.length - t.length;
+      orderedNodes.push(v.name);
+    });
+    // eslint-disable-next-line no-console
+    console.log(orderedNodes.join(' --> '));
+    return orderedNodes.join(' --> ');
+  }
+}

--- a/src/hacbs/components/topology/topology-utils.ts
+++ b/src/hacbs/components/topology/topology-utils.ts
@@ -1,0 +1,174 @@
+import find from 'lodash/find';
+import merge from 'lodash/merge';
+import { SucceedConditionReason, runStatus, pipelineRunStatus } from '../../../shared';
+import {
+  PipelineKind,
+  PipelineRunKind,
+  PipelineTask,
+} from '../../../shared/components/pipeline-run-logs/types';
+import { formatPrometheusDuration } from '../../../shared/components/timestamp/datetime';
+import { DAG } from './dag';
+
+export const extractDepsFromContextVariables = (contextVariable: string) => {
+  const regex = /(?:(?:\$\(tasks.))([a-z0-9_-]+)(?:.results+)(?:[.^\w]+\))/g;
+  let matches;
+  const deps = [];
+  while ((matches = regex.exec(contextVariable)) !== null) {
+    // This is necessary to avoid infinite loops with zero-width matches
+    if (matches.index === regex.lastIndex) {
+      regex.lastIndex++;
+    }
+    if (matches) {
+      if (!deps.includes(matches[1])) {
+        deps.push(matches[1]);
+      }
+    }
+  }
+  return deps;
+};
+
+export const getPipelineFromPipelineRun = (pipelineRun: PipelineRunKind): PipelineKind => {
+  const PIPELINE_LABEL = 'tekton.dev/pipeline';
+  const pipelineName =
+    pipelineRun?.metadata?.labels?.[PIPELINE_LABEL] || pipelineRun?.metadata?.name;
+  const pipelineSpec = pipelineRun?.status?.pipelineSpec || pipelineRun?.spec?.pipelineSpec;
+  if (!pipelineName || !pipelineSpec) {
+    return null;
+  }
+  return {
+    apiVersion: pipelineRun.apiVersion,
+    kind: 'Pipeline',
+    metadata: {
+      name: pipelineName,
+      namespace: pipelineRun.metadata.namespace,
+    },
+    spec: pipelineSpec,
+  };
+};
+
+/**
+ * Appends the pipeline run status to each tasks in the pipeline.
+ * @param pipeline
+ * @param pipelineRun
+ * @param isFinallyTasks
+ */
+export const appendStatus = (pipeline, pipelineRun, isFinallyTasks = false) => {
+  const tasks = (isFinallyTasks ? pipeline.spec.finally : pipeline.spec.tasks) || [];
+
+  return tasks.map((task) => {
+    if (!pipelineRun?.status) {
+      return task;
+    }
+    if (!pipelineRun?.status?.taskRuns) {
+      if (pipelineRun.spec.status === SucceedConditionReason.PipelineRunCancelled) {
+        return merge(task, { status: { reason: runStatus.Cancelled } });
+      }
+      if (pipelineRun.spec.status === SucceedConditionReason.PipelineRunPending) {
+        return merge(task, { status: { reason: runStatus.Idle } });
+      }
+      return merge(task, { status: { reason: runStatus.Failed } });
+    }
+    const mTask = merge(task, {
+      status: find(pipelineRun.status.taskRuns, { pipelineTaskName: task.name })?.status,
+    });
+    // append task duration
+    if (mTask.status && mTask.status.completionTime && mTask.status.startTime) {
+      const date =
+        new Date(mTask.status.completionTime).getTime() -
+        new Date(mTask.status.startTime).getTime();
+      mTask.status.duration = formatPrometheusDuration(date);
+    }
+    // append task status
+    if (!mTask.status) {
+      mTask.status = { reason: runStatus.Idle };
+    } else if (mTask.status && mTask.status.conditions) {
+      mTask.status.reason = pipelineRunStatus(mTask) || runStatus.Idle;
+    } else if (mTask.status && !mTask.status.reason) {
+      mTask.status.reason = runStatus.Idle;
+    }
+    return mTask;
+  });
+};
+
+const getGraphDataModel = (pipeline: PipelineKind, pipelineRun?: PipelineRunKind) => {
+  const taskList = appendStatus(pipeline, pipelineRun);
+
+  const dag = new DAG();
+  taskList?.forEach((task: PipelineTask) => {
+    const from = [];
+    if (task.params) {
+      task.params.map((p) => {
+        if (Array.isArray(p.value)) {
+          p.value.forEach((paramValue) => {
+            from.push(...extractDepsFromContextVariables(paramValue));
+          });
+        } else {
+          from.push(...extractDepsFromContextVariables(p.value));
+        }
+      });
+    }
+    if (task?.when) {
+      task.when.map(({ input, values }) => {
+        from.push(...extractDepsFromContextVariables(input));
+        values.forEach((whenValue) => {
+          from.push(...extractDepsFromContextVariables(whenValue));
+        });
+      });
+    }
+    const runAfters = from.length ? [...(task.runAfter || []), ...from] : task.runAfter;
+
+    dag.addEdges(task.name, task, '', runAfters);
+  });
+
+  const nodes = [];
+  dag.topologicalSort((vertex: any) => {
+    const runAfterTasks = [];
+    if (vertex.dependancyNames) {
+      vertex.dependancyNames.forEach((dep) => {
+        const depObj = dag.vertices.get(dep);
+        if (depObj.level - vertex.level <= 1) {
+          runAfterTasks.push(dep);
+        }
+      });
+    }
+    nodes.push({
+      id: vertex.name,
+      label: vertex.name,
+      level: vertex,
+      status: vertex.data?.status?.reason,
+      runAfterTasks,
+      data: {
+        ...vertex.data,
+      },
+    });
+  });
+  // Todo: the edges forming logic should be replaced by pf pipeline framework's edge forming method.
+  const edges = nodes.reduce((acc, node) => {
+    if (node.runAfterTasks) {
+      node.runAfterTasks.forEach((dep) => {
+        acc.push({
+          id: `${dep}-${node.id}`,
+          source: dep,
+          target: node.id,
+        });
+      });
+    }
+    return acc;
+  }, []);
+
+  return { nodes, edges };
+};
+
+export const getPipelineRunDataModel = (pipelineRun: PipelineRunKind) => {
+  if (!pipelineRun?.status?.pipelineSpec) {
+    return null;
+  }
+  return getGraphDataModel(getPipelineFromPipelineRun(pipelineRun), pipelineRun);
+};
+
+export const getPipelineDataModel = (pipeline: PipelineKind) => {
+  if (!pipeline) {
+    return null;
+  }
+  return getGraphDataModel(pipeline);
+};

--- a/src/shared/components/pipeline-run-logs/types/pipeline.ts
+++ b/src/shared/components/pipeline-run-logs/types/pipeline.ts
@@ -50,6 +50,7 @@ export type PipelineTask = {
   taskSpec?: TektonTaskSpec;
   when?: WhenExpression[];
   workspaces?: PipelineTaskWorkspace[];
+  status?: { [key: string]: unknown };
 };
 
 export type PipelineSpec = {

--- a/src/shared/components/pipeline-run-logs/types/pipelineRun.ts
+++ b/src/shared/components/pipeline-run-logs/types/pipelineRun.ts
@@ -1,6 +1,6 @@
 import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 import { TektonResultsRun, TektonTaskSpec } from './coreTekton';
-import { PipelineKind, PipelineSpec } from './pipeline';
+import { PipelineKind, PipelineSpec, WhenExpression } from './pipeline';
 
 export type PLRTaskRunStep = {
   container: string;
@@ -135,6 +135,7 @@ export type PipelineRunStatus = {
   pipelineSpec: PipelineSpec;
   skippedTasks?: {
     name: string;
+    whenExpressions?: WhenExpression[];
   }[];
   pipelineResults?: TektonResultsRun[];
 };


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->



## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Converts the Tekton data into graph data model. This data model will be integrated with the pf pipeline framework.

 Pipeline graph order is determined using:

-  Resource dependencies:
[results](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#emitting-results-from-a-pipeline) of one Task being passed into params or when expressions of another
         

- ordering dependencies:
[runAfter](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#using-the-runafter-field) clauses on the corresponding Tasks



## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Other (please describe):

Contains the utility for converting the tekton model into topology graph model.

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
No UI changes.


<!-- **Test Configuration(s)**: -->
## Tests
```
 PASS  src/hacbs/components/topology/__tests__/topology-utils.spec.ts
  topology-utils: 
    extractDepsFromContextVariables: 
      ✓ should return emtpy array for invalid values (2 ms)
      ✓ should return empty array if the context variable string does not contain results
      ✓ should return a task name if the context variable string contains results (1 ms)
      ✓ should return a list of task names if the context variable string contains multiple results
    getPipelineFromPipelineRun
      ✓ should return null, if pipelinerun does not have a pipelineSpec field in status or spec (1 ms)
      ✓ should return null, if pipelinerun does not have pipeline labels or name in the metadata field (1 ms)
      ✓ should return the pipeline, if pipelinerun has pipelineSpec in status field
    getPipelineDataModel:
      ✓ should return null for invalid values  (1 ms)
      ✓ should return a nodes and edges for a given pipeline  (1 ms)
    getPipelineRunDataModel:
      ✓ should return null for invalid values 
      ✓ should return null if the pipelinerun does not contain status  (1 ms)
      ✓ should return a nodes and edges for a given pipeline  (2 ms)```
```
```
 PASS  src/hacbs/components/topology/__tests__/dag.spec.ts
  dag
    ✓ should print the tasks in topological sort order  (2 ms)
    addVertex:
      ✓ should add the vertex to the graph (1 ms)
      ✓ should skip the duplicate vertex added to the graph (1 ms)
    AddEdge:
      ✓ should add the vertex if it not available in the graph (1 ms)
      ✓ should add the edges to the graph (1 ms)
      ✓ should skip the duplicate edges added to the graph
    AddEdges
      ✓ should form the dependancies when addEdges is called with multiple before and after tasks (26 ms)
      ✓ should throw an error if there is any cycle detected (14 ms)
```
## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
