### PR TITLE
hacbs feature flag support via query string param

### DIFF
--- a/config/remotePlugin.js
+++ b/config/remotePlugin.js
@@ -152,6 +152,14 @@ module.exports = {
         name: 'Settings',
       },
     },
+    {
+      type: 'core.flag',
+      properties: {
+        handler: {
+          $codeRef: 'HACBSFlag.enableHACBSFlagFromQueryParam',
+        },
+      },
+    },
   ],
   sharedModules: {
     'react-router-dom': { singleton: true },

--- a/src/hacbs/__tests__/hacbsFeatureFlag.spec.tsx
+++ b/src/hacbs/__tests__/hacbsFeatureFlag.spec.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useFeatureFlag } from '@openshift/dynamic-plugin-sdk';
 import { render } from '@testing-library/react';
-import { HACBS_FLAG, EnableHACBSFlagRoute } from '../hacbsFeatureFlag';
+import {
+  HACBS_FLAG,
+  EnableHACBSFlagRoute,
+  enableHACBSFlagFromQueryParam,
+} from '../hacbsFeatureFlag';
 
 jest.mock('react-router-dom', () => ({
   useNavigate: jest.fn(),
@@ -27,5 +31,41 @@ describe('hacbsFeatureFlag', () => {
     expect(useFeatureFlag).toHaveBeenCalledWith(HACBS_FLAG);
     expect(setFlagMock).toHaveBeenCalledWith(true);
     expect(navigateMock).toHaveBeenCalledWith('/app-studio', { replace: true });
+  });
+});
+
+describe('hacbsFeatureFlag#enableHACBSFlagFromQueryParam', () => {
+  let windowSpy;
+
+  beforeEach(() => {
+    windowSpy = jest.spyOn(window, 'window', 'get');
+  });
+
+  afterEach(() => {
+    windowSpy.mockRestore();
+  });
+
+  it('should set hacbs flag with URL query param', () => {
+    windowSpy.mockImplementation(() => ({
+      location: {
+        search: '',
+      },
+    }));
+
+    const setFlag = jest.fn();
+
+    enableHACBSFlagFromQueryParam(setFlag);
+    expect(setFlag).toHaveBeenCalledWith(HACBS_FLAG, false);
+
+    setFlag.mockReset();
+
+    windowSpy.mockImplementation(() => ({
+      location: {
+        search: '?hacbs=true',
+      },
+    }));
+
+    enableHACBSFlagFromQueryParam(setFlag);
+    expect(setFlag).toHaveBeenCalledWith(HACBS_FLAG, true);
   });
 });

--- a/src/hacbs/hacbsFeatureFlag.ts
+++ b/src/hacbs/hacbsFeatureFlag.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useFeatureFlag } from '@openshift/dynamic-plugin-sdk';
+import { SetFeatureFlag, useFeatureFlag } from '@openshift/dynamic-plugin-sdk';
 
 export const HACBS_FLAG = 'HACBS';
 
@@ -16,4 +16,13 @@ export const EnableHACBSFlagRoute: React.FC = () => {
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, []);
   return null;
+};
+
+export const enableHACBSFlagFromQueryParam = (setFlag: SetFeatureFlag): void => {
+  const enabled = new URLSearchParams(window.location.search).get('hacbs') === 'true';
+  if (enabled) {
+    /* eslint-disable-next-line no-console */
+    console.log('HACBS Flag enabled');
+  }
+  setFlag(HACBS_FLAG, enabled);
 };


### PR DESCRIPTION
## Description
Additional feature flag support via extension was added to HAC-core recently.

This PR adds support across all of app studio to enable HACBS via a query string param:

Set `hacbs=true` on any page URL.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## How to test or reproduce?
set `hacbs=true` in the URL and then navigate to an application details page. Observe the details page displays tabs instead of a typical app studio component based via.

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

cc @mfrances17 @karthikjeeyar 