### PR TITLE
Don't reload the page if the test is already there.

### DIFF
--- a/integration-tests/utils/Common.ts
+++ b/integration-tests/utils/Common.ts
@@ -6,7 +6,11 @@ export class Common {
   }
 
   static openURL(URL: string) {
-    cy.visit(URL);
+    cy.url().then(($url) => {
+      if ($url != URL){
+        cy.visit(URL);  
+      }
+    })
   }
 
   static generateAppName(prefix = 'test-app') {
@@ -15,9 +19,7 @@ export class Common {
   }
 
   static openApplicationURL(applicationName: string) {
-    if(!cy.contains('h1', applicationName, { timeout: 90000 })) {
-      cy.get('[data-ouia-component-id="Applications"] > a').click();
-    }
+    Common.openURL(`${Cypress.env('HAC_BASE_URL')}/applications?name=${applicationName.replace('.', '-')}`);
     Common.verifyPageTitle(applicationName);
     Common.waitForLoad();
   }


### PR DESCRIPTION
## Description
The test was reloading the page to access the list of applications even when it already was on the correct page. 
Adding a check to not reload the page and if needed, go to the page by using the URL. The test is also using UI when deleting the app (click Applications in the left menu) so this functionality is still covered in tests.