### PR TITLE
Add Hacbs Application details view layout

### DIFF
--- a/src/hacbs/components/ApplicationDetails/DetailsPage.scss
+++ b/src/hacbs/components/ApplicationDetails/DetailsPage.scss
@@ -1,0 +1,7 @@
+.details {
+  &__tabItem {
+    &.isFilled {
+      height: 100%;
+    }
+  }
+}

--- a/src/hacbs/components/ApplicationDetails/DetailsPage.tsx
+++ b/src/hacbs/components/ApplicationDetails/DetailsPage.tsx
@@ -1,0 +1,158 @@
+import * as React from 'react';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownItemProps,
+  DropdownSeparator,
+  DropdownToggle,
+  Flex,
+  FlexItem,
+  PageGroup,
+  PageSection,
+  PageSectionVariants,
+  Tab,
+  Tabs,
+  TabTitleText,
+  Text,
+  TextContent,
+} from '@patternfly/react-core';
+import { CaretDownIcon } from '@patternfly/react-icons/dist/esm/icons/caret-down-icon';
+import cx from 'classnames';
+import BreadCrumbs from '../../../shared/components/breadcrumbs/BreadCrumbs';
+import { getQueryArgument, removeQueryArguments, setQueryArgument } from '../../../shared/utils';
+
+import './DetailsPage.scss';
+
+type Action = { type?: string; key: string; label: string } & DropdownItemProps;
+type DetailsPageTabProps = {
+  key: string;
+  label: string;
+  component: React.ReactNode;
+  href?: string;
+  isDisabled?: true;
+  className?: string;
+  isFilled?: boolean;
+};
+
+type DetailsPageProps = {
+  title: string;
+  children?: React.ReactNode;
+  footer?: React.ReactNode;
+  description?: React.ReactNode;
+  breadcrumbs?: { name: string; path: string }[];
+  actions?: Action[];
+  tabs: DetailsPageTabProps[];
+  onTabSelect?: (selectedTabKey: string) => void;
+};
+
+const DetailsPage: React.FC<DetailsPageProps> = ({
+  title,
+  footer,
+  description,
+  breadcrumbs,
+  actions = [],
+  tabs = [],
+  onTabSelect,
+}) => {
+  const tabMatched =
+    tabs?.find((t) => t.key === getQueryArgument('activeTab'))?.key || tabs?.[0]?.key;
+  const [activeTab, setActiveTab] = React.useState(tabMatched);
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!tabMatched) {
+      removeQueryArguments('activeTab');
+    } else if (activeTab !== tabMatched) {
+      setActiveTab(tabMatched);
+    }
+  }, [tabMatched, activeTab]);
+
+  const dropdownItems = React.useMemo(
+    () =>
+      actions?.map((action) => {
+        const { type, key, label, ...props } = action;
+        return type === 'seperator' ? (
+          <DropdownSeparator key={key} />
+        ) : (
+          <DropdownItem key={key} {...props}>
+            {label}
+          </DropdownItem>
+        );
+      }),
+    [actions],
+  );
+
+  const tabComponents = tabs?.map(({ key, label, component, isFilled = false, ...rest }) => {
+    return (
+      <Tab
+        data-test={`details__tabItem ${key}`}
+        key={key}
+        eventKey={key}
+        title={<TabTitleText>{label}</TabTitleText>}
+        className={cx('details__tabItem', { isFilled })}
+        {...rest}
+      >
+        {component}
+      </Tab>
+    );
+  });
+
+  return (
+    <PageGroup data-test="details">
+      <PageSection type="breadcrumb">
+        {breadcrumbs && <BreadCrumbs data-test="details__breadcrumbs" breadcrumbs={breadcrumbs} />}
+        <Flex>
+          <FlexItem>
+            <TextContent>
+              <Text component="h1" data-test="details__title">
+                {title}
+              </Text>
+              {description && <Text component="p">{description}</Text>}
+            </TextContent>
+          </FlexItem>
+          {actions?.length && (
+            <FlexItem align={{ default: 'alignRight' }}>
+              <Dropdown
+                data-test="details__actions"
+                position="right"
+                toggle={
+                  <DropdownToggle
+                    onToggle={() => setIsOpen(!isOpen)}
+                    toggleIndicator={CaretDownIcon}
+                    isPrimary
+                  >
+                    Actions
+                  </DropdownToggle>
+                }
+                isOpen={isOpen}
+                dropdownItems={dropdownItems}
+              />
+            </FlexItem>
+          )}
+        </Flex>
+      </PageSection>
+      {tabs?.length && (
+        <PageSection isFilled variant={PageSectionVariants.light}>
+          <Tabs
+            data-test="details__tabs"
+            onSelect={(e, k: string) => {
+              setQueryArgument('activeTab', k);
+              setActiveTab(k);
+              onTabSelect && onTabSelect(k);
+            }}
+            activeKey={activeTab}
+          >
+            {tabComponents}
+          </Tabs>
+        </PageSection>
+      )}
+      {footer && (
+        <PageSection variant={PageSectionVariants.light} isFilled={false} sticky="bottom">
+          {footer}
+        </PageSection>
+      )}
+    </PageGroup>
+  );
+};
+
+export default DetailsPage;

