### PR TITLE
Adds quickstart for HACBS applications

### DIFF
--- a/src/hacbs/components/ApplicationDetails/ApplicationQuickstartContent.ts
+++ b/src/hacbs/components/ApplicationDetails/ApplicationQuickstartContent.ts
@@ -1,0 +1,54 @@
+export const applicationQuickstartContent = {
+  apiVersion: 'console.openshift.io/v1',
+  kind: 'QuickStarts',
+  metadata: {
+    name: 'hacbs-getting-started-app',
+  },
+  spec: {
+    version: 1.0,
+    displayName: `Getting started with an app`,
+    durationMinutes: 15,
+    description: `Getting started with an app.`,
+    introduction: `You created an app and added a component to it. Good job!  
+
+To get started using your app, follow the steps in this quick start guide.`,
+    tasks: [
+      {
+        title: `Add components and builds`,
+        description: `
+1. Go to the **Actions** dropdown and select "Add Component".
+2. Add the components you want included, then you will receive a PR to add the build pipeline to your code.
+3. View the Pull Requests we have sent you by clicking on the **Merge Pull Requests** button. You will be directed to the Pull Requests list.
+4. Customize this build pipeline according to your development needs.
+5. Merge to the PR to add the build pipeline to your code.`,
+      },
+      {
+        title: `Add integration test`,
+        description: `Integration test is a pipeline with the goal to test each component individually and then once more together as one application.  
+
+Because every app is different, we leave it up to you to build the pipeline. Once it is ready, continue by adding the integration test through the interface. We will make sure it is integrated correctly within your application's CI/CD flow.  
+1. To add an integration test pipeline, go to the **Action** dropdown of your application and select "Add integration test".
+2. In the URL line, add a URL to your integration test pipeline.
+3. To ensure your app is only released when the test passes, mark the integration test as **Mandatory for Release**.`,
+      },
+      {
+        title: `Manage environments`,
+        description: `Now, we need to deploy your builds somewhere.  
+        Add a static environment, an environment available only on this workspace.  
+        This will be your development environment.  
+1. To add a static environment, go to the **Actions** dropdown of your application and select **Add environment**. 
+2. On the next page, select a static environment.
+3. On the Create Static environment page, complete all the mandatory input.
+4. Click **Create**.`,
+      },
+    ],
+    conclusion: `All done, your factory is ready!  
+
+Next you would want to:  
+
+- Connect to a managed environment to release your app to
+- Push some code, monitor its process
+
+In case you get lost, this guide is available for you on the Application **Actions** dropdown.`,
+  },
+};

