### PR TITLE
HACBS UI tests: Application Details View

### DIFF
--- a/integration-tests/support/pageObjects/createApplication-po.ts
+++ b/integration-tests/support/pageObjects/createApplication-po.ts
@@ -1,6 +1,6 @@
 export const addComponentPagePO = {
   samples: 'Start with a sample.',
-  addComponent: '[data-test="add-component"]',
+  addComponent: '[data-test="add-component-button"]',
   enterSource: '[data-test="enter-source"]',
   gitOptions: 'Git options',
   gitReference: '[data-test="git-reference"]',
@@ -26,6 +26,9 @@ export const createApplicationPagePO = {
 export const ComponentsPagePO = {
   create: 'button[type=submit]',
   createText: 'Create',
+  editComponentNameIcon: '[data-test="pencil-icon"]',
+  checkIcon: '[data-test="check-icon"]',
+  closeIcon: '[data-test="close-icon"]',
   showAdvancedSetting: 'Show advanced deployment options',
   cpuInput: 'input[name*="cpuValue"]',
   cpuPlusButton: 'button[data-ouia-component-id="OUIA-Generated-Button-control-2"]',

--- a/integration-tests/support/pageObjects/hacbs-po.ts
+++ b/integration-tests/support/pageObjects/hacbs-po.ts
@@ -1,0 +1,32 @@
+export const overviewTabPO = {
+    clickTab: '[data-test="details__tabItem overview"]',
+    goToComponents: '[data-test="go-to-components-tab"]',
+    addComponent: '[data-test="add-component"]'
+}
+
+export const componentsTabPO = {
+    clickTab: '[data-test="details__tabItem components"]',
+    addComponent: '[data-test="add-component-button"]'
+}
+
+export const actionsDropdown = {
+    dropdown: '[data-test="details__actions"]',
+    itemAddComponent: '[data-test="add-component"]',
+    itemAddEnvironment: '[data-test="add-environment"]',
+    itemAddIntegrationTest: '[data-test="add-integration-tests"]',
+    itemDeleteApplication: '[data-test="delete-application"]',
+    itemLearningResources: '[data-test="learning-resources"]'
+}
+
+export const createBuildStepPO = {
+    mergePRButton: '[data-testid="merge-button"]',
+    next: 'button[type=submit]',
+}
+
+export const addIntegrationStepPO = {
+    displayNameInput: '[data-test="display-name-input"]',
+    containerImageInput: '[data-test="container-image-input"]',
+    pipelineNameInput: '[data-test="pipeline-name-input"]',
+    optionalreleaseCheckbox: '[data-test="optional-release-checkbox"]',
+    next: 'button[type=submit]',
+}

--- a/integration-tests/support/pages/ComponentsPage.ts
+++ b/integration-tests/support/pages/ComponentsPage.ts
@@ -5,6 +5,12 @@ import { alertTitle } from '../pageObjects/global-po';
 import { AbstractWizardPage } from './AbstractWizardPage';
 
 export class ComponentPage extends AbstractWizardPage {
+  editComponentName(newName: string) {
+    cy.get(ComponentsPagePO.editComponentNameIcon).eq(0).click();
+    cy.get('input').clear().type(newName);
+    cy.get(ComponentsPagePO.checkIcon).click();
+  }
+
   saveChanges() {
     cy.get(ComponentsPagePO.saveButton).click();
     Common.waitForLoad();

--- a/integration-tests/support/pages/hacbs/AddIntegrationTestPage.ts
+++ b/integration-tests/support/pages/hacbs/AddIntegrationTestPage.ts
@@ -1,0 +1,16 @@
+import { addIntegrationStepPO } from '../../pageObjects/hacbs-po';
+
+export class AddIntegrationTestPage {
+    enterDisplayName(displayName: string) {
+        cy.get(addIntegrationStepPO.displayNameInput).clear().type(displayName);
+    }
+    enterContainerImage(containerImage: string) {
+        cy.get(addIntegrationStepPO.containerImageInput).clear().type(containerImage);
+    }
+    enterPipelineName(pipelineName: string) {
+        cy.get(addIntegrationStepPO.pipelineNameInput).clear().type(pipelineName);
+    }
+    clickNext() {
+        cy.get(addIntegrationStepPO.next).trigger('click');
+    }
+}

--- a/integration-tests/support/pages/hacbs/ComponentsTabPage.ts
+++ b/integration-tests/support/pages/hacbs/ComponentsTabPage.ts
@@ -1,0 +1,7 @@
+import { componentsTabPO } from '../../pageObjects/hacbs-po';
+
+export class ComponentsTabPage {
+    clickAddComponent() {
+        cy.get(componentsTabPO.addComponent).click();
+    }
+}

--- a/integration-tests/support/pages/hacbs/CreateBuildPage.ts
+++ b/integration-tests/support/pages/hacbs/CreateBuildPage.ts
@@ -1,0 +1,7 @@
+import { createBuildStepPO } from '../../pageObjects/hacbs-po';
+
+export class CreateBuildPage {
+    clickNext() {
+        cy.get(createBuildStepPO.next).trigger('click');
+    }
+}

--- a/integration-tests/support/pages/hacbs/OverviewTabPage.ts
+++ b/integration-tests/support/pages/hacbs/OverviewTabPage.ts
@@ -1,0 +1,11 @@
+import { overviewTabPO } from '../../pageObjects/hacbs-po';
+
+export class OverviewTabPage {
+    goToComponentsTab() {
+        cy.get(overviewTabPO.goToComponents).click();
+    }
+
+    addComponent() {
+        cy.get(overviewTabPO.addComponent).click();
+    }
+}

--- a/integration-tests/tests/hacbs/add-component-to-application-via-hacbs-tab.spec.ts
+++ b/integration-tests/tests/hacbs/add-component-to-application-via-hacbs-tab.spec.ts
@@ -1,0 +1,85 @@
+import { Applications } from "../../utils/Applications";
+import { Common } from "../../utils/Common";
+import { ComponentsTabPage } from "../../support/pages/hacbs/ComponentsTabPage";
+import { actionsDropdown } from "../../support/pageObjects/hacbs-po";
+import { HACBSApplications } from "../../utils/HACBSApplications";
+import { OverviewTabPage } from "../../support/pages/hacbs/OverviewTabPage";
+
+describe('Create Components using the HACBS UI', () => {
+    const LOCAL_STORAGE_KEY_GS_MODAL = 'hacbs/getting-started-modal';
+    const LOCAL_STORAGE_KEY_QUICKSTART = 'hacbs/showApplicationQuickstart';
+    const applicationName = Common.generateAppName();
+    const overviewTabPage = new OverviewTabPage();
+    const componentsTabPage = new ComponentsTabPage();
+    const publicRepos = [
+            'https://github.com/dheerajodha/devfile-sample-code-with-quarkus',
+            'https://github.com/devfile-samples/devfile-sample-go-basic.git',
+            'https://github.com/nodeshift-starters/devfile-sample.git'
+            ]
+    const componentNames = ['java-quarkus', 'go', 'go-component', 'nodejs'];
+
+    before(function () {
+        // Enable HACBS
+        localStorage.setItem('hacbs', 'true');
+        localStorage.setItem(LOCAL_STORAGE_KEY_GS_MODAL, 'true');
+        // Need to reload the page after enabling HACBS via localStorage
+        cy.reload();
+    });
+
+    beforeEach(function () {
+        localStorage.setItem(LOCAL_STORAGE_KEY_GS_MODAL, 'true');
+        localStorage.setItem(LOCAL_STORAGE_KEY_QUICKSTART, 'true');
+    });
+
+    after(function () {
+        //Delete the application
+        Applications.deleteApplication(applicationName);
+    });
+
+    describe('Create an Application with a component', () => {
+        it('Set Application Name', () => {
+            Applications.createApplication(applicationName);
+        })
+
+        it('Add a component to Application', () => {
+            HACBSApplications.createComponent(publicRepos[0], componentNames[0]);
+            HACBSApplications.createdComponentExists(componentNames[0], applicationName);
+        });
+    });
+
+    describe('Add a new component using the "Overview" tab', () => {
+        it("Use HACBS 'Components' tabs to start adding a new compoent", () => {
+            HACBSApplications.goToOverviewTab();
+            overviewTabPage.addComponent();
+        });
+
+        it('Add a component to Application', () => {
+            HACBSApplications.createComponent(publicRepos[1], componentNames[1]);
+            HACBSApplications.createdComponentExists(componentNames[1], applicationName);
+        });
+    });
+
+    describe('Add a new component using the "Components" tab', () => {
+        it("Use HACBS 'Components' tabs to start adding a new compoent", () => {
+            HACBSApplications.goToComponentsTab();
+            componentsTabPage.clickAddComponent();
+        });
+
+        it('Add a component to Application', () => {
+            HACBSApplications.createComponent(publicRepos[1], componentNames[2]);
+            HACBSApplications.createdComponentExists(componentNames[2], applicationName);
+        });
+    });
+
+    describe('Add a new component using the "Actions" dropdown', () => {
+        it("Click 'Actions' dropdown to add a component", () => {
+            cy.get(actionsDropdown.dropdown).click();
+            cy.contains('Add Component').click();
+        });
+
+        it('Add a component to Application', () => {
+            HACBSApplications.createComponent(publicRepos[2], componentNames[3]);
+            HACBSApplications.createdComponentExists(componentNames[3], applicationName);
+        });
+    });
+});

--- a/integration-tests/utils/Common.ts
+++ b/integration-tests/utils/Common.ts
@@ -39,7 +39,7 @@ export class Common {
   }
 
   static verifyPageTitle(title: string) {
-    cy.contains('h1', title, { timeout: 90000 }).should('be.visible');
+    cy.contains('h1', title, { timeout: 250000 }).should('be.visible');
   }
 
   static clickOnConsentButton() {

--- a/integration-tests/utils/HACBSApplications.ts
+++ b/integration-tests/utils/HACBSApplications.ts
@@ -1,0 +1,93 @@
+import { applicationDetailPagePO } from '../support/pageObjects/createApplication-po';
+import { overviewTabPO, componentsTabPO } from '../support/pageObjects/hacbs-po';
+import { AddComponentPage } from '../support/pages/AddComponentPage';
+import { ComponentPage } from '../support/pages/ComponentsPage';
+import { AddIntegrationTestPage } from '../support/pages/hacbs/AddIntegrationTestPage';
+import { CreateBuildPage } from '../support/pages/hacbs/CreateBuildPage';
+import { Applications } from './Applications';
+import { Common } from './Common';
+
+export class HACBSApplications {
+    static deleteApplication(applicationName: string) {
+        Applications.deleteApplication(applicationName);
+    }
+
+    static createApplication(name: string) {
+        Applications.createApplication(name);
+    }
+
+    static createComponent(publicGitRepo: string, componentName: string) {
+        addComponentStep(publicGitRepo);
+        reviewComponentsStep(componentName);
+        createBuildStep();
+        addIntegrationTestStep();
+    }
+
+    static createdComponentExists(componentName: string, applicationName: string) {
+        this.goToComponentsTab();
+
+        Common.verifyPageTitle(applicationName);
+        Common.waitForLoad();
+        this.getComponentListItem(componentName).should('exist');
+    }
+
+    static getComponentListItem(application: string) {
+        return cy.contains(applicationDetailPagePO.item, application, { timeout: 60000 });
+    }
+
+    static goToOverviewTab() {
+        cy.get(overviewTabPO.clickTab).click();
+    }
+
+    static goToComponentsTab() {
+        cy.get(componentsTabPO.clickTab).click();
+    }
+}
+
+function addComponentStep(publicGitRepo: string) {
+    const addComponent = new AddComponentPage();
+
+    // Enter git repo URL
+    addComponent.setSource(publicGitRepo);
+    // Check if the source is validated
+    addComponent.waitRepoValidated();
+    // Setup Git Options
+    addComponent.clickGitOptions();
+
+    addComponent.clickNext();
+}
+
+
+function reviewComponentsStep(componentName: string) {
+    const componentPage = new ComponentPage();
+
+    // Edit component name
+    componentPage.editComponentName(componentName + "-temp");
+    cy.contains('div', componentName + "-temp").should('be.visible');
+
+    // Switch back to orginal name
+    componentPage.editComponentName(componentName);
+    cy.contains('div', componentName).should('be.visible');;
+
+    //Create Application
+    componentPage.createApplication();
+}
+
+
+function createBuildStep() {
+    new CreateBuildPage().clickNext();
+}
+
+
+function addIntegrationTestStep() {
+    const addIntegrationTestPage = new AddIntegrationTestPage();
+    const displayName = Common.generateAppName('My-name');
+    const containerImage = 'quay.io/kpavic/test-bundle:pipeline'
+    const pipelineName = 'demo-pipeline'
+
+    addIntegrationTestPage.enterDisplayName(displayName);
+    addIntegrationTestPage.enterContainerImage(containerImage);
+    addIntegrationTestPage.enterPipelineName(pipelineName);
+
+    addIntegrationTestPage.clickNext();
+}

--- a/src/components/ComponentsListView/ComponentListView.tsx
+++ b/src/components/ComponentsListView/ComponentListView.tsx
@@ -199,7 +199,7 @@ const ComponentListView: React.FC<ComponentListViewProps> = ({
               component={(p) => (
                 <Link
                   {...p}
-                  data-test="add-component"
+                  data-test="add-component-button"
                   to={`/app-studio/import?application=${applicationName}`}
                 />
               )}

--- a/src/hacbs/components/ApplicationDetails/DetailsPage.tsx
+++ b/src/hacbs/components/ApplicationDetails/DetailsPage.tsx
@@ -87,7 +87,7 @@ const DetailsPage: React.FC<DetailsPageProps> = ({
         return type === 'separator' ? (
           <DropdownSeparator key={key} />
         ) : (
-          <DropdownItem key={key} {...props}>
+          <DropdownItem key={key} data-test={key} {...props}>
             {label}
           </DropdownItem>
         );

--- a/src/hacbs/components/ApplicationDetails/tabs/overview/sections/AppWorkflowSection.tsx
+++ b/src/hacbs/components/ApplicationDetails/tabs/overview/sections/AppWorkflowSection.tsx
@@ -48,6 +48,7 @@ const AppWorkflowSection: React.FC<AppWorkflowSectionProps> = ({ applicationName
           component={(props) => (
             <Link {...props} to={`/app-studio/import?application=${applicationName}`} />
           )}
+          data-test="add-component"
         >
           Add component
         </Button>

--- a/src/hacbs/components/Commits/AppRecentCommits.tsx
+++ b/src/hacbs/components/Commits/AppRecentCommits.tsx
@@ -67,6 +67,7 @@ const AppRecentCommits = ({ applicationName }) => {
             />
           )}
           variant="secondary"
+          data-test="go-to-components-tab"
         >
           Go to components tab
         </Button>

--- a/src/hacbs/components/IntegrationTestForm/IntegrationTestSection.tsx
+++ b/src/hacbs/components/IntegrationTestForm/IntegrationTestSection.tsx
@@ -47,6 +47,7 @@ const IntegrationTestSection: React.FunctionComponent<{ isInPage?: boolean }> = 
           label="Display name"
           name="integrationTest.name"
           placeholder="Enter the integration test pipeline name"
+          data-test="display-name-input"
           required
         />
         <InputField
@@ -55,12 +56,14 @@ const IntegrationTestSection: React.FunctionComponent<{ isInPage?: boolean }> = 
           label="Container image"
           labelIcon={<HelpTooltipIcon content={'Provide your image bundle'} />}
           name="integrationTest.bundle"
+          data-test="container-image-input"
         />
         <InputField
           aria-label="Pipeline specified in container image"
           label="Pipeline specified in container image"
           name="integrationTest.pipeline"
           helpText="Specify the pipeline name as it appears in the image bundle."
+          data-test="pipeline-name-input"
           required
         />
         <CheckboxField
@@ -68,6 +71,7 @@ const IntegrationTestSection: React.FunctionComponent<{ isInPage?: boolean }> = 
           aria-label="Mark as optional for release"
           label="Mark as optional for release"
           helpText="Passing this test is optional, and it cannot prevent the application from being deployed or released."
+          data-test="optional-release-checkbox"
         />
         {infoAlert && (
           <Alert


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
_Main aim of the PR:_ To add UI tests for the following scenario,

* Using the **"Application Details View Page"**:
    * Enabling HACBS UI.
    * Adding a component while creating an application.
    * Adding a component by using the "Overview" tab.
    * Adding a component by using the "Components" tab.
    * Adding a component by the "Actions" drop-down.

<!-- * To do this, I've made the following changes:
    * created a new file called `integration-tests/support/pageObjects/hacbs-po.ts` which specifically stores all the POs of HACBS UI.
    * created multiple new files () in the new folder under `integration-tests/support/pages` where we store all the util methods related to a given (tab) page on the HACBS UI.
    * added new util methods to enable HACBS UI and to click on 'Applications' breadcrumbs for faster page load.
    * added the `data-test` property to several UI elements. -->

[Test Recording](https://drive.google.com/file/d/1sBZUW80OqFH2sF37BZTT4Zj8U39LuTwL/view?usp=sharing)

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Other (please describe): Tests


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
