### PR TITLE
Avoid creating binding when provider is unknown

### DIFF
--- a/src/components/ImportForm/SourceSection/SourceSection.tsx
+++ b/src/components/ImportForm/SourceSection/SourceSection.tsx
@@ -85,13 +85,18 @@ export const SourceSection: React.FC<SourceSectionProps> = ({ onStrategyChange }
       if (isRepoAccessible) {
         setFormValidated();
         isGit && setShowGitOptions(true);
-      } else if (
-        serviceProvider === ServiceProviderType.GitHub ||
-        serviceProvider === ServiceProviderType.Quay
-      ) {
-        setValidated(ValidatedOptions.error);
-        setHelpTextInvalid('Unable to access repository');
-        setShowAuthOptions(true);
+      } else {
+        if (
+          serviceProvider === ServiceProviderType.GitHub ||
+          serviceProvider === ServiceProviderType.Quay
+        ) {
+          setValidated(ValidatedOptions.error);
+          setHelpTextInvalid('Unable to access repository');
+          setShowAuthOptions(true);
+        } else if (!serviceProvider) {
+          setValidated(ValidatedOptions.error);
+          setHelpTextInvalid('This provider is not supported');
+        }
       }
     }
   }, [

--- a/src/components/ImportForm/SourceSection/__tests__/SourceSection.spec.tsx
+++ b/src/components/ImportForm/SourceSection/__tests__/SourceSection.spec.tsx
@@ -66,6 +66,15 @@ describe('SourceSection', () => {
     expect(screen.getByText('Unable to access repository')).toBeVisible();
   });
 
+  it('displays error when provider is not supported', async () => {
+    useAccessCheckMock.mockReturnValue([{ isRepoAccessible: false, serviceProvider: '' }, true]);
+
+    renderSourceSection();
+
+    expect(screen.getByPlaceholderText('Enter your source')).toBeInvalid();
+    expect(screen.getByText('This provider is not supported')).toBeVisible();
+  });
+
   it('validates input field when repo is accessible', async () => {
     useAccessCheckMock.mockReturnValue([
       { isRepoAccessible: true, serviceProvider: ServiceProviderType.GitHub },


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-1992
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
Avoid creating binding and show error message when a repo from unknown provider is used.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
![0](https://user-images.githubusercontent.com/20013884/183112027-27a09881-fbc8-4563-9d30-d15b51569cdc.png)

<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
Enter an unknown provider url.
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