--- a/src/hacbs/components/ApplicationDetails/DetailsPage.tsx
+++ b/src/hacbs/components/ApplicationDetails/DetailsPage.tsx
@@ -71,7 +71,7 @@ const DetailsPage: React.FC<DetailsPageProps> = ({
     () =>
       actions?.map((action) => {
         const { type, key, label, ...props } = action;
-        return type === 'seperator' ? (
+        return type === 'separator' ? (
           <DropdownSeparator key={key} />
         ) : (
           <DropdownItem key={key} {...props}>
@@ -124,6 +124,7 @@ const DetailsPage: React.FC<DetailsPageProps> = ({
                     Actions
                   </DropdownToggle>
                 }
+                onSelect={() => setIsOpen(!isOpen)}
                 isOpen={isOpen}
                 dropdownItems={dropdownItems}
               />

--- a/src/hacbs/components/ApplicationDetails/HacbsApplicationDetails.tsx
+++ b/src/hacbs/components/ApplicationDetails/HacbsApplicationDetails.tsx
@@ -1,10 +1,12 @@
-import * as React from 'react';
+import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { Bullseye, Spinner } from '@patternfly/react-core';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { NamespaceContext } from '../../../components/NamespacedPage/NamespacedPage';
 import { ApplicationGroupVersionKind } from '../../../models';
 import { ApplicationKind } from '../../../types';
+import { applicationQuickstartContent } from './ApplicationQuickstartContent';
 import DetailsPage from './DetailsPage';
 import ApplicationOverviewTab from './tabs/ApplicationOverviewTab';
 import CommitsTab from './tabs/CommitsTab';
@@ -19,12 +21,27 @@ type HacbsApplicationDetailsProps = {
 const HacbsApplicationDetails: React.FC<HacbsApplicationDetailsProps> = ({ applicationName }) => {
   const { namespace } = React.useContext(NamespaceContext);
   const navigate = useNavigate();
+  const { quickStarts } = useChrome();
+
   const [application, applicationsLoaded] = useK8sWatchResource<ApplicationKind>({
     groupVersionKind: ApplicationGroupVersionKind,
     name: applicationName,
     namespace,
   });
   const appDisplayName = application?.spec?.displayName || '';
+
+  useEffect(() => {
+    const hacbsShowAppQs = localStorage.getItem('hacbs/showApplicationQuickstart');
+    if (hacbsShowAppQs === null) {
+      localStorage.setItem('hacbs/showApplicationQuickstart', 'false');
+      // TODO Need to revisit once we have ability to add new quickstarts to an existing chrome store
+      // See https://issues.redhat.com/browse/RHCLOUD-20677
+      quickStarts.set('hac-dev', [applicationQuickstartContent]);
+      quickStarts.toggle('hacbs-getting-started-app');
+    }
+    // dependencies not needed since we only want to run once when component mounts
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const loading = (
     <Bullseye>
@@ -74,9 +91,17 @@ const HacbsApplicationDetails: React.FC<HacbsApplicationDetailsProps> = ({ appli
             isDisabled: true,
           },
           {
-            type: 'seperator',
-            key: 'seperator',
+            type: 'separator',
+            key: 'separator',
             label: '',
+          },
+          {
+            key: 'application-quickstart',
+            label: 'Getting started with an app',
+            onClick: () => {
+              quickStarts.set('hac-dev', [applicationQuickstartContent]);
+              quickStarts.toggle('hacbs-getting-started-app');
+            },
           },
           {
             key: 'learning-resources',

--- a/src/hacbs/components/ApplicationDetails/__tests__/HacbsApplicationDetails.spec.tsx
+++ b/src/hacbs/components/ApplicationDetails/__tests__/HacbsApplicationDetails.spec.tsx
@@ -2,8 +2,10 @@ import * as React from 'react';
 import '@testing-library/jest-dom';
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { render, screen, configure } from '@testing-library/react';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { mockApplication } from '../../../../components/ApplicationDetailsView/__data__/mock-data';
-import HacbApplicationDetails from '../HacbsApplicationDetails';
+import { applicationQuickstartContent } from '../ApplicationQuickstartContent';
+import HacbsApplicationDetails from '../HacbsApplicationDetails';
 
 jest.mock('react-router-dom', () => ({
   Link: (props) => <a href={props.to}>{props.children}</a>,
@@ -14,21 +16,74 @@ jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   useK8sWatchResource: jest.fn(),
 }));
 
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  useChrome: jest.fn(),
+}));
+
+const useChromeMock = useChrome as jest.Mock;
+
 configure({ testIdAttribute: 'data-test' });
 
 const watchResourceMock = useK8sWatchResource as jest.Mock;
 
-describe('HacbApplicationDetails', () => {
+describe('HacbsApplicationDetails', () => {
   it('should render spinner if application data is not loaded', () => {
     watchResourceMock.mockReturnValue([[], false]);
-    render(<HacbApplicationDetails applicationName="test" />);
+    const set = jest.fn();
+    const toggle = jest.fn();
+    useChromeMock.mockReturnValue({
+      quickStarts: { set, toggle },
+    });
+    render(<HacbsApplicationDetails applicationName="test" />);
     expect(screen.queryByTestId('spinner')).toBeInTheDocument();
   });
 
   it('should render application display name if application data is loaded', () => {
     watchResourceMock.mockReturnValueOnce([mockApplication, true]);
-    render(<HacbApplicationDetails applicationName="test" />);
+    const set = jest.fn();
+    const toggle = jest.fn();
+    useChromeMock.mockReturnValue({
+      quickStarts: { set, toggle },
+    });
+    render(<HacbsApplicationDetails applicationName="test" />);
     expect(screen.queryByTestId('details__title')).toBeInTheDocument();
     expect(screen.queryByTestId('details__title').innerHTML).toBe('Test Application');
+  });
+
+  it('should only display quick start on first run', () => {
+    const gsApp = 'hacbs-getting-started-app';
+    const chromeStore = 'hac-dev';
+
+    localStorage.removeItem('hacbs/showApplicationQuickstart');
+    let showQuickStart = localStorage.getItem('hacbs/showApplicationQuickstart');
+    expect(showQuickStart).toBeNull();
+    watchResourceMock.mockReturnValueOnce([mockApplication, true]);
+    const set = jest.fn();
+    const toggle = jest.fn();
+    useChromeMock.mockReturnValue({
+      quickStarts: { set, toggle },
+    });
+
+    render(<HacbsApplicationDetails applicationName="test" />);
+    showQuickStart = localStorage.getItem('hacbs/showApplicationQuickstart');
+    // localStorage key doesn't exist, quickstart set/toggle should be called
+    expect(showQuickStart).toEqual('false');
+    expect(set).toHaveBeenCalledWith(chromeStore, [applicationQuickstartContent]);
+    expect(toggle).toHaveBeenCalledWith(gsApp);
+    set.mockClear();
+    toggle.mockClear();
+
+    render(<HacbsApplicationDetails applicationName="test" />);
+    // localStorage key exists, quickstart set/toggle should not be called
+    expect(set).not.toHaveBeenCalled();
+    expect(toggle).not.toHaveBeenCalled();
+    set.mockClear();
+    toggle.mockClear();
+
+    localStorage.removeItem('hacbs/showApplicationQuickstart');
+    render(<HacbsApplicationDetails applicationName="test" />);
+    // localStorage key removed, quickstart set/toggle should be called
+    expect(set).toHaveBeenCalledWith(chromeStore, [applicationQuickstartContent]);
+    expect(toggle).toHaveBeenCalledWith(gsApp);
   });
 });


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HACBS-827


## Description
Displays a quickstart in a right-side panel the first time a new application has been successfully created in HACBS. On subsequent application creations, the quickstart is no longer shown.

## Type of change
- [x] Feature

## Screen shots / Gifs for design review 
**Screen shot:**
![app-qs](https://user-images.githubusercontent.com/39063664/182241624-54ea07b9-4dca-4d55-84ac-a36108dff744.png)

**Movie:**
https://user-images.githubusercontent.com/39063664/182902832-dc253e02-e4b7-4fd4-ac9a-7d5f2341525d.mov

## How to test or reproduce?
1. With HACBS active, create a new application. Upon successful completion, the quickstart will appear in a right-side panel. 2. When the quickstart is completed/dismissed, create another application. The quickstart will no longer appear when the application creation is completed.

## Browser conformance: 
- [x] Chrome
