### PR TITLE
add route /hacbs to enables the hacbs feature flag

### DIFF
--- a/config/remotePlugin.js
+++ b/config/remotePlugin.js
@@ -9,6 +9,7 @@ module.exports = {
       Applications: resolve(__dirname, '../src/pages/ApplicationsPage'),
       Import: resolve(__dirname, '../src/pages/ImportPage'),
       ComponentSettings: resolve(__dirname, '../src/pages/ComponentSettingsPage'),
+      HACBSFlag: resolve(__dirname, '../src/hacbs/hacbsFeatureFlag'),
     },
   },
   extensions: [
@@ -89,6 +90,16 @@ module.exports = {
         exact: true,
         component: {
           $codeRef: 'ComponentSettings',
+        },
+      },
+    },
+    {
+      type: 'core.page/route',
+      properties: {
+        path: '/hacbs',
+        exact: true,
+        component: {
+          $codeRef: 'HACBSFlag.EnableHACBSFlagRoute',
         },
       },
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.9.0",
-        "@openshift/dynamic-plugin-sdk": "^1.0.0-alpha2",
+        "@openshift/dynamic-plugin-sdk": "1.0.0-alpha10",
         "@openshift/dynamic-plugin-sdk-utils": "^1.0.0-alpha4",
         "@patternfly/quickstarts": "^2.2.1",
         "@patternfly/react-catalog-view-extension": "4.13.18",
@@ -41,7 +41,7 @@
         "yup": "^0.32.11"
       },
       "devDependencies": {
-        "@openshift/dynamic-plugin-sdk-webpack": "^1.0.0-alpha2",
+        "@openshift/dynamic-plugin-sdk-webpack": "1.0.0-alpha3",
         "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^1.2.1",
         "@redhat-cloud-services/frontend-components-config": "^4.6.14",
         "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.15",
@@ -1531,16 +1531,25 @@
       }
     },
     "node_modules/@openshift/dynamic-plugin-sdk": {
-      "version": "1.0.0-alpha2",
-      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-1.0.0-alpha2.tgz",
-      "integrity": "sha512-pNXqHSGkYf7IQgmN4IBEzRcYONz8H4kncnd32oNN5FbsyUrtVB4dUxSorVwZnGr+80Sc5xfoGpj7/jlybKnfLg==",
+      "version": "1.0.0-alpha10",
+      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-1.0.0-alpha10.tgz",
+      "integrity": "sha512-sQ1l9dcvFd8duZoXbQZT8eKQzHTU8/7mMCwoj+TuweyZv4de4rX1/KXa38Fb5lG66eQBHNSDJZYNTZA9oK+GWw==",
       "dependencies": {
         "lodash-es": "^4.17.21",
         "yup": "^0.32.11"
       },
       "peerDependencies": {
         "react": "^17.0.2",
+        "react-router": "^5.2.1",
         "redux": "^4.1.2"
+      },
+      "peerDependenciesMeta": {
+        "react-router": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/@openshift/dynamic-plugin-sdk-utils": {
@@ -1563,20 +1572,19 @@
       }
     },
     "node_modules/@openshift/dynamic-plugin-sdk-webpack": {
-      "version": "1.0.0-alpha2",
-      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk-webpack/-/dynamic-plugin-sdk-webpack-1.0.0-alpha2.tgz",
-      "integrity": "sha512-jg/Tk9K4DY+sDKgte5H+kAK62TzBAun9ZeBVzRPxC9CVNmO1OPR/i2vMXHEBKxmNJxDstVb9FqFS+vEGDcNheQ==",
+      "version": "1.0.0-alpha3",
+      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk-webpack/-/dynamic-plugin-sdk-webpack-1.0.0-alpha3.tgz",
+      "integrity": "sha512-IFFvQFZDbC6C0XUBgYcP++jFDJMs4J3JVx/Bm/vs7tTT2K1dMUGVDHVrgEvKuVFUfuSX/najlECIk/RgCFSL9A==",
       "dev": true,
       "dependencies": {
         "glob": "^7.2.0",
-        "lodash-es": "^4.17.21",
+        "lodash": "^4.17.21",
         "yup": "^0.32.11"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "@openshift/dynamic-plugin-sdk": "^1.0.0",
         "webpack": "^5.69.1"
       }
     },
