### PR TITLE
Reset detected components if sample tile is deselected

### DIFF
--- a/src/components/ImportForm/SampleSection/SampleSection.tsx
+++ b/src/components/ImportForm/SampleSection/SampleSection.tsx
@@ -70,18 +70,23 @@ const SampleSection = ({ onStrategyChange }) => {
       setFieldValue('isValidated', false);
     }
 
-    if (!unmounted && !detectingComponents && detectedComponents) {
-      const transformedComponents = transformComponentValues(detectedComponents).map(
-        (component) => ({
-          ...component,
-          componentStub: {
-            ...component.componentStub,
-            componentName: `${component.componentStub.componentName}-sample`,
-          },
-        }),
-      );
-      setFieldValue('components', transformedComponents);
-      setFieldValue('isValidated', true);
+    if (!detectingComponents) {
+      if (detectedComponents) {
+        const transformedComponents = transformComponentValues(detectedComponents).map(
+          (component) => ({
+            ...component,
+            componentStub: {
+              ...component.componentStub,
+              componentName: `${component.componentStub.componentName}-sample`,
+            },
+          }),
+        );
+        setFieldValue('components', transformedComponents);
+        setFieldValue('isValidated', true);
+      } else {
+        setFieldValue('components', null);
+        setFieldValue('isValidated', false);
+      }
     }
 
     return () => {
@@ -93,6 +98,7 @@ const SampleSection = ({ onStrategyChange }) => {
     (item) => {
       setSelected((prevState) => {
         if (prevState?.name === item.name) {
+          setFieldValue('source', undefined);
           return undefined;
         }
         const sourceUrl = item?.attributes?.git?.remotes?.origin;

--- a/src/components/ImportForm/SampleSection/__tests__/SampleSection.spec.tsx
+++ b/src/components/ImportForm/SampleSection/__tests__/SampleSection.spec.tsx
@@ -36,7 +36,10 @@ const getDevfileMock = getDevfileSamples as jest.Mock;
 
 describe('SampleSection', () => {
   it('renders component samples page with a progressbar when samples are loading', async () => {
-    useFormikContextMock.mockReturnValue({ values: { source: '', application: { name: '' } } });
+    useFormikContextMock.mockReturnValue({
+      values: { source: '', application: { name: '' } },
+      setFieldValue: jest.fn(),
+    });
     getDevfileMock.mockReturnValue(Promise.resolve(null));
     render(<SampleSection onStrategyChange={onStrategyChangeMock} />);
     await screen.getByText('Select a sample');
@@ -44,7 +47,10 @@ describe('SampleSection', () => {
   });
 
   it('renders component samples page with an empty state when no samples are loaded', async () => {
-    useFormikContextMock.mockReturnValue({ values: { source: '', application: { name: '' } } });
+    useFormikContextMock.mockReturnValue({
+      values: { source: '', application: { name: '' } },
+      setFieldValue: jest.fn(),
+    });
     getDevfileMock.mockReturnValue(Promise.resolve([]));
     render(<SampleSection onStrategyChange={onStrategyChangeMock} />);
     await waitFor(() => {
@@ -53,7 +59,10 @@ describe('SampleSection', () => {
   });
 
   it('renders component samples page with nodejs sample tile', async () => {
-    useFormikContextMock.mockReturnValue({ values: { source: '', application: { name: '' } } });
+    useFormikContextMock.mockReturnValue({
+      values: { source: '', application: { name: '' } },
+      setFieldValue: jest.fn(),
+    });
     getDevfileMock.mockReturnValue(Promise.resolve([mockCatalogItem[0]]));
     render(<SampleSection onStrategyChange={onStrategyChangeMock} />);
     await waitFor(() => {
@@ -76,6 +85,47 @@ describe('SampleSection', () => {
 
     await waitFor(() => {
       expect(useComponentDetectionMock).toHaveBeenCalledWith('https://github.com/repo', 'test-app');
+    });
+  });
+
+  it('validates form after a sample is selected', async () => {
+    const setFieldValue = jest.fn();
+    useFormikContextMock.mockReturnValue({
+      values: { source: 'https://github.com/repo', application: 'test-app' },
+      setFieldValue,
+      setStatus: jest.fn(),
+    });
+    useComponentDetectionMock.mockReturnValue([[], true, null]);
+    getDevfileMock.mockReturnValue(Promise.resolve(mockCatalogItem));
+
+    render(<SampleSection onStrategyChange={onStrategyChangeMock} />);
+
+    await waitFor(() => fireEvent.click(screen.getByText('Basic Node.js')));
+
+    await waitFor(() => {
+      expect(setFieldValue).toHaveBeenLastCalledWith('isValidated', true);
+    });
+  });
+
+  it('unvalidates form after a selected sample is deselected', async () => {
+    const setFieldValue = jest.fn();
+    useFormikContextMock.mockReturnValue({
+      values: { source: 'https://github.com/repo', application: 'test-app' },
+      setFieldValue,
+      setStatus: jest.fn(),
+    });
+    useComponentDetectionMock.mockReturnValue([[], true, null]);
+    getDevfileMock.mockReturnValue(Promise.resolve(mockCatalogItem));
+
+    render(<SampleSection onStrategyChange={onStrategyChangeMock} />);
+
+    await waitFor(() => fireEvent.click(screen.getByText('Basic Node.js')));
+
+    useComponentDetectionMock.mockReturnValue([null, true, null]);
+    await waitFor(() => fireEvent.click(screen.getByText('Basic Node.js')));
+
+    await waitFor(() => {
+      expect(setFieldValue).toHaveBeenLastCalledWith('isValidated', false);
     });
   });
 });


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-1983
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
Detected components were not being reset if catalog tile is deselected.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

https://user-images.githubusercontent.com/20013884/182419900-3786d23f-c4a5-4819-954b-da507ec2e446.mp4

<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
Click the same sample tile twice
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