--- a/src/hacbs/components/ApplicationDetails/HacbsApplicationDetails.tsx
+++ b/src/hacbs/components/ApplicationDetails/HacbsApplicationDetails.tsx
@@ -1,0 +1,121 @@
+import * as React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { Bullseye, Spinner } from '@patternfly/react-core';
+import { NamespaceContext } from '../../../components/NamespacedPage/NamespacedPage';
+import { ApplicationGroupVersionKind } from '../../../models';
+import { ApplicationKind } from '../../../types';
+import DetailsPage from './DetailsPage';
+import ApplicationOverviewTab from './tabs/ApplicationOverviewTab';
+import CommitsTab from './tabs/CommitsTab';
+import ComponentsTab from './tabs/ComponentsTab';
+import EnvironmentsTab from './tabs/EnvironmentsTab';
+import PipelineRunsTab from './tabs/PipelineRunsTab';
+
+type HacbsApplicationDetailsProps = {
+  applicationName: string;
+};
+
+const HacbsApplicationDetails: React.FC<HacbsApplicationDetailsProps> = ({ applicationName }) => {
+  const { namespace } = React.useContext(NamespaceContext);
+  const navigate = useNavigate();
+  const [application, applicationsLoaded] = useK8sWatchResource<ApplicationKind>({
+    groupVersionKind: ApplicationGroupVersionKind,
+    name: applicationName,
+    namespace,
+  });
+  const appDisplayName = application?.spec?.displayName || '';
+
+  const loading = (
+    <Bullseye>
+      <Spinner data-test="spinner" />
+    </Bullseye>
+  );
+
+  if (!applicationsLoaded) {
+    return loading;
+  }
+
+  return (
+    <React.Fragment>
+      <DetailsPage
+        breadcrumbs={[
+          { path: '/app-studio/applications', name: 'Applications' },
+          {
+            path: `/app-studio/applications/:${applicationName}`,
+            name: appDisplayName,
+          },
+        ]}
+        title={appDisplayName}
+        actions={[
+          {
+            key: 'add-component',
+            label: 'Add Component',
+            onClick: () => {
+              navigate(`/app-studio/import?application=${applicationName}`);
+            },
+          },
+          {
+            key: 'add-environment',
+            label: 'Add Environement',
+            href: '',
+            isDisabled: true,
+          },
+          {
+            key: 'add-integration-tests',
+            label: 'Add Integration test',
+            href: '',
+            isDisabled: true,
+          },
+          {
+            key: 'delete-application',
+            label: 'Delete Application',
+            href: '',
+            isDisabled: true,
+          },
+          {
+            type: 'seperator',
+            key: 'seperator',
+            label: '',
+          },
+          {
+            key: 'learning-resources',
+            label: 'Learning Resources',
+            href: '',
+            isDisabled: true,
+          },
+        ]}
+        tabs={[
+          {
+            key: 'overview',
+            label: 'Overview',
+            component: <ApplicationOverviewTab applicationName={applicationName} />,
+          },
+          {
+            key: 'components',
+            label: 'Components',
+            isFilled: true,
+            component: <ComponentsTab applicationName={applicationName} namespace={namespace} />,
+          },
+          {
+            key: 'commits',
+            label: 'Commits',
+            component: <CommitsTab applicationName={applicationName} />,
+          },
+          {
+            key: 'pipelineruns',
+            label: 'Pipelineruns',
+            component: <PipelineRunsTab applicationName={applicationName} />,
+          },
+          {
+            key: 'environments',
+            label: 'Environments',
+            component: <EnvironmentsTab applicationName={applicationName} />,
+          },
+        ]}
+      />
+    </React.Fragment>
+  );
+};
+
+export default HacbsApplicationDetails;