@@ -2799,6 +2807,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
       "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "optional": true,
       "dependencies": {
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
@@ -2910,7 +2919,7 @@
       "version": "16.11.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.5.tgz",
       "integrity": "sha512-NyUV2DGcqYIx9op++MG2+Z4Nhw1tPhi0Wfs81TgncuX1aJC4zf2fgCJlJhl4BW9bCSS04e34VkqmOS96w0XQdg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -2933,7 +2942,8 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
+      "devOptional": true
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -2951,6 +2961,7 @@
       "version": "17.0.32",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.32.tgz",
       "integrity": "sha512-hAm1pmwA3oZWbkB985RFwNvBRMG0F3KWSiC4/hNmanigKZMiKQoH5Q6etNw8HIDztTGfvXyOjPvdNnvBUCuaPg==",
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -2979,6 +2990,7 @@
       "version": "7.1.20",
       "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.20.tgz",
       "integrity": "sha512-q42es4c8iIeTgcnB+yJgRTTzftv3eYYvCZOh1Ckn2eX/3o5TdsQYKUWpLoLuGlcY/p+VAhV9IOEZJcWk/vfkXw==",
+      "optional": true,
       "dependencies": {
         "@types/hoist-non-react-statics": "^3.3.0",
         "@types/react": "*",
@@ -3035,7 +3047,8 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "devOptional": true
     },
     "node_modules/@types/serve-index": {
       "version": "1.9.1",
@@ -15019,6 +15032,7 @@
       "version": "7.2.4",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.4.tgz",
       "integrity": "sha512-hOQ5eOSkEJEXdpIKbnRyl04LhaWabkDPV+Ix97wqQX3T3d2NQ8DUblNXXtNMavc7DpswyQM6xfaN4HQDKNY2JA==",
+      "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.12.1",
         "@types/react-redux": "^7.1.16",
@@ -15042,7 +15056,8 @@
     "node_modules/react-redux/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "optional": true
     },
     "node_modules/react-router": {
       "version": "6.3.0",
@@ -20072,9 +20087,9 @@
       }
     },
     "@openshift/dynamic-plugin-sdk": {
-      "version": "1.0.0-alpha2",
-      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-1.0.0-alpha2.tgz",
-      "integrity": "sha512-pNXqHSGkYf7IQgmN4IBEzRcYONz8H4kncnd32oNN5FbsyUrtVB4dUxSorVwZnGr+80Sc5xfoGpj7/jlybKnfLg==",
+      "version": "1.0.0-alpha10",
+      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-1.0.0-alpha10.tgz",
+      "integrity": "sha512-sQ1l9dcvFd8duZoXbQZT8eKQzHTU8/7mMCwoj+TuweyZv4de4rX1/KXa38Fb5lG66eQBHNSDJZYNTZA9oK+GWw==",
       "requires": {
         "lodash-es": "^4.17.21",
         "yup": "^0.32.11"
@@ -20092,13 +20107,13 @@
       }
     },
     "@openshift/dynamic-plugin-sdk-webpack": {
-      "version": "1.0.0-alpha2",
-      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk-webpack/-/dynamic-plugin-sdk-webpack-1.0.0-alpha2.tgz",
-      "integrity": "sha512-jg/Tk9K4DY+sDKgte5H+kAK62TzBAun9ZeBVzRPxC9CVNmO1OPR/i2vMXHEBKxmNJxDstVb9FqFS+vEGDcNheQ==",
+      "version": "1.0.0-alpha3",
+      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk-webpack/-/dynamic-plugin-sdk-webpack-1.0.0-alpha3.tgz",
+      "integrity": "sha512-IFFvQFZDbC6C0XUBgYcP++jFDJMs4J3JVx/Bm/vs7tTT2K1dMUGVDHVrgEvKuVFUfuSX/najlECIk/RgCFSL9A==",
       "dev": true,
       "requires": {
         "glob": "^7.2.0",
-        "lodash-es": "^4.17.21",
+        "lodash": "^4.17.21",
         "yup": "^0.32.11"
       }
     },
