### PR TITLE
Use hac build service feature flags to gate app details view

### DIFF
--- a/src/pages/ApplicationsPage.tsx
+++ b/src/pages/ApplicationsPage.tsx
@@ -1,18 +1,20 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
+import { useFeatureFlag } from '@openshift/dynamic-plugin-sdk';
 import { PageSection, PageSectionVariants } from '@patternfly/react-core';
 import ApplicationDetailsView from '../components/ApplicationDetailsView/ApplicationDetailsView';
 import ApplicationListView from '../components/ApplicationListView/ApplicationListView';
 import NamespacedPage from '../components/NamespacedPage/NamespacedPage';
 import PageLayout from '../components/PageLayout/PageLayout';
 import HacbsApplicationDetails from '../hacbs/components/ApplicationDetails/HacbsApplicationDetails';
+import { HACBS_FLAG } from '../hacbs/hacbsFeatureFlag';
 import { useQuickstartCloseOnUnmount } from '../hooks/useQuickstartCloseOnUnmount';
 import { getQueryArgument } from '../shared/utils';
 
 const ApplicationsPage = () => {
   useQuickstartCloseOnUnmount();
   const applicationName = getQueryArgument('name');
-  const hacbs = JSON.parse(getQueryArgument('hacbs'));
+  const [hacbs] = useFeatureFlag(HACBS_FLAG);
 
   return (
     <NamespacedPage>


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

[Use Feature flags](https://github.com/openshift/hac-dev/pull/140) in Application details page instead of queryparams (`&hacbs=true`) to gate hacbs UI elements.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Refactoring (no functional changes, no api changes)


## How to test?

With this changes, once you visit `/hacbs` route, then you should see hacbs specific application details page (tabbed view).

![image](https://user-images.githubusercontent.com/9964343/178438397-c4f2d5c7-168b-4a36-b9ef-4844dccfa478.png)