--- a/src/hacbs/components/ApplicationDetails/__tests__/DetailsPage.spec.tsx
+++ b/src/hacbs/components/ApplicationDetails/__tests__/DetailsPage.spec.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { act, configure, fireEvent, render, screen } from '@testing-library/react';
+import DetailsPage from '../DetailsPage';
+
+configure({ testIdAttribute: 'data-test' });
+
+describe('DetailsPage', () => {
+  it('should render the DetailsPage', () => {
+    const { getByTestId } = render(<DetailsPage title="Details" tabs={[]} />);
+    expect(getByTestId('details')).toBeInTheDocument();
+  });
+
+  it('should render the DetailsPage', () => {
+    const { getByTestId } = render(<DetailsPage title="Details" tabs={[]} />);
+    expect(getByTestId('details')).toBeInTheDocument();
+  });
+
+  it('should not render the tabs if invalid values are passed', () => {
+    render(<DetailsPage title="Details" tabs={null} />);
+    expect(screen.queryByTestId('details__tabs')).not.toBeInTheDocument();
+  });
+
+  it('should render the tabs', () => {
+    const { getByTestId } = render(
+      <DetailsPage
+        title="Details"
+        tabs={[{ key: 'tab1', label: 'Tab 1', component: <div>Tab1 content</div> }]}
+      />,
+    );
+    expect(getByTestId('details__tabs')).toBeInTheDocument();
+  });
+
+  it('should render the tabs', async () => {
+    const onTabSelect = jest.fn();
+    render(
+      <DetailsPage
+        onTabSelect={onTabSelect}
+        title="Details"
+        tabs={[
+          { key: 'tab1', label: 'Tab 1', component: <div>Tab1 content</div> },
+          { key: 'tab2', label: 'Tab 1', component: <div>Tab1 content</div> },
+        ]}
+      />,
+    );
+
+    const tab2 = screen.queryByTestId('details__tabItem tab2');
+
+    await act(async () => {
+      fireEvent.click(tab2);
+    });
+    expect(onTabSelect).toHaveBeenCalledWith('tab2');
+  });
+
+  it('should not render the actions if it is not passed', () => {
+    render(<DetailsPage title="Details" tabs={[]} />);
+    expect(screen.queryByTestId('details__actions')).not.toBeInTheDocument();
+  });
+
+  it('should not render actions invalid values are passed to actions', () => {
+    render(<DetailsPage title="Details" tabs={[]} actions={null} />);
+    expect(screen.queryByTestId('details__actions')).not.toBeInTheDocument();
+  });
+});

