### PR TITLE
Fix image sizing for getting started cards

### DIFF
--- a/src/components/ApplicationDetailsView/ApplicationDetailsView.tsx
+++ b/src/components/ApplicationDetailsView/ApplicationDetailsView.tsx
@@ -83,9 +83,9 @@ const ApplicationDetailsView: React.FunctionComponent<ApplicationViewProps> = ({
   return (
     <React.Fragment>
       <GettingStartedCard
-        imgClassName="pf-u-w-25 pf-u-px-4xl"
+        imgClassName="pf-u-px-2xl-on-xl"
         localStorageKey={GETTING_STARTED_CARD_KEY}
-        title="Manage you applications"
+        title="Manage your applications"
         imgSrc={imageUrl}
         imgAlt="Illustration showing users managing applications"
       >

--- a/src/components/ApplicationListView/ApplicationListView.tsx
+++ b/src/components/ApplicationListView/ApplicationListView.tsx
@@ -53,7 +53,7 @@ const ApplicationListView: React.FC = () => {
     <>
       {applications.length === 0 && (
         <GettingStartedCard
-          imgClassName="pf-u-w-25 pf-u-px-4xl"
+          imgClassName="pf-u-px-2xl-on-xl"
           localStorageKey={GETTING_STARTED_CARD_KEY}
           title="Create and manage you applications"
           imgSrc={imageUrl}

--- a/src/components/GettingStartedCard/GettingStartedCard.scss
+++ b/src/components/GettingStartedCard/GettingStartedCard.scss
@@ -1,0 +1,6 @@
+.getting-started-card {
+  &__img {
+    --pf-u-min-width--MinWidth-on-sm: 20ch;
+    --pf-u-min-width--MinWidth-on-xl: 30ch;
+  }
+}

--- a/src/components/GettingStartedCard/GettingStartedCard.tsx
+++ b/src/components/GettingStartedCard/GettingStartedCard.tsx
@@ -11,7 +11,9 @@ import {
   SplitItem,
 } from '@patternfly/react-core';
 import CloseIcon from '@patternfly/react-icons/dist/js/icons/close-icon';
+import classnames from 'classnames';
 import { useLocalStorage } from '../../hooks';
+import './GettingStartedCard.scss';
 
 type GettingStartedCardProps = {
   imgClassName?: string;
@@ -43,7 +45,9 @@ export const GettingStartedCard: React.FC<GettingStartedCardProps> = ({
         <Card>
           <Split>
             {imgSrc && (
-              <SplitItem className={imgClassName}>
+              <SplitItem
+                className={classnames('pf-u-min-width getting-started-card__img', imgClassName)}
+              >
                 <img src={imgSrc} alt={imgAlt} />
               </SplitItem>
             )}
@@ -53,7 +57,7 @@ export const GettingStartedCard: React.FC<GettingStartedCardProps> = ({
                 <CardActions>
                   <Button
                     variant="plain"
-                    aria-label="close"
+                    aria-label="Hide card"
                     onClick={() => setStorageKeys({ ...keys, [localStorageKey]: true })}
                   >
                     <CloseIcon />

--- a/src/pages/WorkspaceSettingsPage.scss
+++ b/src/pages/WorkspaceSettingsPage.scss
@@ -1,0 +1,6 @@
+.workspace-settings-page {
+  &__card-img {
+    --pf-u-min-width--MinWidth-on-sm: 10ch;
+    --pf-u-min-width--MinWidth-on-md: 20ch;
+  }
+}

--- a/src/pages/WorkspaceSettingsPage.tsx
+++ b/src/pages/WorkspaceSettingsPage.tsx
@@ -6,6 +6,7 @@ import { GettingStartedCard } from '../components/GettingStartedCard/GettingStar
 import NamespacedPage from '../components/NamespacedPage/NamespacedPage';
 import PageLayout from '../components/PageLayout/PageLayout';
 import imageUrl from '../imgs/getting-started-illustration.svg';
+import './WorkspaceSettingsPage.scss';
 
 const GETTING_STARTED_CARD_KEY = 'environments-list-getting-started-card';
 
@@ -16,7 +17,7 @@ const WorkspaceSettingsPage: React.FC = () => {
         <title>Workspace settings page</title>
       </Helmet>
       <GettingStartedCard
-        imgClassName="pf-u-px-2xl pf-u-w-33"
+        imgClassName="pf-u-px-md-on-xl pf-u-min-width workspace-settings-page__card-img"
         localStorageKey={GETTING_STARTED_CARD_KEY}
         title="Manage your workspace settings"
         imgSrc={imageUrl}


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-1946
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
Make getting started card images responsive.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

https://user-images.githubusercontent.com/20013884/180005724-104163fd-4897-4a88-8957-2d43d37e47a6.mp4

<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration 

## How to test or reproduce?
-->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