@@ -20368,8 +20383,7 @@
     "@patternfly/react-icons": {
       "version": "4.53.16",
       "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.53.16.tgz",
-      "integrity": "sha512-QQOZwl9MR71uNaKUPKJUm2qjvol28evN7GgyiqGn7fr0p4FnPopm9F5GsnKMsE/764/HGwGLjYHulUo3Eb06dQ==",
-      "requires": {}
+      "integrity": "sha512-QQOZwl9MR71uNaKUPKJUm2qjvol28evN7GgyiqGn7fr0p4FnPopm9F5GsnKMsE/764/HGwGLjYHulUo3Eb06dQ=="
     },
     "@patternfly/react-styles": {
       "version": "4.52.16",
@@ -20883,8 +20897,7 @@
       "version": "14.1.1",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.1.1.tgz",
       "integrity": "sha512-XrjH/iEUqNl9lF2HX9YhPNV7Amntkcnpw0Bo1KkRzowNDcgSN9i0nm4Q8Oi5wupgdfPaJNMAWa61A+voD6Kmwg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@tootallnate/once": {
       "version": "1.1.2",
@@ -21079,6 +21092,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
       "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "optional": true,
       "requires": {
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
@@ -21190,7 +21204,7 @@
       "version": "16.11.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.5.tgz",
       "integrity": "sha512-NyUV2DGcqYIx9op++MG2+Z4Nhw1tPhi0Wfs81TgncuX1aJC4zf2fgCJlJhl4BW9bCSS04e34VkqmOS96w0XQdg==",
-      "devOptional": true
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -21213,7 +21227,8 @@
     "@types/prop-types": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
+      "devOptional": true
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -21231,6 +21246,7 @@
       "version": "17.0.32",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.32.tgz",
       "integrity": "sha512-hAm1pmwA3oZWbkB985RFwNvBRMG0F3KWSiC4/hNmanigKZMiKQoH5Q6etNw8HIDztTGfvXyOjPvdNnvBUCuaPg==",
+      "devOptional": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -21259,6 +21275,7 @@
       "version": "7.1.20",
       "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.20.tgz",
       "integrity": "sha512-q42es4c8iIeTgcnB+yJgRTTzftv3eYYvCZOh1Ckn2eX/3o5TdsQYKUWpLoLuGlcY/p+VAhV9IOEZJcWk/vfkXw==",
+      "optional": true,
       "requires": {
         "@types/hoist-non-react-statics": "^3.3.0",
         "@types/react": "*",
@@ -21315,7 +21332,8 @@
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "devOptional": true
     },
     "@types/serve-index": {
       "version": "1.9.1",
@@ -21794,8 +21812,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
       "integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/info": {
       "version": "1.4.0",
@@ -21810,8 +21827,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
       "integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@wojtekmaj/enzyme-adapter-react-17": {
       "version": "0.6.5",
@@ -21890,8 +21906,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -21963,8 +21978,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-colors": {
       "version": "4.1.1",
@@ -24418,8 +24432,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
       "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -24660,8 +24673,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
       "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-rulesdir": {
       "version": "0.1.0",
@@ -25920,8 +25932,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "identity-obj-proxy": {
       "version": "3.0.0",
@@ -27276,8 +27287,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "27.0.6",
@@ -29860,8 +29870,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -30012,8 +30021,7 @@
       "version": "0.36.2",
       "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
       "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-value-parser": {
       "version": "4.1.0",
@@ -30295,8 +30303,7 @@
     "react-content-loader": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/react-content-loader/-/react-content-loader-6.0.3.tgz",
-      "integrity": "sha512-CIRgTHze+ls+jGDIfCitw27YkW2XcaMpsYORTUdBxsMFiKuUYMnlvY76dZE4Lsaa9vFXVw+41ieBEK7SJt0nug==",
-      "requires": {}
+      "integrity": "sha512-CIRgTHze+ls+jGDIfCitw27YkW2XcaMpsYORTUdBxsMFiKuUYMnlvY76dZE4Lsaa9vFXVw+41ieBEK7SJt0nug=="
     },
     "react-dnd": {
       "version": "14.0.4",
@@ -30388,6 +30395,7 @@
       "version": "7.2.4",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.4.tgz",
       "integrity": "sha512-hOQ5eOSkEJEXdpIKbnRyl04LhaWabkDPV+Ix97wqQX3T3d2NQ8DUblNXXtNMavc7DpswyQM6xfaN4HQDKNY2JA==",
+      "optional": true,
       "requires": {
         "@babel/runtime": "^7.12.1",
         "@types/react-redux": "^7.1.16",
@@ -30400,7 +30408,8 @@
         "react-is": {
           "version": "16.13.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "optional": true
         }
       }
     },
@@ -30434,8 +30443,7 @@
     "react-side-effect": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
-      "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
-      "requires": {}
+      "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ=="
     },
     "react-test-renderer": {
       "version": "17.0.2",
@@ -30574,14 +30582,12 @@
     "redux-promise-middleware": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/redux-promise-middleware/-/redux-promise-middleware-6.1.2.tgz",
-      "integrity": "sha512-ZqZu/nnSzGgwTtNbGoGVontpk7LjTOv0kigtt3CcgXI9gpq+8WlfXTXRZD0WTD5yaohRq0q2nYmJXSTjwXs83Q==",
-      "requires": {}
+      "integrity": "sha512-ZqZu/nnSzGgwTtNbGoGVontpk7LjTOv0kigtt3CcgXI9gpq+8WlfXTXRZD0WTD5yaohRq0q2nYmJXSTjwXs83Q=="
     },
     "redux-thunk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
-      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
-      "requires": {}
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q=="
     },
     "regenerator-runtime": {
       "version": "0.13.9",
@@ -31792,8 +31798,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-3.0.0.tgz",
       "integrity": "sha512-F6yTRuc06xr1h5Qw/ykb2LuFynJ2IxkKfCMf+1xqPffkxh0S09Zc902XCffcsw/XMFq/OzQ1w54fLIDtmRNHnQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "stylelint-config-recommended-scss": {
       "version": "4.2.0",
@@ -32744,8 +32749,7 @@
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
           "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "enhanced-resolve": {
           "version": "5.8.3",
@@ -33039,8 +33043,7 @@
           "version": "8.8.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
           "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -33284,8 +33287,7 @@
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
       "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.9.0",
-    "@openshift/dynamic-plugin-sdk": "^1.0.0-alpha2",
+    "@openshift/dynamic-plugin-sdk": "1.0.0-alpha10",
     "@openshift/dynamic-plugin-sdk-utils": "^1.0.0-alpha4",
     "@patternfly/quickstarts": "^2.2.1",
     "@patternfly/react-catalog-view-extension": "4.13.18",
@@ -58,7 +58,7 @@
     "yup": "^0.32.11"
   },
   "devDependencies": {
-    "@openshift/dynamic-plugin-sdk-webpack": "^1.0.0-alpha2",
+    "@openshift/dynamic-plugin-sdk-webpack": "1.0.0-alpha3",
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^1.2.1",
     "@redhat-cloud-services/frontend-components-config": "^4.6.14",
     "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.15",

--- a/src/hacbs/__tests__/hacbsFeatureFlag.spec.tsx
+++ b/src/hacbs/__tests__/hacbsFeatureFlag.spec.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useFeatureFlag } from '@openshift/dynamic-plugin-sdk';
+import { render } from '@testing-library/react';
+import { HACBS_FLAG, EnableHACBSFlagRoute } from '../hacbsFeatureFlag';
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: jest.fn(),
+}));
+
+jest.mock('@openshift/dynamic-plugin-sdk', () => ({
+  useFeatureFlag: jest.fn(),
+}));
+
+const useNavigateMock = useNavigate as jest.Mock;
+const useFeatureFlagMock = useFeatureFlag as jest.Mock;
+
+describe('hacbsFeatureFlag', () => {
+  it('should set hacbs flag and navigate to app studio', () => {
+    const setFlagMock = jest.fn();
+    useFeatureFlagMock.mockReturnValue([false, setFlagMock]);
+    const navigateMock = jest.fn();
+    useNavigateMock.mockReturnValue(navigateMock);
+
+    render(<EnableHACBSFlagRoute />);
+
+    expect(useFeatureFlag).toHaveBeenCalledWith(HACBS_FLAG);
+    expect(setFlagMock).toHaveBeenCalledWith(true);
+    expect(navigateMock).toHaveBeenCalledWith('/app-studio', { replace: true });
+  });
+});

--- a/src/hacbs/hacbsFeatureFlag.ts
+++ b/src/hacbs/hacbsFeatureFlag.ts
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useFeatureFlag } from '@openshift/dynamic-plugin-sdk';
+
+export const HACBS_FLAG = 'HACBS';
+
+export const EnableHACBSFlagRoute: React.FC = () => {
+  const navigate = useNavigate();
+  const [, setFlag] = useFeatureFlag(HACBS_FLAG);
+  React.useEffect(() => {
+    setFlag(true);
+    /* eslint-disable-next-line no-console */
+    console.log('HACBS Flag enabled');
+    navigate('/app-studio', { replace: true });
+    // No deps because setting the flag only needs to run once.
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, []);
+  return null;
+};


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HACBS-796

## Description
Adding a new route `.../hac/hacbs` which can be first loaded to enable the hacbs feature flag until full model feature flag support is present.

This will help demo hacbs UI in the short term.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
No change to UI.

## How to test or reproduce?
go to `.../hac/hacbs` and the page should redirect to `.../hac/app-studio` as well as log to the console `HACBS Flag enabled`


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
