### PR TITLE
hacbs feature flag support via localStorage

### DIFF
--- a/src/hacbs/__tests__/hacbsFeatureFlag.spec.tsx
+++ b/src/hacbs/__tests__/hacbsFeatureFlag.spec.tsx
@@ -68,4 +68,47 @@ describe('hacbsFeatureFlag#enableHACBSFlagFromQueryParam', () => {
     enableHACBSFlagFromQueryParam(setFlag);
     expect(setFlag).toHaveBeenCalledWith(HACBS_FLAG, true);
   });
+
+  it('should set hacbs flag from localStorage', () => {
+    const setFlag = jest.fn();
+
+    enableHACBSFlagFromQueryParam(setFlag);
+    expect(setFlag).toHaveBeenCalledWith(HACBS_FLAG, false);
+
+    setFlag.mockReset();
+
+    localStorage.setItem('hacbs', 'true');
+
+    enableHACBSFlagFromQueryParam(setFlag);
+    expect(setFlag).toHaveBeenCalledWith(HACBS_FLAG, true);
+
+    localStorage.removeItem('hacbs');
+  });
+
+  it('should use params over localStorage', () => {
+    windowSpy.mockImplementation(() => ({
+      location: {
+        search: '?hacbs=false',
+      },
+    }));
+    localStorage.setItem('hacbs', 'true');
+
+    const setFlag = jest.fn();
+
+    enableHACBSFlagFromQueryParam(setFlag);
+    expect(setFlag).toHaveBeenCalledWith(HACBS_FLAG, false);
+
+    setFlag.mockReset();
+
+    windowSpy.mockImplementation(() => ({
+      location: {
+        search: '?hacbs=wrong',
+      },
+    }));
+
+    enableHACBSFlagFromQueryParam(setFlag);
+    expect(setFlag).toHaveBeenCalledWith(HACBS_FLAG, true);
+
+    localStorage.removeItem('hacbs');
+  });
 });

--- a/src/hacbs/hacbsFeatureFlag.ts
+++ b/src/hacbs/hacbsFeatureFlag.ts
@@ -19,7 +19,13 @@ export const EnableHACBSFlagRoute: React.FC = () => {
 };
 
 export const enableHACBSFlagFromQueryParam = (setFlag: SetFeatureFlag): void => {
-  const enabled = new URLSearchParams(window.location.search).get('hacbs') === 'true';
+  let enabled = false;
+  const hacbsParam = new URLSearchParams(window.location.search).get('hacbs');
+  if (['true', 'false'].includes(hacbsParam)) {
+    enabled = hacbsParam === 'true';
+  } else {
+    enabled = localStorage.getItem('hacbs') === 'true';
+  }
   if (enabled) {
     /* eslint-disable-next-line no-console */
     console.log('HACBS Flag enabled');


### PR DESCRIPTION
## Description
Allow users to enable the hacbs feature flag using localStorage `hacbs` = `true`

This is useful for developers who want to always work in a hacbs.

Note that if the query param `hacbs` is equal to `true` or `false` it will take precedence over the localStorage value to give quick control to the developer to flip between the two UIs.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## How to test or reproduce?
Set localStorage value `hacbs` to `true`. Upon visiting any app-studio page, the hacbs feature flag will be enabled.


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