--- a/src/hacbs/components/ApplicationDetails/__tests__/HacbsApplicationDetails.spec.tsx
+++ b/src/hacbs/components/ApplicationDetails/__tests__/HacbsApplicationDetails.spec.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { render, screen, configure } from '@testing-library/react';
+import { mockApplication } from '../../../../components/ApplicationDetailsView/__data__/mock-data';
+import HacbApplicationDetails from '../HacbsApplicationDetails';
+
+jest.mock('react-router-dom', () => ({
+  Link: (props) => <a href={props.to}>{props.children}</a>,
+  useNavigate: () => jest.fn(),
+}));
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  useK8sWatchResource: jest.fn(),
+}));
+
+configure({ testIdAttribute: 'data-test' });
+
+const watchResourceMock = useK8sWatchResource as jest.Mock;
+
+describe('HacbApplicationDetails', () => {
+  it('should render spinner if application data is not loaded', () => {
+    watchResourceMock.mockReturnValue([[], false]);
+    render(<HacbApplicationDetails applicationName="test" />);
+    expect(screen.queryByTestId('spinner')).toBeInTheDocument();
+  });
+
+  it('should render application display name if application data is loaded', () => {
+    watchResourceMock.mockReturnValueOnce([mockApplication, true]);
+    render(<HacbApplicationDetails applicationName="test" />);
+    expect(screen.queryByTestId('details__title')).toBeInTheDocument();
+    expect(screen.queryByTestId('details__title').innerHTML).toBe('Test Application');
+  });
+});

