### PR TITLE
Validate application name on submit

### DIFF
--- a/src/components/ImportForm/utils/submit-utils.ts
+++ b/src/components/ImportForm/utils/submit-utils.ts
@@ -1,3 +1,4 @@
+import { FormikHelpers } from 'formik';
 import { createApplication, createComponent } from '../../../utils/create-utils';
 import { transformResources } from './transform-utils';
 import { DetectedFormComponent, ImportFormValues } from './types';
@@ -43,4 +44,19 @@ export const createResources = async (formValues: ImportFormValues) => {
   await createComponents(components, applicationName, namespace, secret);
 
   return applicationName;
+};
+
+export const checkApplicationName = async (
+  values: ImportFormValues,
+  formikHelpers: FormikHelpers<ImportFormValues>,
+) => {
+  const { application, namespace } = values;
+  try {
+    await createApplication(application, namespace, true);
+    formikHelpers.setStatus({});
+  } catch (error) {
+    const message = error.code === 409 ? 'Application name already exists.' : error.message;
+    formikHelpers.setStatus({ submitError: message });
+    throw error;
+  }
 };

--- a/src/components/ImportForm/utils/useImportSteps.tsx
+++ b/src/components/ImportForm/utils/useImportSteps.tsx
@@ -4,6 +4,7 @@ import ApplicationSection from '../ApplicationSection/ApplicationSection';
 import ReviewSection from '../ReviewSection/ReviewSection';
 import SampleSection from '../SampleSection/SampleSection';
 import { SourceSection } from '../SourceSection/SourceSection';
+import { checkApplicationName } from './submit-utils';
 import { ImportStrategy } from './types';
 import {
   applicationValidationSchema,
@@ -24,7 +25,7 @@ export const useImportSteps = (applicationName: string): FormikWizardStep[] => {
               name: 'Name application',
               component: <ApplicationSection />,
               validationSchema: applicationValidationSchema,
-              validateOnChange: false,
+              onSubmit: checkApplicationName,
             },
           ]),
       ...(strategy === ImportStrategy.GIT

--- a/src/components/ImportForm/utils/validation-utils.ts
+++ b/src/components/ImportForm/utils/validation-utils.ts
@@ -1,5 +1,4 @@
 import * as yup from 'yup';
-import { createApplication } from '../../../utils/create-utils';
 
 export const gitUrlRegex =
   /^((((ssh|git|https?:?):\/\/:?)(([^\s@]+@|[^@]:?)[-\w.]+(:\d\d+:?)?(\/[-\w.~/?[\]!$&'()*+,;=:@%]*:?)?:?))|([^\s@]+@[-\w.]+:[-\w.~/?[\]!$&'()*+,;=:@%]*?:?))$/;
@@ -15,17 +14,7 @@ const combineRegExps = (...regexps: RegExp[]) => {
 };
 
 export const applicationValidationSchema = yup.object({
-  application: yup
-    .string()
-    .required('Required')
-    .test('isUnique', 'Application name already exists.', async (value, context) => {
-      try {
-        await createApplication(value, context.parent.namespace, true);
-        return true;
-      } catch {
-        return false;
-      }
-    }),
+  application: yup.string().required('Required'),
 });
 
 export const sourceValidationSchema = yup.object({


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
- https://issues.redhat.com/browse/HAC-1948

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- The application name was being validated onBlur which is why on first click it would validate and enable the next button. On next click it would change the step.
- Updated the validation to validate on submit instead of onBlur.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

https://user-images.githubusercontent.com/6041994/181507977-2373e7a2-fd1f-464e-af65-8b7e98e21125.mov


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
