### PR TITLE
Allow clicking on "Applications" breadcrumb

### DIFF
--- a/integration-tests/support/pageObjects/global-po.ts
+++ b/integration-tests/support/pageObjects/global-po.ts
@@ -36,3 +36,7 @@ export const actions = {
   deleteModalInput: 'input[name*="resourceName"]',
   deleteModalButton: 'button[data-testid="delete-resource"]',
 }
+
+export const breadcrumbs = {
+  applications: '[data-test-id="breadcrumb-link-0"]'
+}

--- a/integration-tests/utils/Common.ts
+++ b/integration-tests/utils/Common.ts
@@ -52,4 +52,8 @@ export class Common {
         .should('contain', 'Done running the script');
     }
   }
+
+  static clickBreadcrumbs(breadcrumbPO: string) {
+    cy.get(breadcrumbPO).click();
+  }
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR introduces the ability to click on the "Applications" breadcrumb (shown below)
While working on our tests, this can be further extended to click on other breadcrumbs as per our needs.

_Why do we need this?_
Because in our tests, to visit the "Applications" page (`hac/app-studio/` or `hac/app-studio/applications`) on AppStudio we are currently [using this](https://github.com/openshift/hac-dev/blob/da444ef22c2cf582ba33f37b256e505d7735817e/integration-tests/utils/Common.ts#L4). And it takes a LOT of time to load the page, which leads to test failures due to timeout. A better way to reach the same page is to reach it by just clicking the "Applications" breadcrumb on top.

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
![image](https://user-images.githubusercontent.com/43273420/179192592-4d3f7106-bbe2-4250-a4ad-4be442cd1de1.png)


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Add `Common.clickBreadcrumbs(breadcrumbs.applications);` as one of the steps in your tests inside the "integration-tests/tests" folder

<!-- ## Checklist: -->

<!-- 
- [x] Code follows the style guidelines
- [x] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
