### PR TITLE
Use display name for application delete confirmation modal

### DIFF
--- a/src/components/modal/DeleteResourceModal.tsx
+++ b/src/components/modal/DeleteResourceModal.tsx
@@ -26,6 +26,7 @@ import { ComponentProps, createModalLauncher } from './createModalLauncher';
 type DeleteResourceModalProps = ComponentProps & {
   obj: K8sResourceCommon;
   model: K8sModelCommon;
+  displayName?: string;
   description?: React.ReactNode;
 };
 
@@ -33,9 +34,11 @@ export const DeleteResourceModal: React.FC<DeleteResourceModalProps> = ({
   obj,
   model,
   onClose,
+  displayName,
   description,
 }) => {
   const [error, setError] = React.useState();
+  const resourceName = displayName || obj.metadata.name;
   const deleteResource = async () => {
     try {
       await k8sDeleteResource({
@@ -65,7 +68,7 @@ export const DeleteResourceModal: React.FC<DeleteResourceModalProps> = ({
         touched: { resourceName: touched },
       }) => {
         const input = values.resourceName;
-        const isValid = input === obj.metadata.name;
+        const isValid = input === resourceName;
         const helpText = touched && !input ? 'Missing information' : undefined;
         const validatedState = touched
           ? !input
@@ -85,7 +88,7 @@ export const DeleteResourceModal: React.FC<DeleteResourceModalProps> = ({
                       description
                     ) : (
                       <>
-                        The {obj.kind} <strong>{obj.metadata.name}</strong> will be deleted.
+                        The {obj.kind} <strong>{resourceName}</strong> will be deleted.
                       </>
                     )}
                   </Text>

--- a/src/components/modal/__tests__/DeleteResourceModal.spec.tsx
+++ b/src/components/modal/__tests__/DeleteResourceModal.spec.tsx
@@ -47,4 +47,21 @@ describe('DeleteResourceModal', () => {
     await waitFor(() => expect(k8sDeleteMock).toHaveBeenCalled());
     expect(onClose).toHaveBeenCalled();
   });
+
+  it('should use display name instead of resource name when provided', () => {
+    const obj = { apiVersion: 'v1', kind: 'Application', metadata: { name: 'test' } };
+    const onClose = jest.fn();
+    render(
+      <DeleteResourceModal
+        obj={obj}
+        model={ApplicationModel}
+        onClose={onClose}
+        displayName="My App"
+      />,
+    );
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'test' } });
+    expect(screen.getByText('Delete')).toBeDisabled();
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'My App' } });
+    expect(screen.getByText('Delete')).toBeEnabled();
+  });
 });

--- a/src/components/modal/resource-modals.tsx
+++ b/src/components/modal/resource-modals.tsx
@@ -3,8 +3,12 @@ import { ApplicationModel, ComponentModel } from '../../models';
 import { ApplicationKind, ComponentKind } from '../../types';
 import { createDeleteModalLauncher } from './DeleteResourceModal';
 
-export const applicationDeleteModal = (applicatioObj: ApplicationKind) =>
-  createDeleteModalLauncher(applicatioObj.kind)({ obj: applicatioObj, model: ApplicationModel });
+export const applicationDeleteModal = (applicationObj: ApplicationKind) =>
+  createDeleteModalLauncher(applicationObj.kind)({
+    obj: applicationObj,
+    model: ApplicationModel,
+    displayName: applicationObj.spec.displayName,
+  });
 
 export const componentDeleteModal = (component: ComponentKind) =>
   createDeleteModalLauncher(component.kind)({


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-1963
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
Use display name instead of resource name for app delete modal.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

https://user-images.githubusercontent.com/20013884/181466615-6ee7c445-0595-4daa-8912-4b03f1fe860c.mp4

<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
Open application delete modal.
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
