### PR TITLE
Watch binding to get secret for previously authorized repos

### DIFF
--- a/src/components/ImportForm/SourceSection/__tests__/SourceSection.spec.tsx
+++ b/src/components/ImportForm/SourceSection/__tests__/SourceSection.spec.tsx
@@ -2,15 +2,14 @@ import * as React from 'react';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ServiceProviderType, SPIAccessCheckAccessibilityStatus } from '../../../../types';
-import { initiateAccessTokenBinding } from '../../../../utils/create-utils';
 import { formikRenderer } from '../../../../utils/test-utils';
-import { useAccessCheck } from '../../utils/auth-utils';
+import { useAccessCheck, useAccessTokenBinding } from '../../utils/auth-utils';
 import { SourceSection } from '../SourceSection';
 
 import '@testing-library/jest-dom';
 
 jest.mock('../../utils/auth-utils', () => ({
-  useAccessTokenBinding: () => ['', true],
+  useAccessTokenBinding: jest.fn(),
   useAccessCheck: jest.fn(),
 }));
 
@@ -22,12 +21,8 @@ jest.mock('../../../../shared/hooks', () => ({
   useFormikValidationFix: jest.fn(),
 }));
 
-jest.mock('../../../../utils/create-utils', () => ({
-  initiateAccessTokenBinding: jest.fn(),
-}));
-
 const useAccessCheckMock = useAccessCheck as jest.Mock;
-const instantiateAccessBindingMock = initiateAccessTokenBinding as jest.Mock;
+const useBindingMock = useAccessTokenBinding as jest.Mock;
 
 const renderSourceSection = () => {
   const onClick = jest.fn();
@@ -63,6 +58,7 @@ describe('SourceSection', () => {
       { isRepoAccessible: false, serviceProvider: ServiceProviderType.GitHub },
       true,
     ]);
+    useBindingMock.mockReturnValue(['', true]);
 
     renderSourceSection();
 
@@ -87,6 +83,7 @@ describe('SourceSection', () => {
       { isRepoAccessible: false, serviceProvider: ServiceProviderType.GitHub },
       true,
     ]);
+    useBindingMock.mockReturnValue(['', true]);
 
     renderSourceSection();
 
@@ -100,6 +97,7 @@ describe('SourceSection', () => {
       { isRepoAccessible: false, isGit: false, serviceProvider: ServiceProviderType.Quay },
       true,
     ]);
+    useBindingMock.mockReturnValue(['', true]);
 
     renderSourceSection();
 
@@ -168,15 +166,10 @@ describe('SourceSection', () => {
       true,
     ]);
 
-    instantiateAccessBindingMock.mockResolvedValue({
-      status: { phase: 'Injected', syncedObjectRef: { name: 'test-token' } },
-      spec: { repoUrl: 'https://github.com/example/repo' },
-    });
-
     const { input, user } = renderSourceSection();
 
+    expect(useBindingMock).toHaveBeenCalledWith('');
     await user.type(input, 'https://github.com/example/repo');
-
-    expect(instantiateAccessBindingMock).toHaveBeenCalled();
+    expect(useBindingMock).toHaveBeenCalledWith('https://github.com/example/repo');
   });
 });

--- a/src/components/ImportForm/utils/__tests__/auth-utils.spec.ts
+++ b/src/components/ImportForm/utils/__tests__/auth-utils.spec.ts
@@ -61,6 +61,9 @@ describe('Auth Utils: useAccessTokenBinding', () => {
           oAuthUrl: 'https://test-app.auth.svc.cluster.local/oauth/token',
           phase: '',
           linkedAccessTokenName: 'test-token',
+          syncedObjectRef: {
+            name: 'secret',
+          },
         },
       },
       true,

--- a/src/components/ImportForm/utils/auth-utils.ts
+++ b/src/components/ImportForm/utils/auth-utils.ts
@@ -95,7 +95,7 @@ export const useAccessCheck = (
  * @returns oAuth URL provided by the binding
  */
 export const useAccessTokenBinding = (
-  source: string,
+  source?: string,
 ): [{ oAuthUrl: string; accessTokenName: string }, boolean] => {
   const { namespace } = useNamespace();
   const { setFieldValue } = useFormikContext();
@@ -109,6 +109,8 @@ export const useAccessTokenBinding = (
         })
         // eslint-disable-next-line no-console
         .catch((e) => console.error('Error when initiating access token binding: ', e));
+    } else {
+      setName(null);
     }
   }, [namespace, source]);
 
@@ -124,7 +126,11 @@ export const useAccessTokenBinding = (
 
   React.useEffect(() => {
     if (!name || !loaded) return;
-    if (binding.status?.phase === SPIAccessTokenBindingPhase.Injected) {
+    // set injected token only if source hasn't changed after call
+    if (
+      binding.status?.phase === SPIAccessTokenBindingPhase.Injected &&
+      binding.spec?.repoUrl === source
+    ) {
       setFieldValue('secret', binding.status.syncedObjectRef.name);
       // eslint-disable-next-line no-console
       console.log('Git repository successfully authorized.');
@@ -135,10 +141,12 @@ export const useAccessTokenBinding = (
   }, [
     name,
     loaded,
+    source,
     setFieldValue,
     binding?.status?.phase,
     binding?.status?.errorMessage,
-    binding?.status?.syncedObjectRef?.name,
+    binding?.status?.syncedObjectRef.name,
+    binding?.spec?.repoUrl,
   ]);
 
   return [


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-1645
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
The source section effect did not watch the binding for previously authorized repos, and wasn't able to get the secret when binding status was updated.

This fix replaces the effect with watch hook.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

https://user-images.githubusercontent.com/20013884/181784964-970f7cf4-3881-4564-bcdd-319efdaa5b8c.mp4

<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
- Authorize a private repo
- Delete all SPIAccessTokenBindings
- Enter the authorized repo in import form
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