--- a/src/hacbs/components/ApplicationDetails/tabs/ApplicationOverviewTab.tsx
+++ b/src/hacbs/components/ApplicationDetails/tabs/ApplicationOverviewTab.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import {
+  EmptyState,
+  EmptyStateIcon,
+  Title,
+  EmptyStateBody,
+  Button,
+  EmptyStateVariant,
+  EmptyStateSecondaryActions,
+} from '@patternfly/react-core';
+import { OutlinedFileImageIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-file-image-icon';
+
+type ApplicationOverviewTabProps = {
+  applicationName: string;
+};
+
+const ApplicationOverviewTab: React.FC<ApplicationOverviewTabProps> = ({ applicationName }) => {
+  return (
+    <EmptyState variant={EmptyStateVariant.large}>
+      <EmptyStateIcon icon={OutlinedFileImageIcon} />
+      <Title headingLevel="h4" size="lg">
+        Monitor your commits and their pipeline progression across all components
+      </Title>
+      <EmptyStateBody>
+        To get started, create components and merge their pull request for build pipeline.
+      </EmptyStateBody>
+      <EmptyStateSecondaryActions>
+        <Button
+          component={(props) => (
+            <Link
+              {...props}
+              to={`/app-studio/applications?name=${applicationName}&activeTab=components&hacbs=true`}
+            />
+          )}
+          variant="secondary"
+        >
+          Go to components tab
+        </Button>
+      </EmptyStateSecondaryActions>
+    </EmptyState>
+  );
+};
+
+export default ApplicationOverviewTab;

--- a/src/hacbs/components/ApplicationDetails/tabs/CommitsTab.tsx
+++ b/src/hacbs/components/ApplicationDetails/tabs/CommitsTab.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import {
+  EmptyState,
+  EmptyStateIcon,
+  Title,
+  EmptyStateBody,
+  Button,
+  EmptyStateSecondaryActions,
+} from '@patternfly/react-core';
+import { OutlinedFileImageIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-file-image-icon';
+
+type CommitTabProps = {
+  applicationName: string;
+};
+
+const CommitsTab: React.FC<CommitTabProps> = ({ applicationName }) => {
+  return (
+    <EmptyState>
+      <EmptyStateIcon icon={OutlinedFileImageIcon} />
+      <Title headingLevel="h4" size="lg">
+        Monitor your commits and their pipeline progression across all components
+      </Title>
+      <EmptyStateBody>
+        No commits found yet. <br />
+        To get started, create components and merge their pull request for build pipeline.
+      </EmptyStateBody>
+      <EmptyStateSecondaryActions>
+        <Button
+          component={(props) => (
+            <Link
+              {...props}
+              to={`/app-studio/applications?name=${applicationName}&activeTab=components&hacbs=true`}
+            />
+          )}
+          variant="secondary"
+        >
+          Go to components tab
+        </Button>
+      </EmptyStateSecondaryActions>
+    </EmptyState>
+  );
+};
+
+export default CommitsTab;

--- a/src/hacbs/components/ApplicationDetails/tabs/ComponentsTab.tsx
+++ b/src/hacbs/components/ApplicationDetails/tabs/ComponentsTab.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import {
+  EmptyState,
+  EmptyStateIcon,
+  Title,
+  EmptyStateBody,
+  Button,
+  Bullseye,
+  Spinner,
+  EmptyStateVariant,
+} from '@patternfly/react-core';
+import { OutlinedFileImageIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-file-image-icon';
+import ComponentListView from '../../../../components/ApplicationDetailsView/ComponentListView';
+import { ComponentGroupVersionKind } from '../../../../models';
+import { ComponentKind } from '../../../../types';
+
+type ComponentTabProps = {
+  applicationName: string;
+  namespace: string;
+};
+
+const ComponentsTab: React.FC<ComponentTabProps> = ({ applicationName, namespace }) => {
+  const [components, componentsLoaded] = useK8sWatchResource<ComponentKind[]>({
+    groupVersionKind: ComponentGroupVersionKind,
+    namespace,
+    isList: true,
+  });
+
+  const filteredComponents = React.useMemo(
+    () =>
+      componentsLoaded ? components?.filter((c) => c.spec.application === applicationName) : [],
+    [components, applicationName, componentsLoaded],
+  );
+
+  const componentList = (
+    <ComponentListView applicationName={applicationName} components={filteredComponents} />
+  );
+  const loading = (
+    <Bullseye>
+      <Spinner />
+    </Bullseye>
+  );
+
+  const emptyState = (
+    <EmptyState variant={EmptyStateVariant.large}>
+      <EmptyStateIcon icon={OutlinedFileImageIcon} />
+      <Title headingLevel="h4" size="lg">
+        No components
+      </Title>
+      <EmptyStateBody>To get started, add a component to your application.</EmptyStateBody>
+      <Button
+        variant="primary"
+        component={(props) => (
+          <Link {...props} to={`/app-studio/import?application=${applicationName}`} />
+        )}
+      >
+        Add component
+      </Button>
+    </EmptyState>
+  );
+
+  return !componentsLoaded ? loading : filteredComponents.length > 0 ? componentList : emptyState;
+};
+
+export default ComponentsTab;

--- a/src/hacbs/components/ApplicationDetails/tabs/EnvironmentsTab.tsx
+++ b/src/hacbs/components/ApplicationDetails/tabs/EnvironmentsTab.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import {
+  EmptyState,
+  EmptyStateIcon,
+  Title,
+  EmptyStateBody,
+  Button,
+  EmptyStateSecondaryActions,
+} from '@patternfly/react-core';
+import { OutlinedFileImageIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-file-image-icon';
+
+type EnvironmentTabProps = {
+  applicationName: string;
+};
+
+const EnvironmentTab: React.FC<EnvironmentTabProps> = ({ applicationName }) => {
+  return (
+    <EmptyState>
+      <EmptyStateIcon icon={OutlinedFileImageIcon} />
+      <Title headingLevel="h4" size="lg">
+        Add static environments or link to external, managed environments as your release
+        destination
+      </Title>
+      <EmptyStateBody>
+        No environments found yet.
+        <br />
+        To get Started, create an environment or connect to a release environment.
+      </EmptyStateBody>
+      <EmptyStateSecondaryActions>
+        <Button
+          component={(props) => (
+            <Link
+              {...props}
+              to={`/app-studio/applications?name=${applicationName}&activeTab=components&hacbs=true`}
+            />
+          )}
+          variant="secondary"
+        >
+          Go to components tab
+        </Button>
+      </EmptyStateSecondaryActions>
+    </EmptyState>
+  );
+};
+
+export default EnvironmentTab;

--- a/src/hacbs/components/ApplicationDetails/tabs/PipelineRunsTab.tsx
+++ b/src/hacbs/components/ApplicationDetails/tabs/PipelineRunsTab.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import {
+  EmptyState,
+  EmptyStateIcon,
+  Title,
+  EmptyStateBody,
+  Button,
+  EmptyStateSecondaryActions,
+} from '@patternfly/react-core';
+import { OutlinedFileImageIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-file-image-icon';
+
+type PipelineRunsTabProps = {
+  applicationName: string;
+};
+
+const PipelineRunsTab: React.FC<PipelineRunsTabProps> = ({ applicationName }) => {
+  return (
+    <EmptyState>
+      <EmptyStateIcon icon={OutlinedFileImageIcon} />
+      <Title headingLevel="h4" size="lg">
+        Manage your components via pipelines. Monitor CI/CD activity.
+      </Title>
+      <EmptyStateBody>
+        No pipeline run triggered yet.
+        <br />
+        To get Started, create components and merge their pull request for build pipeline.
+      </EmptyStateBody>
+      <EmptyStateSecondaryActions>
+        <Button
+          component={(props) => (
+            <Link
+              {...props}
+              to={`/app-studio/applications?name=${applicationName}&activeTab=components&hacbs=true`}
+            />
+          )}
+          variant="secondary"
+        >
+          Go to components tab
+        </Button>
+      </EmptyStateSecondaryActions>
+    </EmptyState>
+  );
+};
+
+export default PipelineRunsTab;

--- a/src/pages/ApplicationsPage.tsx
+++ b/src/pages/ApplicationsPage.tsx
@@ -5,12 +5,14 @@ import ApplicationDetailsView from '../components/ApplicationDetailsView/Applica
 import ApplicationListView from '../components/ApplicationListView/ApplicationListView';
 import NamespacedPage from '../components/NamespacedPage/NamespacedPage';
 import PageLayout from '../components/PageLayout/PageLayout';
+import HacbsApplicationDetails from '../hacbs/components/ApplicationDetails/HacbsApplicationDetails';
 import { useQuickstartCloseOnUnmount } from '../hooks/useQuickstartCloseOnUnmount';
 import { getQueryArgument } from '../shared/utils';
 
 const ApplicationsPage = () => {
   useQuickstartCloseOnUnmount();
   const applicationName = getQueryArgument('name');
+  const hacbs = JSON.parse(getQueryArgument('hacbs'));
 
   return (
     <NamespacedPage>
@@ -19,7 +21,11 @@ const ApplicationsPage = () => {
           <Helmet>
             <title>Application Details Page</title>
           </Helmet>
-          <ApplicationDetailsView applicationName={applicationName} />
+          {hacbs ? (
+            <HacbsApplicationDetails applicationName={applicationName} />
+          ) : (
+            <ApplicationDetailsView applicationName={applicationName} />
+          )}
         </React.Fragment>
       ) : (
         <React.Fragment>


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/HACBS-699


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

PR contains the application details view page layout
- Tabs with empty state
- Actions
- Components tab contains the component list as app studio

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/9964343/177197602-b61b4b5f-8b9d-4682-8af7-e2e948a1def2.png">


<img width="1789" alt="image" src="https://user-images.githubusercontent.com/9964343/177198293-c91446e6-22c5-490d-9d6d-28292f07f193.png">


## Tests

```
 PASS  src/hacbs/components/ApplicationDetails/__tests__/DetailsPage.spec.tsx
  DetailsPage
    ✓ should render the DetailsPage (23 ms)
    ✓ should render the DetailsPage (5 ms)
    ✓ should not render the tabs if invalid values are passed (3 ms)
    ✓ should render the tabs (15 ms)
    ✓ should render the tabs (30 ms)
    ✓ should not render the actions if it is not passed (4 ms)
    ✓ should not render actions invalid values are passed to actions (5 ms)
```

```
 PASS  src/hacbs/components/ApplicationDetails/__tests__/HacbsApplicationDetails.spec.tsx
  HacbApplicationDetails
    ✓ should render spinner if application data is not loaded (21 ms)
    ✓ should render application display name if application data is loaded (47 ms)
```

## How to test?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

* Visit Application details page
*  add `&hacbs=true` query param in the url to see the hacbs application details view


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge



cc: @mfrances17 