### PR TITLE
Add application environment details view

### DIFF
--- a/config/remotePlugin.js
+++ b/config/remotePlugin.js
@@ -45,6 +45,16 @@ const hacbs = {
       },
     },
     {
+      type: 'core.page/route',
+      properties: {
+        path: '/app-studio/application-environment-details',
+        exact: true,
+        component: {
+          $codeRef: 'ApplicationEnvironmentDetails',
+        },
+      },
+    },
+    {
       type: 'console.page/route',
       properties: {
         path: '/app-studio/import',
@@ -83,6 +93,10 @@ module.exports = {
 
       // App Studio
       Applications: resolve(__dirname, '../src/pages/ApplicationsPage'),
+      ApplicationEnvironmentDetails: resolve(
+        __dirname,
+        '../src/pages/ApplicationEnvironmentDetailsPage',
+      ),
       Import: resolve(__dirname, '../src/pages/ImportPage'),
       ComponentSettings: resolve(__dirname, '../src/pages/ComponentSettingsPage'),
       WorkspaceSettings: resolve(__dirname, '../src/pages/WorkspaceSettingsPage'),

--- a/config/remotePlugin.js
+++ b/config/remotePlugin.js
@@ -45,9 +45,29 @@ const hacbs = {
       },
     },
     {
+      type: 'console.page/route',
+      properties: {
+        path: '/app-studio/applications/:appName',
+        exact: true,
+        component: {
+          $codeRef: 'ApplicationDetails',
+        },
+      },
+    },
+    {
       type: 'core.page/route',
       properties: {
-        path: '/app-studio/application-environment-details',
+        path: '/app-studio/applications/:appName',
+        exact: true,
+        component: {
+          $codeRef: 'ApplicationDetails',
+        },
+      },
+    },
+    {
+      type: 'core.page/route',
+      properties: {
+        path: '/app-studio/applications/:appName/environments/:envName',
         exact: true,
         component: {
           $codeRef: 'ApplicationEnvironmentDetails',
@@ -93,6 +113,7 @@ module.exports = {
 
       // App Studio
       Applications: resolve(__dirname, '../src/pages/ApplicationsPage'),
+      ApplicationDetails: resolve(__dirname, '../src/pages/ApplicationDetailsPage'),
       ApplicationEnvironmentDetails: resolve(
         __dirname,
         '../src/pages/ApplicationEnvironmentDetailsPage',

--- a/src/components/ApplicationDetailsView/ApplicationDetailsView.tsx
+++ b/src/components/ApplicationDetailsView/ApplicationDetailsView.tsx
@@ -4,7 +4,6 @@ import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import {
   Bullseye,
   Button,
-  Divider,
   EmptyState,
   EmptyStateBody,
   EmptyStateIcon,
@@ -29,7 +28,6 @@ import { useModalLauncher } from '../modal/ModalProvider';
 import { applicationDeleteModal } from '../modal/resource-modals';
 import { OutlinedHelpPopperIcon } from '../OutlinedHelpTooltipIcon';
 import PageLayout from '../PageLayout/PageLayout';
-import { ComponentCard } from './ComponentCard';
 import { ComponentDetails } from './ComponentDetails';
 
 const GETTING_STARTED_CARD_KEY = 'application-details-getting-started';
@@ -78,6 +76,12 @@ const ApplicationDetailsView: React.FunctionComponent<ApplicationViewProps> = ({
     ],
     [application, applicationName, navigate, showModal],
   );
+
+  const navigateToEnvironment = (environmentName: string) => {
+    navigate(
+      `/app-studio/application-environment-details?application=${applicationName}&name=${environmentName}`,
+    );
+  };
 
   const loading = (
     <Bullseye>
@@ -134,20 +138,6 @@ const ApplicationDetailsView: React.FunctionComponent<ApplicationViewProps> = ({
       >
         <PageSection>
           <Flex>
-            <Flex direction={{ default: 'column' }}>
-              <FlexItem>
-                <b>Application components:</b>
-                {'  '}
-                <OutlinedHelpPopperIcon
-                  heading="Application components"
-                  content="Manage and add components from the components detail view. Note: Components from code repositories are rebuilt to capture the latest code changes. These updates will deploy to your development environment based on your deployment strategy."
-                />
-              </FlexItem>
-              <FlexItem>
-                <ComponentCard applicationName={applicationName} isExpanded={cardsExpanded} />
-              </FlexItem>
-            </Flex>
-            <Divider isVertical />
             <Flex direction={{ default: 'column' }} grow={{ default: 'grow' }}>
               <Flex>
                 <FlexItem>
@@ -169,9 +159,10 @@ const ApplicationDetailsView: React.FunctionComponent<ApplicationViewProps> = ({
                   </Button>
                 </FlexItem>
               </Flex>
-              <Flex>
-                <ApplicationEnvironmentCards isExpanded={cardsExpanded} />
-              </Flex>
+              <ApplicationEnvironmentCards
+                isExpanded={cardsExpanded}
+                onSelect={navigateToEnvironment}
+              />
             </Flex>
           </Flex>
         </PageSection>

--- a/src/components/ApplicationDetailsView/ApplicationDetailsView.tsx
+++ b/src/components/ApplicationDetailsView/ApplicationDetailsView.tsx
@@ -3,13 +3,10 @@ import { useNavigate } from 'react-router-dom';
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import {
   Bullseye,
-  Button,
   EmptyState,
   EmptyStateBody,
   EmptyStateIcon,
   EmptyStateVariant,
-  Flex,
-  FlexItem,
   PageSection,
   Spinner,
   Title,
@@ -26,7 +23,6 @@ import { GettingStartedCard } from '../GettingStartedCard/GettingStartedCard';
 import { HelpTopicLink } from '../HelpTopicLink/HelpTopicLink';
 import { useModalLauncher } from '../modal/ModalProvider';
 import { applicationDeleteModal } from '../modal/resource-modals';
-import { OutlinedHelpPopperIcon } from '../OutlinedHelpTooltipIcon';
 import PageLayout from '../PageLayout/PageLayout';
 import { ComponentDetails } from './ComponentDetails';
 
@@ -42,8 +38,6 @@ const ApplicationDetailsView: React.FunctionComponent<ApplicationViewProps> = ({
   const namespace = useNamespace();
   const showModal = useModalLauncher();
   const navigate = useNavigate();
-
-  const [cardsExpanded, setCardExpanded] = React.useState<boolean>(true);
 
   const resource = React.useMemo(() => {
     return {
@@ -135,32 +129,7 @@ const ApplicationDetailsView: React.FunctionComponent<ApplicationViewProps> = ({
         actions={actions}
       >
         <PageSection>
-          <Flex direction={{ default: 'column' }} grow={{ default: 'grow' }}>
-            <Flex>
-              <FlexItem>
-                <b>Environments:</b>
-                {'  '}
-                <OutlinedHelpPopperIcon
-                  heading="Application environments"
-                  content="View components and their settings as deployed to environments. Component updates can be promoted between environments. Additional environments can be added via the workspace."
-                />
-              </FlexItem>
-              <FlexItem align={{ default: 'alignRight' }}>
-                <Button
-                  onClick={() => setCardExpanded((e) => !e)}
-                  variant="link"
-                  isInline
-                  style={{ textDecoration: 'none' }}
-                >
-                  {cardsExpanded ? 'Collapse' : 'Expand'}
-                </Button>
-              </FlexItem>
-            </Flex>
-            <ApplicationEnvironmentCards
-              isExpanded={cardsExpanded}
-              onSelect={navigateToEnvironment}
-            />
-          </Flex>
+          <ApplicationEnvironmentCards onSelect={navigateToEnvironment} />
         </PageSection>
         <ComponentDetails application={application} />
       </PageLayout>

--- a/src/components/ApplicationDetailsView/ApplicationDetailsView.tsx
+++ b/src/components/ApplicationDetailsView/ApplicationDetailsView.tsx
@@ -78,9 +78,7 @@ const ApplicationDetailsView: React.FunctionComponent<ApplicationViewProps> = ({
   );
 
   const navigateToEnvironment = (environmentName: string) => {
-    navigate(
-      `/app-studio/application-environment-details?application=${applicationName}&name=${environmentName}`,
-    );
+    navigate(`/app-studio/applications/${applicationName}/environments/${environmentName}`);
   };
 
   const loading = (
@@ -137,33 +135,31 @@ const ApplicationDetailsView: React.FunctionComponent<ApplicationViewProps> = ({
         actions={actions}
       >
         <PageSection>
-          <Flex>
-            <Flex direction={{ default: 'column' }} grow={{ default: 'grow' }}>
-              <Flex>
-                <FlexItem>
-                  <b>Environments:</b>
-                  {'  '}
-                  <OutlinedHelpPopperIcon
-                    heading="Application environments"
-                    content="View components and their settings as deployed to environments. Component updates can be promoted between environments. Additional environments can be added via the workspace."
-                  />
-                </FlexItem>
-                <FlexItem align={{ default: 'alignRight' }}>
-                  <Button
-                    onClick={() => setCardExpanded((e) => !e)}
-                    variant="link"
-                    isInline
-                    style={{ textDecoration: 'none' }}
-                  >
-                    {cardsExpanded ? 'Collapse' : 'Expand'}
-                  </Button>
-                </FlexItem>
-              </Flex>
-              <ApplicationEnvironmentCards
-                isExpanded={cardsExpanded}
-                onSelect={navigateToEnvironment}
-              />
+          <Flex direction={{ default: 'column' }} grow={{ default: 'grow' }}>
+            <Flex>
+              <FlexItem>
+                <b>Environments:</b>
+                {'  '}
+                <OutlinedHelpPopperIcon
+                  heading="Application environments"
+                  content="View components and their settings as deployed to environments. Component updates can be promoted between environments. Additional environments can be added via the workspace."
+                />
+              </FlexItem>
+              <FlexItem align={{ default: 'alignRight' }}>
+                <Button
+                  onClick={() => setCardExpanded((e) => !e)}
+                  variant="link"
+                  isInline
+                  style={{ textDecoration: 'none' }}
+                >
+                  {cardsExpanded ? 'Collapse' : 'Expand'}
+                </Button>
+              </FlexItem>
             </Flex>
+            <ApplicationEnvironmentCards
+              isExpanded={cardsExpanded}
+              onSelect={navigateToEnvironment}
+            />
           </Flex>
         </PageSection>
         <ComponentDetails application={application} />

--- a/src/components/ApplicationDetailsView/ComponentListView.tsx
+++ b/src/components/ApplicationDetailsView/ComponentListView.tsx
@@ -115,7 +115,7 @@ const ComponentListView: React.FC<ComponentListViewProps> = ({ applicationName, 
                     |
                   </ToolbarItem>
                   <ToolbarItem>
-                    Deployment Strategy:{' '}
+                    Deployment strategy:{' '}
                     <Label>{getGitOpsDeploymentStrategy(gitOpsDeployment)}</Label>
                   </ToolbarItem>
                 </>

--- a/src/components/ApplicationDetailsView/__tests__/ApplicationDetailsView.spec.tsx
+++ b/src/components/ApplicationDetailsView/__tests__/ApplicationDetailsView.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import '@testing-library/jest-dom';
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { mockApplication } from '../__data__/mock-data';
 import { mockPipelineRuns } from '../__data__/mock-pipeline-run';
 import ApplicationDetailsView from '../ApplicationDetailsView';
@@ -51,18 +51,6 @@ describe('ApplicationDetailsView', () => {
     watchResourceMock.mockReturnValueOnce([mockApplication, true]).mockReturnValue([[], true]);
     render(<ApplicationDetailsView applicationName="test-application" />);
     screen.getAllByText('Test Application');
-  });
-
-  it('should render spinner if components data is not loaded', () => {
-    watchResourceMock.mockReturnValueOnce([mockApplication, true]).mockReturnValue([[], true]);
-    render(<ApplicationDetailsView applicationName="test-application" />);
-    const button = screen.getByText('Collapse');
-    expect(screen.queryByText('Build Succeeded')).toBeInTheDocument();
-    expect(screen.queryByText('Last Build')).toBeInTheDocument();
-    fireEvent.click(button);
-    screen.getByText('Expand');
-    expect(screen.queryByText('Succeeded')).toBeInTheDocument();
-    expect(screen.queryByText('Last Build')).not.toBeInTheDocument();
   });
 
   it('should show error state if application cannot be loaded', () => {

--- a/src/components/ApplicationEnvironment/ApplicationEnvironmentDetails.scss
+++ b/src/components/ApplicationEnvironment/ApplicationEnvironmentDetails.scss
@@ -1,0 +1,36 @@
+.application-environment-details  {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+
+  &__contents {
+    display: flex;
+    flex-direction: column;
+  }
+  &__toolbar {
+    border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
+    border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
+  }
+  .pf-c-data-list {
+    height: 100%;
+    width: 100%;
+  }
+
+  .pf-c-drawer__panel {
+    border-top: solid var(--pf-c-drawer__splitter--after--BorderColor);
+    border-top-width: var(--pf-global--BorderWidth--sm);
+  }
+  &__header-info {
+    background-color: var(--pf-c-page__main-section--m-light--BackgroundColor);
+    padding: 0 var(--pf-c-page__main-section--PaddingRight) var(--pf-global--spacer--sm) var(--pf-c-page__main-section--PaddingLeft);
+    &-item {
+      border-left: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
+      padding-left: var(--pf-global--spacer--md);
+      &:first-of-type {
+        border-left: 0;
+        padding-left: 0;
+      }
+    }
+  }
+}
+

--- a/src/components/ApplicationEnvironment/ApplicationEnvironmentDetails.scss
+++ b/src/components/ApplicationEnvironment/ApplicationEnvironmentDetails.scss
@@ -32,5 +32,8 @@
       }
     }
   }
+  &__health-status {
+    text-transform: lowercase;
+  }
 }
 

--- a/src/components/ApplicationEnvironment/ApplicationEnvironmentDetailsView.tsx
+++ b/src/components/ApplicationEnvironment/ApplicationEnvironmentDetailsView.tsx
@@ -184,14 +184,17 @@ export const ApplicationEnvironmentDetailsView: React.FC<ApplicationEnvironmentD
             gitOpsDeployment ? (
               <>
                 <FlexItem className="application-environment-details__header-info-item">
-                  {gitOpsDeploymentHealthStatusIcon} Application {gitOpsDeploymentHealthStatus}
+                  {gitOpsDeploymentHealthStatusIcon} Application{' '}
+                  <span className="application-environment-details__health-status">
+                    {gitOpsDeploymentHealthStatus}
+                  </span>
                 </FlexItem>
                 <FlexItem className="application-environment-details__header-info-item">
-                  Deployment Strategy:{' '}
+                  Deployment strategy:{' '}
                   <Label>{getEnvironmentDeploymentStrategyLabel(environment)}</Label>
                 </FlexItem>
                 <FlexItem className="application-environment-details__header-info-item">
-                  Last deploy: Nov 29, 2021 2:11 PM
+                  Last deployment: Nov 29, 2021 2:11 PM
                 </FlexItem>
               </>
             ) : null

--- a/src/components/ApplicationEnvironment/ApplicationEnvironmentDetailsView.tsx
+++ b/src/components/ApplicationEnvironment/ApplicationEnvironmentDetailsView.tsx
@@ -136,12 +136,18 @@ export const ApplicationEnvironmentDetailsView: React.FC<ApplicationEnvironmentD
   }, [components, selectedComponentId]);
 
   const loading = (
-    <Bullseye>
+    <Bullseye className="pf-u-mt-md">
       <Spinner />
     </Bullseye>
   );
 
-  if (applicationError || !applicationLoaded || environmentError || !environmentLoaded) {
+  if (
+    applicationError ||
+    !applicationLoaded ||
+    environmentError ||
+    !environmentLoaded ||
+    !componentsLoaded
+  ) {
     return loading;
   }
 

--- a/src/components/ApplicationEnvironment/ApplicationEnvironmentDetailsView.tsx
+++ b/src/components/ApplicationEnvironment/ApplicationEnvironmentDetailsView.tsx
@@ -60,7 +60,7 @@ type ApplicationEnvironmentDetailsProps = {
 const ApplicationEnvironmentDetailsEmptyState: React.FC<{ environmentName: string }> = ({
   environmentName,
 }) => (
-  <EmptyState variant={EmptyStateVariant.large}>
+  <EmptyState variant={EmptyStateVariant.large} data-testid="env-details-empty-state">
     <EmptyStateIcon icon={CubesIcon} />
     <Title headingLevel="h4" size="lg">
       No deployed components
@@ -83,8 +83,8 @@ export const ApplicationEnvironmentDetailsView: React.FC<ApplicationEnvironmentD
 }) => {
   const namespace = useNamespace();
   const [viewType, setViewType] = useSearchParam('view', 'list');
-  const [selectedId, setSelectedId] = useSearchParam('selected', '');
   const [nameFilter, setNameFilter] = React.useState<string>('');
+  const [selectedId, setSelectedId] = useSearchParam('selected', null);
   const [application, applicationLoaded, applicationError] = useK8sWatchResource<ApplicationKind>({
     groupVersionKind: ApplicationGroupVersionKind,
     name: applicationName,
@@ -136,6 +136,13 @@ export const ApplicationEnvironmentDetailsView: React.FC<ApplicationEnvironmentD
     return components.find((component) => component.metadata.uid === selectedId);
   }, [components, selectedId]);
 
+  const onSelect = React.useCallback(
+    (id: string) => {
+      setSelectedId(id === selectedId ? null : id || null);
+    },
+    [selectedId, setSelectedId],
+  );
+
   const loading = (
     <Bullseye className="pf-u-mt-md">
       <Spinner />
@@ -151,8 +158,6 @@ export const ApplicationEnvironmentDetailsView: React.FC<ApplicationEnvironmentD
   ) {
     return loading;
   }
-
-  const onSelect = (id: string) => setSelectedId(id === selectedId ? null : id);
 
   return (
     <PageLayout

--- a/src/components/ApplicationEnvironment/ApplicationEnvironmentDetailsView.tsx
+++ b/src/components/ApplicationEnvironment/ApplicationEnvironmentDetailsView.tsx
@@ -1,0 +1,296 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import {
+  Bullseye,
+  Button,
+  Drawer,
+  DrawerContent,
+  DrawerContentBody,
+  DrawerPanelContent,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  Flex,
+  FlexItem,
+  Label,
+  PageSection,
+  Panel,
+  Spinner,
+  StackItem,
+  TextInput,
+  Title,
+  ToggleGroup,
+  ToggleGroupItem,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+  Tooltip,
+} from '@patternfly/react-core';
+import { CubesIcon } from '@patternfly/react-icons/dist/esm/icons/cubes-icon';
+import { FilterIcon, ListIcon, TopologyIcon } from '@patternfly/react-icons/dist/js/icons';
+import { css } from '@patternfly/react-styles';
+import viewStyles from '@patternfly/react-styles/css/components/Topology/topology-view';
+import { useGitOpsDeploymentCR } from '../../hooks/useGitOpsDeploymentCR';
+import {
+  ApplicationGroupVersionKind,
+  ComponentGroupVersionKind,
+  EnvironmentGroupVersionKind,
+} from '../../models';
+import { ApplicationKind, ComponentKind, EnvironmentKind } from '../../types';
+import { getEnvironmentDeploymentStrategyLabel } from '../../utils/environment-utils';
+import { getGitOpsDeploymentHealthStatusIcon } from '../../utils/gitops-utils';
+import { useNamespace } from '../../utils/namespace-context-utils';
+import { HelpTopicLink } from '../HelpTopicLink/HelpTopicLink';
+import PageLayout from '../PageLayout/PageLayout';
+import ApplicationEnvironmentGraphView from './ApplicationEnvironmentGraphView';
+import ApplicationEnvironmentListView from './ApplicationEnvironmentListView';
+import ApplicationEnvironmentSidePanel from './ApplicationEnvironmentSidePanel';
+
+import './ApplicationEnvironmentDetails.scss';
+
+type ApplicationEnvironmentDetailsProps = {
+  applicationName: string;
+  environmentName: string;
+};
+
+const ApplicationEnvironmentDetailsEmptyState: React.FC<{ environmentName: string }> = ({
+  environmentName,
+}) => (
+  <EmptyState variant={EmptyStateVariant.large}>
+    <EmptyStateIcon icon={CubesIcon} />
+    <Title headingLevel="h4" size="lg">
+      No deployed components
+    </Title>
+    <EmptyStateBody>To get started, add some deploy components to your environment.</EmptyStateBody>
+    <Button
+      variant="primary"
+      component={(props) => (
+        <Link {...props} to={`/app-studio/import?environment=${environmentName}`} />
+      )}
+    >
+      Deploy Components
+    </Button>
+  </EmptyState>
+);
+
+export const ApplicationEnvironmentDetailsView: React.FC<ApplicationEnvironmentDetailsProps> = ({
+  applicationName,
+  environmentName,
+}) => {
+  const namespace = useNamespace();
+  const [nameFilter, setNameFilter] = React.useState<string>('');
+
+  const [application, applicationLoaded, applicationError] = useK8sWatchResource<ApplicationKind>({
+    groupVersionKind: ApplicationGroupVersionKind,
+    name: applicationName,
+    namespace,
+  });
+  const [environment, environmentLoaded, environmentError] = useK8sWatchResource<EnvironmentKind>({
+    groupVersionKind: EnvironmentGroupVersionKind,
+    namespace,
+    name: environmentName,
+  });
+
+  const [components, componentsLoaded] = useK8sWatchResource<ComponentKind[]>({
+    groupVersionKind: ComponentGroupVersionKind,
+    namespace,
+    isList: true,
+  });
+  const [gitOpsDeployment, gitOpsDeploymentLoaded] = useGitOpsDeploymentCR(
+    applicationName,
+    namespace,
+  );
+  const gitOpsDeploymentHealthStatus = gitOpsDeploymentLoaded
+    ? gitOpsDeployment?.status?.health?.status
+    : null;
+  const gitOpsDeploymentHealthStatusIcon = getGitOpsDeploymentHealthStatusIcon(
+    gitOpsDeploymentHealthStatus,
+  );
+
+  const filteredComponents = React.useMemo(() => {
+    if (!componentsLoaded || !components?.length) {
+      return [];
+    }
+
+    return components?.filter(
+      (c) =>
+        c.spec.application === applicationName &&
+        (!nameFilter || c.metadata.name.indexOf(nameFilter) !== -1),
+    );
+  }, [components, applicationName, componentsLoaded, nameFilter]);
+
+  const [selectedComponentId, setSelectedComponentId] = React.useState<string | null>(null);
+  const [showGraphView, setShowGraphView] = React.useState<boolean>(false);
+
+  const onClearFilters = () => setNameFilter('');
+  const onNameInput = (name: string) => setNameFilter(name);
+
+  const selectedComponent = React.useMemo(() => {
+    if (!components?.length) {
+      return undefined;
+    }
+    return components.find((component) => component.metadata.uid === selectedComponentId);
+  }, [components, selectedComponentId]);
+
+  const loading = (
+    <Bullseye>
+      <Spinner />
+    </Bullseye>
+  );
+
+  if (applicationError || !applicationLoaded || environmentError || !environmentLoaded) {
+    return loading;
+  }
+
+  const onSelect = (id: string) => setSelectedComponentId(id === selectedComponentId ? null : id);
+
+  return (
+    <PageLayout
+      breadcrumbs={[
+        { path: `/app-studio/applications`, name: 'Applications' },
+        {
+          path: `/app-studio/applications?name=${application?.metadata.name}`,
+          name: application?.spec?.displayName,
+        },
+        {
+          path: `/app-studio/environmentDetails/:${environment.metadata.name}`,
+          name: environment.metadata.name,
+        },
+      ]}
+      title={`${environment.spec.displayName} environment`}
+      description={
+        <>
+          Use the application environment view to access the specifics of the components deployed to
+          the environment. <HelpTopicLink topicId="app-view">Learn more</HelpTopicLink>
+        </>
+      }
+    >
+      <PageSection isFilled className="application-environment-details" style={{ paddingTop: 0 }}>
+        <Flex
+          className="application-environment-details__header-info"
+          justifyContent={{ default: 'justifyContentFlexEnd' }}
+        >
+          {gitOpsDeploymentLoaded ? (
+            gitOpsDeployment ? (
+              <>
+                <FlexItem className="application-environment-details__header-info-item">
+                  {gitOpsDeploymentHealthStatusIcon} Application {gitOpsDeploymentHealthStatus}
+                </FlexItem>
+                <FlexItem className="application-environment-details__header-info-item">
+                  Deployment Strategy:{' '}
+                  <Label>{getEnvironmentDeploymentStrategyLabel(environment)}</Label>
+                </FlexItem>
+                <FlexItem className="application-environment-details__header-info-item">
+                  Last deploy: Nov 29, 2021 2:11 PM
+                </FlexItem>
+              </>
+            ) : null
+          ) : (
+            <FlexItem className="application-environment-details__header-info-item">
+              <Spinner isSVG size="md" />
+            </FlexItem>
+          )}
+        </Flex>
+        <Panel className="application-environment-details__contents" style={{ height: '100%' }}>
+          {components.length === 0 ? (
+            <ApplicationEnvironmentDetailsEmptyState environmentName={environment.metadata.name} />
+          ) : (
+            <>
+              <Toolbar
+                data-testid="application-environment-details-toolbar"
+                className="application-environment-details__toolbar"
+                clearAllFilters={onClearFilters}
+              >
+                <ToolbarContent>
+                  <ToolbarGroup alignment={{ default: 'alignLeft' }}>
+                    <ToolbarItem>
+                      <Button variant="control">
+                        <FilterIcon /> {'Name'}
+                      </Button>
+                    </ToolbarItem>
+                    <ToolbarItem>
+                      <TextInput
+                        name="nameInput"
+                        data-testid="name-input-filter"
+                        type="search"
+                        aria-label="name filter"
+                        placeholder="Filter by name..."
+                        onChange={(name) => onNameInput(name)}
+                      />
+                    </ToolbarItem>
+                  </ToolbarGroup>
+                  <ToolbarGroup alignment={{ default: 'alignRight' }}>
+                    <ToolbarItem>
+                      <ToggleGroup aria-label="select view type">
+                        <Tooltip position="left" content="List view">
+                          <ToggleGroupItem
+                            icon={<ListIcon />}
+                            aria-label="list view"
+                            buttonId="application-environment-list-toggle"
+                            isSelected={!showGraphView}
+                            onChange={() => setShowGraphView((prev) => !prev)}
+                            data-testid="list-view-toggle"
+                          />
+                        </Tooltip>
+                        <Tooltip position="left" content="Graph view">
+                          <ToggleGroupItem
+                            icon={<TopologyIcon />}
+                            aria-label="graph view"
+                            buttonId="application-environment-graph-toggle"
+                            isSelected={showGraphView}
+                            onChange={() => setShowGraphView((prev) => !prev)}
+                            data-testid="graph-view-toggle"
+                          />
+                        </Tooltip>
+                      </ToggleGroup>
+                    </ToolbarItem>
+                  </ToolbarGroup>
+                </ToolbarContent>
+              </Toolbar>
+              <StackItem isFilled className={css(viewStyles.topologyContainer)}>
+                <Drawer isExpanded={!!selectedComponent} isInline>
+                  <DrawerContent
+                    panelContent={
+                      <DrawerPanelContent isResizable id="topology-resize-panel">
+                        {selectedComponent && (
+                          <ApplicationEnvironmentSidePanel
+                            component={selectedComponent}
+                            onClose={() => setSelectedComponentId(null)}
+                          />
+                        )}
+                      </DrawerPanelContent>
+                    }
+                  >
+                    <DrawerContentBody>
+                      {componentsLoaded ? (
+                        showGraphView ? (
+                          <ApplicationEnvironmentGraphView
+                            components={filteredComponents}
+                            selectedId={selectedComponentId}
+                            onSelect={onSelect}
+                          />
+                        ) : (
+                          <ApplicationEnvironmentListView
+                            components={filteredComponents}
+                            selectedId={selectedComponentId}
+                            onSelect={onSelect}
+                            applicationName={applicationName}
+                          />
+                        )
+                      ) : (
+                        loading
+                      )}
+                    </DrawerContentBody>
+                  </DrawerContent>
+                </Drawer>
+              </StackItem>
+            </>
+          )}
+        </Panel>
+      </PageSection>
+    </PageLayout>
+  );
+};

--- a/src/components/ApplicationEnvironment/ApplicationEnvironmentGraphView.tsx
+++ b/src/components/ApplicationEnvironment/ApplicationEnvironmentGraphView.tsx
@@ -1,0 +1,160 @@
+import * as React from 'react';
+import {
+  action,
+  createTopologyControlButtons,
+  defaultControlButtonsOptions,
+  isNode,
+  Model,
+  NodeModel,
+  SELECTION_EVENT,
+  SelectionEventListener,
+  TopologyControlBar,
+  TopologyView,
+  Visualization,
+  VisualizationProvider,
+  VisualizationSurface,
+} from '@patternfly/react-topology';
+import { ComponentKind } from '../../types';
+import componentFactory from './topology/factories/componentFactory';
+import { DEFAULT_LAYOUT, layoutFactory } from './topology/factories/layoutFactory';
+
+export const DEFAULT_NODE_PAD = 20;
+export const NODE_WIDTH = 104;
+export const NODE_HEIGHT = 104;
+export const NODE_PADDING = [0, DEFAULT_NODE_PAD];
+
+export const TOP_LAYER = 'top';
+export const GROUPS_LAYER = 'groups';
+export const DEFAULT_LAYER = 'default';
+export const BOTTOM_LAYER = 'bottom';
+
+export const DEFAULT_LAYERS = [BOTTOM_LAYER, GROUPS_LAYER, DEFAULT_LAYER, TOP_LAYER];
+
+const graphModel: Model = {
+  graph: {
+    id: 'topology-graph',
+    type: 'graph',
+    layout: DEFAULT_LAYOUT,
+    layers: DEFAULT_LAYERS,
+  },
+};
+
+type ApplicationEnvironmentGraphViewProps = {
+  components: ComponentKind[];
+  selectedId: string | null;
+  onSelect: (selected: string | null) => void;
+};
+
+const ApplicationEnvironmentGraphView: React.FC<ApplicationEnvironmentGraphViewProps> = ({
+  components,
+  selectedId,
+  onSelect,
+}) => {
+  const [model, setModel] = React.useState<Model>(graphModel);
+
+  const createVisualization = React.useCallback(() => {
+    const newVisualization = new Visualization();
+    newVisualization.registerLayoutFactory(layoutFactory);
+    newVisualization.registerComponentFactory(componentFactory);
+
+    newVisualization.fromModel(graphModel);
+    newVisualization.addEventListener<SelectionEventListener>(SELECTION_EVENT, (ids: string[]) => {
+      onSelect(ids[0]);
+    });
+    return newVisualization;
+  }, [onSelect]);
+
+  const visualizationRef = React.useRef<Visualization>();
+  if (!visualizationRef.current) {
+    visualizationRef.current = createVisualization();
+  }
+  const visualization = visualizationRef.current;
+
+  React.useEffect(() => {
+    if (components) {
+      const nodes: NodeModel[] = components.map((component) => ({
+        id: component.metadata.uid,
+        type: 'ComponentType',
+        label: component.metadata.name,
+        width: NODE_WIDTH,
+        height: NODE_HEIGHT,
+        group: false,
+        visible: true,
+        style: {
+          padding: NODE_PADDING,
+        },
+        data: {
+          component,
+        },
+      }));
+
+      setModel((prev) => ({ ...prev, nodes }));
+    }
+  }, [components]);
+
+  React.useEffect(() => {
+    visualization.fromModel(model);
+    const selectedItem = selectedId ? visualization.getElementById(selectedId) : null;
+    if (model.nodes?.length && (!selectedItem || !selectedItem.isVisible())) {
+      onSelect(null);
+    }
+    // don't update on selection change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [model, visualization]);
+
+  React.useEffect(() => {
+    let resizeTimeout = null;
+    if (visualization) {
+      const selectedEntity = visualization.getElementById(selectedId);
+      if (selectedEntity && isNode(selectedEntity)) {
+        resizeTimeout = setTimeout(
+          action(() => {
+            visualization
+              .getGraph()
+              .panIntoView(selectedEntity, { offset: 20, minimumVisible: 100 });
+            resizeTimeout = null;
+          }),
+          500,
+        );
+      }
+    }
+    return () => {
+      if (resizeTimeout) {
+        clearTimeout(resizeTimeout);
+      }
+    };
+  }, [selectedId, visualization]);
+
+  return (
+    <VisualizationProvider controller={visualization}>
+      <TopologyView
+        controlBar={
+          <TopologyControlBar
+            controlButtons={createTopologyControlButtons({
+              ...defaultControlButtonsOptions,
+              zoomInCallback: action(() => {
+                visualization.getGraph().scaleBy(4 / 3);
+              }),
+              zoomOutCallback: action(() => {
+                visualization.getGraph().scaleBy(0.75);
+              }),
+              fitToScreenCallback: action(() => {
+                visualization.getGraph().fit(80);
+              }),
+              resetViewCallback: action(() => {
+                visualization.getGraph().reset();
+                visualization.getGraph().layout();
+              }),
+              legend: false,
+            })}
+          />
+        }
+        data-testid="application-environment-graph"
+      >
+        <VisualizationSurface state={{ selectedIds: [selectedId] }} />
+      </TopologyView>
+    </VisualizationProvider>
+  );
+};
+
+export default ApplicationEnvironmentGraphView;

--- a/src/components/ApplicationEnvironment/ApplicationEnvironmentGraphView.tsx
+++ b/src/components/ApplicationEnvironment/ApplicationEnvironmentGraphView.tsx
@@ -51,18 +51,23 @@ const ApplicationEnvironmentGraphView: React.FC<ApplicationEnvironmentGraphViewP
   onSelect,
 }) => {
   const [model, setModel] = React.useState<Model>(graphModel);
+  const handleSelection = React.useRef<(selected: string | null) => void>(onSelect);
 
-  const createVisualization = React.useCallback(() => {
+  React.useEffect(() => {
+    handleSelection.current = onSelect;
+  }, [onSelect]);
+
+  const createVisualization = () => {
     const newVisualization = new Visualization();
     newVisualization.registerLayoutFactory(layoutFactory);
     newVisualization.registerComponentFactory(componentFactory);
 
     newVisualization.fromModel(graphModel);
-    newVisualization.addEventListener<SelectionEventListener>(SELECTION_EVENT, (ids: string[]) => {
-      onSelect(ids[0]);
-    });
+    newVisualization.addEventListener<SelectionEventListener>(SELECTION_EVENT, (ids: string[]) =>
+      handleSelection.current(ids[0] || ''),
+    );
     return newVisualization;
-  }, [onSelect]);
+  };
 
   const visualizationRef = React.useRef<Visualization>();
   if (!visualizationRef.current) {

--- a/src/components/ApplicationEnvironment/ApplicationEnvironmentListItem.scss
+++ b/src/components/ApplicationEnvironment/ApplicationEnvironmentListItem.scss
@@ -1,0 +1,15 @@
+.environment-list-item {
+  &__details {
+    margin-left: 72px;
+  }
+  &__breadcrumb-link {
+    color: var(--pf-global--secondary-color--100);
+    font-size: var(--pf-c-breadcrumb__item--FontSize);
+    .pf-c-label {
+      font-size: 12px;
+    }
+    .pf-c-label__icon {
+      color: var(--pf-global--primary-color--100);
+    }
+  }
+}

--- a/src/components/ApplicationEnvironment/ApplicationEnvironmentListItem.tsx
+++ b/src/components/ApplicationEnvironment/ApplicationEnvironmentListItem.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import {
+  DataListAction,
+  DataListCell,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
+  Flex,
+  FlexItem,
+  Tooltip,
+} from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
+import ActionMenu from '../../shared/components/action-menu/ActionMenu';
+import ExternalLink from '../../shared/components/links/ExternalLink';
+import { ComponentKind, RouteKind } from '../../types';
+import { getComponentRouteWebURL } from '../../utils/route-utils';
+import { useComponentActions } from '../ApplicationDetailsView/component-actions';
+import ApplicationEnvironmentRevisionLink from './ApplicationEnvironmentRevisionLink';
+
+import './ApplicationEnvironmentListItem.scss';
+
+type ApplicationEnvironmentListViewPageProps = {
+  component: ComponentKind;
+  routes?: RouteKind[];
+};
+
+export const ApplicationEnvironmentListItem: React.FC<ApplicationEnvironmentListViewPageProps> = ({
+  component,
+  routes,
+}) => {
+  const { name, uid } = component.metadata;
+  const actions = useComponentActions(component, name);
+  const componentRouteWebURL = routes?.length > 0 && getComponentRouteWebURL(routes, name);
+  const containerImage = component.status?.containerImage;
+
+  const imageNameParts = containerImage.split('/');
+  const imageName = imageNameParts[imageNameParts.length - 1];
+
+  return (
+    <DataListItem id={uid} aria-label={name} data-testid="application-environment-list-item">
+      <DataListItemRow>
+        <DataListItemCells
+          dataListCells={[
+            <DataListCell key="name" width={1}>
+              <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+                <FlexItem>
+                  <b>{name}</b>
+                </FlexItem>
+                <FlexItem>
+                  <Tooltip content="Route">
+                    <ExternalLink href={componentRouteWebURL} text={<ExternalLinkAltIcon />} />
+                  </Tooltip>
+                </FlexItem>
+              </Flex>
+            </DataListCell>,
+            <DataListCell key="revision" width={2}>
+              <ApplicationEnvironmentRevisionLink component={component} />
+            </DataListCell>,
+            <DataListCell key="image" width={2}>
+              <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+                <FlexItem>Image:</FlexItem>
+                <FlexItem>
+                  <ExternalLink href={`https://${containerImage}`} text={imageName} />
+                </FlexItem>
+              </Flex>
+            </DataListCell>,
+          ]}
+        />
+        <DataListAction
+          aria-labelledby={`${name.toLowerCase()}-actions`}
+          data-testid={`${name.toLowerCase()}-actions`}
+          id={`${name.toLowerCase()}-actions`}
+          aria-label={`${name.toLowerCase()}-actions`}
+          isPlainButtonAction
+        >
+          <ActionMenu actions={actions} />
+        </DataListAction>
+      </DataListItemRow>
+    </DataListItem>
+  );
+};

--- a/src/components/ApplicationEnvironment/ApplicationEnvironmentListItem.tsx
+++ b/src/components/ApplicationEnvironment/ApplicationEnvironmentListItem.tsx
@@ -48,7 +48,11 @@ export const ApplicationEnvironmentListItem: React.FC<ApplicationEnvironmentList
                 </FlexItem>
                 <FlexItem>
                   <Tooltip content="Route">
-                    <ExternalLink href={componentRouteWebURL} text={<ExternalLinkAltIcon />} />
+                    <ExternalLink
+                      href={componentRouteWebURL}
+                      text={<ExternalLinkAltIcon />}
+                      stopPropagation
+                    />
                   </Tooltip>
                 </FlexItem>
               </Flex>
@@ -60,7 +64,11 @@ export const ApplicationEnvironmentListItem: React.FC<ApplicationEnvironmentList
               <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                 <FlexItem>Image:</FlexItem>
                 <FlexItem>
-                  <ExternalLink href={`https://${containerImage}`} text={imageName} />
+                  <ExternalLink
+                    href={`https://${containerImage}`}
+                    text={imageName}
+                    stopPropagation
+                  />
                 </FlexItem>
               </Flex>
             </DataListCell>,

--- a/src/components/ApplicationEnvironment/ApplicationEnvironmentListView.tsx
+++ b/src/components/ApplicationEnvironment/ApplicationEnvironmentListView.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { DataList } from '@patternfly/react-core';
+import { useApplicationRoutes } from '../../hooks';
+import { ComponentKind } from '../../types';
+import { useNamespace } from '../../utils/namespace-context-utils';
+import { ApplicationEnvironmentListItem } from './ApplicationEnvironmentListItem';
+
+type ApplicationEnvironmentListViewProps = {
+  applicationName: string;
+  components: ComponentKind[];
+  selectedId: string | null;
+  onSelect?: (selected: string | null) => void;
+};
+
+const ApplicationEnvironmentListView: React.FC<ApplicationEnvironmentListViewProps> = ({
+  applicationName,
+  components,
+  selectedId,
+  onSelect,
+}) => {
+  const namespace = useNamespace();
+  const [routes] = useApplicationRoutes(applicationName, namespace);
+
+  return (
+    <DataList
+      className="application-environment-details__list-view"
+      aria-label="Components"
+      data-testid="application-environment-list"
+      selectedDataListItemId={selectedId}
+      onSelectDataListItem={onSelect}
+    >
+      {components?.map((component) => (
+        <ApplicationEnvironmentListItem
+          key={component.metadata.uid}
+          component={component}
+          routes={routes}
+        />
+      ))}
+    </DataList>
+  );
+};
+
+export default ApplicationEnvironmentListView;

--- a/src/components/ApplicationEnvironment/ApplicationEnvironmentRevisionLink.tsx
+++ b/src/components/ApplicationEnvironment/ApplicationEnvironmentRevisionLink.tsx
@@ -10,9 +10,20 @@ const ApplicationEnvironmentRevisionLink: React.FC<{ component: ComponentKind }>
   return (
     <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsXs' }}>
       <FlexItem>
-        <Label variant="outline" icon={<GithubIcon />}>
-          72c1a29
-        </Label>
+        <ExternalLink
+          href={
+            component.spec.source?.git?.url ||
+            (component.spec.containerImage.includes('http')
+              ? component.spec.containerImage
+              : `https://${component.spec.containerImage}`)
+          }
+          text={
+            <Label variant="outline" icon={<GithubIcon />}>
+              72c1a29
+            </Label>
+          }
+          stopPropagation
+        />
       </FlexItem>
       <FlexItem>
         <Flex spaceItems={{ default: 'spaceItemsSm' }}>
@@ -29,6 +40,7 @@ const ApplicationEnvironmentRevisionLink: React.FC<{ component: ComponentKind }>
                   <b>#196</b> Linter updates
                 </span>
               }
+              stopPropagation
             />
           </FlexItem>
           <FlexItem>
@@ -41,6 +53,7 @@ const ApplicationEnvironmentRevisionLink: React.FC<{ component: ComponentKind }>
                   : `https://${component.spec.containerImage}`)
               }
               text="by e_cary"
+              stopPropagation
             />
           </FlexItem>
         </Flex>

--- a/src/components/ApplicationEnvironment/ApplicationEnvironmentRevisionLink.tsx
+++ b/src/components/ApplicationEnvironment/ApplicationEnvironmentRevisionLink.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { Flex, FlexItem, Label } from '@patternfly/react-core';
+import { GithubIcon } from '@patternfly/react-icons/dist/esm/icons/github-icon';
+import ExternalLink from '../../shared/components/links/ExternalLink';
+import { ComponentKind } from '../../types';
+
+const ApplicationEnvironmentRevisionLink: React.FC<{ component: ComponentKind }> = ({
+  component,
+}) => {
+  return (
+    <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsXs' }}>
+      <FlexItem>
+        <Label variant="outline" icon={<GithubIcon />}>
+          72c1a29
+        </Label>
+      </FlexItem>
+      <FlexItem>
+        <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+          <FlexItem>
+            <ExternalLink
+              href={
+                component.spec.source?.git?.url ||
+                (component.spec.containerImage.includes('http')
+                  ? component.spec.containerImage
+                  : `https://${component.spec.containerImage}`)
+              }
+              text={
+                <span>
+                  <b>#196</b> Linter updates
+                </span>
+              }
+            />
+          </FlexItem>
+          <FlexItem>
+            <ExternalLink
+              additionalClassName="environment-list-item__breadcrumb-link"
+              href={
+                component.spec.source?.git?.url ||
+                (component.spec.containerImage.includes('http')
+                  ? component.spec.containerImage
+                  : `https://${component.spec.containerImage}`)
+              }
+              text="by e_cary"
+            />
+          </FlexItem>
+        </Flex>
+      </FlexItem>
+    </Flex>
+  );
+};
+
+export default ApplicationEnvironmentRevisionLink;

--- a/src/components/ApplicationEnvironment/ApplicationEnvironmentSidePanel.scss
+++ b/src/components/ApplicationEnvironment/ApplicationEnvironmentSidePanel.scss
@@ -1,0 +1,34 @@
+.application-environment-details__component-side-panel {
+  .pf-c-drawer__actions {
+    justify-content: flex-end;
+    padding-top: var(--pf-global--spacer--md);
+    padding-right: var(--pf-global--spacer--md);
+  }
+  .pf-c-drawer__body:first-of-type {
+    padding: 0;
+  }
+  &__header {
+    padding-top: 5px;
+  }
+  &__header-heading {
+    display: flex;
+    justify-content: space-between;
+    font-size: var(--pf-global--FontSize--xl);
+    padding: 0 var(--pf-c-drawer--child--PaddingRight) 0 var(--pf-c-drawer--child--PaddingLeft);
+  }
+
+  &__actions {
+    align-items: flex-end;
+    display: flex;
+    margin-top: -3px;
+    @media(max-width: 480px){
+      flex-direction: column;
+    }
+  }
+
+  &__name {
+    min-width: 0; // required by FF and Edge
+    overflow-wrap: break-word; // new name as per the CSS3 spec
+    word-break: break-word; // required by FF and Edge
+  }
+}

--- a/src/components/ApplicationEnvironment/ApplicationEnvironmentSidePanel.tsx
+++ b/src/components/ApplicationEnvironment/ApplicationEnvironmentSidePanel.tsx
@@ -101,18 +101,20 @@ const ApplicationEnvironmentSidePanel: React.FC<EnvironmentSidePanelProps> = ({
               </DescriptionListDescription>
             </DescriptionListGroup>
           )}
-          <DescriptionListGroup>
-            <Flex spaceItems={{ default: 'spaceItems4xl' }}>
-              <FlexItem>
-                <DescriptionListTerm>CPU</DescriptionListTerm>
-                <DescriptionListDescription>{resourceRequests.cpu}</DescriptionListDescription>
-              </FlexItem>
-              <FlexItem>
-                <DescriptionListTerm>Memory</DescriptionListTerm>
-                <DescriptionListDescription>{resourceRequests.memory}</DescriptionListDescription>
-              </FlexItem>
-            </Flex>
-          </DescriptionListGroup>
+          {resourceRequests && (
+            <DescriptionListGroup>
+              <Flex spaceItems={{ default: 'spaceItems4xl' }}>
+                <FlexItem>
+                  <DescriptionListTerm>CPU</DescriptionListTerm>
+                  <DescriptionListDescription>{resourceRequests.cpu}</DescriptionListDescription>
+                </FlexItem>
+                <FlexItem>
+                  <DescriptionListTerm>Memory</DescriptionListTerm>
+                  <DescriptionListDescription>{resourceRequests.memory}</DescriptionListDescription>
+                </FlexItem>
+              </Flex>
+            </DescriptionListGroup>
+          )}
           <DescriptionListGroup>
             <DescriptionListTerm>Instances</DescriptionListTerm>
             <DescriptionListDescription>{replicas}</DescriptionListDescription>

--- a/src/components/ApplicationEnvironment/ApplicationEnvironmentSidePanel.tsx
+++ b/src/components/ApplicationEnvironment/ApplicationEnvironmentSidePanel.tsx
@@ -1,0 +1,142 @@
+import * as React from 'react';
+import {
+  Bullseye,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DrawerActions,
+  DrawerCloseButton,
+  DrawerPanelBody,
+  Flex,
+  FlexItem,
+  Spinner,
+} from '@patternfly/react-core';
+import { TopologySideBar } from '@patternfly/react-topology';
+import { useApplicationRoutes } from '../../hooks';
+import { ApplicationGroupVersionKind } from '../../models';
+import ExternalLink from '../../shared/components/links/ExternalLink';
+import { ComponentKind } from '../../types';
+import { useNamespace } from '../../utils/namespace-context-utils';
+import { getComponentRouteWebURL } from '../../utils/route-utils';
+import ApplicationEnvironmentRevisionLink from './ApplicationEnvironmentRevisionLink';
+import SidePanelActionMenu from './SidePanelActionMenu';
+
+import './ApplicationEnvironmentSidePanel.scss';
+
+type EnvironmentSidePanelProps = {
+  component: ComponentKind;
+  onClose: () => void;
+};
+
+const ApplicationEnvironmentSidePanel: React.FC<EnvironmentSidePanelProps> = ({
+  component,
+  onClose,
+}) => {
+  const { resources, replicas } = component.spec;
+  const namespace = useNamespace();
+  const applicationName = component.metadata?.ownerReferences?.find(
+    (ref) => ref.kind === ApplicationGroupVersionKind.kind,
+  )?.name;
+  const name = component.metadata.name;
+  const resourceRequests = resources?.requests;
+  const containerImage = component.status?.containerImage;
+  const [routes, routesLoaded] = useApplicationRoutes(applicationName, namespace);
+  const componentRouteWebURL = routes?.length > 0 && getComponentRouteWebURL(routes, name);
+
+  return (
+    <TopologySideBar
+      resizable
+      className="application-environment-details__component-side-panel pf-topology-side-bar-resizable"
+    >
+      <DrawerActions>
+        <DrawerCloseButton onClick={onClose} />
+      </DrawerActions>
+      <div className="application-environment-details__component-side-panel__header">
+        <h1 className="application-environment-details__component-side-panel__header-heading">
+          <div className="application-environment-details__component-side-panel__name">{name}</div>
+          <div className="application-environment-details__component-side-panel__actions">
+            <SidePanelActionMenu component={component} />
+          </div>
+        </h1>
+      </div>
+      <DrawerPanelBody>
+        <DescriptionList
+          columnModifier={{
+            default: '1Col',
+          }}
+        >
+          {routesLoaded ? (
+            <>
+              {componentRouteWebURL && (
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Route</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <ExternalLink href={componentRouteWebURL} text={componentRouteWebURL} />
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              )}
+            </>
+          ) : (
+            <DescriptionListGroup>
+              <DescriptionListTerm>Route</DescriptionListTerm>
+              <DescriptionListDescription>
+                <Bullseye>
+                  <Spinner size="md" />
+                </Bullseye>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          )}
+          <DescriptionListGroup>
+            <DescriptionListTerm>Revision</DescriptionListTerm>
+            <DescriptionListDescription>
+              <ApplicationEnvironmentRevisionLink component={component} />
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          {containerImage && (
+            <DescriptionListGroup>
+              <DescriptionListTerm>Image</DescriptionListTerm>
+              <DescriptionListDescription>
+                <ExternalLink href={`https://${containerImage}`} text={containerImage} />
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          )}
+          <DescriptionListGroup>
+            <Flex spaceItems={{ default: 'spaceItems4xl' }}>
+              <FlexItem>
+                <DescriptionListTerm>CPU</DescriptionListTerm>
+                <DescriptionListDescription>{resourceRequests.cpu}</DescriptionListDescription>
+              </FlexItem>
+              <FlexItem>
+                <DescriptionListTerm>Memory</DescriptionListTerm>
+                <DescriptionListDescription>{resourceRequests.memory}</DescriptionListDescription>
+              </FlexItem>
+            </Flex>
+          </DescriptionListGroup>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Instances</DescriptionListTerm>
+            <DescriptionListDescription>{replicas}</DescriptionListDescription>
+          </DescriptionListGroup>
+          {resourceRequests && (
+            <DescriptionListGroup>
+              <DescriptionListTerm>Code repository</DescriptionListTerm>
+              <DescriptionListDescription>
+                <ExternalLink
+                  href={
+                    component.spec.source?.git?.url ||
+                    (component.spec.containerImage.includes('http')
+                      ? component.spec.containerImage
+                      : `https://${component.spec.containerImage}`)
+                  }
+                  text={component.spec.source?.git?.url || component.spec.containerImage}
+                />
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          )}
+        </DescriptionList>
+      </DrawerPanelBody>
+    </TopologySideBar>
+  );
+};
+
+export default ApplicationEnvironmentSidePanel;

--- a/src/components/ApplicationEnvironment/ApplicationEnvironmentSidePanel.tsx
+++ b/src/components/ApplicationEnvironment/ApplicationEnvironmentSidePanel.tsx
@@ -115,10 +115,12 @@ const ApplicationEnvironmentSidePanel: React.FC<EnvironmentSidePanelProps> = ({
               </Flex>
             </DescriptionListGroup>
           )}
-          <DescriptionListGroup>
-            <DescriptionListTerm>Instances</DescriptionListTerm>
-            <DescriptionListDescription>{replicas}</DescriptionListDescription>
-          </DescriptionListGroup>
+          {replicas !== undefined && (
+            <DescriptionListGroup>
+              <DescriptionListTerm>Instances</DescriptionListTerm>
+              <DescriptionListDescription>{replicas}</DescriptionListDescription>
+            </DescriptionListGroup>
+          )}
           {resourceRequests && (
             <DescriptionListGroup>
               <DescriptionListTerm>Code repository</DescriptionListTerm>

--- a/src/components/ApplicationEnvironment/SidePanelActionMenu.tsx
+++ b/src/components/ApplicationEnvironment/SidePanelActionMenu.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Dropdown, DropdownItem, DropdownPosition, DropdownToggle } from '@patternfly/react-core';
+import { CaretDownIcon } from '@patternfly/react-icons/dist/esm/icons/caret-down-icon';
+import isFunction from 'lodash/isFunction';
+import isObject from 'lodash/isObject';
+import { Action } from '../../shared/components/action-menu/types';
+import { ComponentKind } from '../../types';
+import { useComponentActions } from '../ApplicationDetailsView/component-actions';
+
+const SidePanelActionMenu: React.FC<{ component: ComponentKind }> = ({ component }) => {
+  const navigate = useNavigate();
+  const actions = useComponentActions(component, component.metadata.name);
+  const [active, setActive] = React.useState<boolean>(false);
+
+  const dropdownItems = React.useMemo(() => {
+    if (!actions) {
+      return [];
+    }
+    const handleActionClick = (
+      event: MouseEvent | React.MouseEvent<any, MouseEvent> | React.KeyboardEvent<Element>,
+      action: Action,
+    ): void => {
+      event.preventDefault();
+      if (isFunction(action.cta)) {
+        action.cta();
+      } else if (isObject(action.cta)) {
+        if (!action.cta.external) {
+          navigate(action.cta.href);
+        }
+      }
+    };
+    return actions.map((action) => (
+      <DropdownItem
+        key={action.id}
+        icon={action.icon}
+        onClick={(e) => handleActionClick(e, action)}
+      >
+        {action.label}
+      </DropdownItem>
+    ));
+  }, [actions, navigate]);
+
+  const onSelect = () => {
+    setActive(false);
+  };
+
+  if (!dropdownItems) {
+    return null;
+  }
+
+  return (
+    <Dropdown
+      onSelect={onSelect}
+      toggle={
+        <DropdownToggle
+          id="toggle-router-link"
+          onToggle={() => setActive((prev) => !prev)}
+          toggleIndicator={CaretDownIcon}
+        >
+          Actions
+        </DropdownToggle>
+      }
+      position={DropdownPosition.right}
+      data-test-id="actions-menu-button"
+      isOpen={active}
+      dropdownItems={dropdownItems}
+    />
+  );
+};
+
+export default SidePanelActionMenu;

--- a/src/components/ApplicationEnvironment/__data__/mock-data.ts
+++ b/src/components/ApplicationEnvironment/__data__/mock-data.ts
@@ -61,7 +61,13 @@ export const mockComponents: ComponentKind[] = [
         containerImage: '',
       },
       componentName: 'basic-node-js',
-      resources: {},
+      replicas: 1,
+      resources: {
+        requests: {
+          cpu: '10m',
+          memory: '50Mi',
+        },
+      },
       source: {
         git: {
           url: 'https://github.com/nodeshift-starters/devfile-sample.git',
@@ -131,6 +137,88 @@ export const mockComponents: ComponentKind[] = [
       gitops: {
         repositoryURL:
           'https://github.com/redhat-appstudio-appdata/test-application-rorai-hold-control',
+      },
+    },
+  },
+];
+export const mockGitOpsDeployments = [
+  {
+    apiVersion: 'managed-gitops.redhat.com/v1alpha1',
+    kind: 'GitOpsDeployment',
+    metadata: {
+      creationTimestamp: '2022-06-01T14:00:56Z',
+      generation: 1,
+      labels: {
+        'appstudio.application.name': 'application-to-test-git-ops',
+      },
+      name: 'application-to-test-git-ops-deployment',
+      namespace: 'sbudhwar-1',
+      ownerReferences: [
+        {
+          apiVersion: 'appstudio.redhat.com/v1alpha1',
+          kind: 'Application',
+          name: 'application-to-test-git-ops',
+          uid: '1935564f-c9a0-4ed5-acea-22ce1315311c',
+        },
+      ],
+      resourceVersion: '548372841',
+      uid: '85fba8b1-a728-4aed-9d17-c874d14c512e',
+    },
+    spec: {
+      destination: {},
+      source: {
+        path: './',
+        repoURL:
+          'https://github.com/redhat-appstudio-appdata/application-to-test-git-ops-sbudhwar-1-rise-stop',
+      },
+      type: 'automated',
+    },
+    status: {
+      health: {
+        status: 'Healthy',
+      },
+      sync: {
+        status: 'Unknown',
+      },
+    },
+  },
+  {
+    apiVersion: 'managed-gitops.redhat.com/v1alpha1',
+    kind: 'GitOpsDeployment',
+    metadata: {
+      creationTimestamp: '2022-06-01T14:00:56Z',
+      generation: 1,
+      labels: {
+        'appstudio.application.name': 'application-to-test',
+      },
+      name: 'application-to-test-deployment',
+      namespace: 'sbudhwar-1',
+      ownerReferences: [
+        {
+          apiVersion: 'appstudio.redhat.com/v1alpha1',
+          kind: 'Application',
+          name: 'application-to-test',
+          uid: '1935564f-c9a0-4ed5-acea-22ce1315311c',
+        },
+      ],
+      resourceVersion: '548372841',
+      uid: '85fba8b1-a728-4aed-9d17-c874d14c512e',
+    },
+    spec: {
+      destination: {},
+      source: {
+        path: './',
+        repoURL:
+          'https://github.com/redhat-appstudio-appdata/application-to-test-git-ops-sbudhwar-1-rise-stop',
+      },
+      type: 'automated',
+    },
+    status: {
+      health: {
+        status: 'Degraded',
+      },
+      sync: {
+        status: 'Unknown',
       },
     },
   },

--- a/src/components/ApplicationEnvironment/__data__/mock-data.ts
+++ b/src/components/ApplicationEnvironment/__data__/mock-data.ts
@@ -1,0 +1,137 @@
+import { ComponentKind, EnvironmentKind } from '../../../types';
+
+export const mockApplication = {
+  apiVersion: 'appstudio.redhat.com/v1alpha1',
+  kind: 'Application',
+  metadata: {
+    annotations: {
+      finalizeCount: '0',
+    },
+    creationTimestamp: '2022-04-11T19:36:25Z',
+    finalizers: ['application.appstudio.redhat.com/finalizer'],
+    generation: 1,
+    name: 'test-application',
+    namespace: 'rorai',
+    resourceVersion: '357091606',
+    uid: '400b639d-826d-4071-bfcd-fb142fb9a80c',
+  },
+  spec: {
+    appModelRepository: {
+      url: '',
+    },
+    displayName: 'Test Application',
+    gitOpsRepository: {
+      url: '',
+    },
+  },
+  status: {
+    conditions: [
+      {
+        lastTransitionTime: '2022-04-11T19:36:26Z',
+        message: 'Application has been successfully created',
+        reason: 'OK',
+        status: 'True',
+        type: 'Created',
+      },
+    ],
+    devfile:
+      'metadata:\n  attributes:\n    appModelRepository.url: https://github.com/redhat-appstudio-appdata/test-application-rorai-hold-control\n    gitOpsRepository.url: https://github.com/redhat-appstudio-appdata/test-application-rorai-hold-control\n  name: Test Application\nprojects:\n- git:\n    remotes:\n      origin: https://github.com/nodeshift-starters/devfile-sample\n  name: nodejs\nschemaVersion: 2.1.0\n',
+  },
+};
+
+export const mockEnvironment: EnvironmentKind = {
+  apiVersion: 'appstudio.redhat.com/v1alpha1',
+  kind: 'environment',
+  metadata: { name: 'production' },
+  spec: { displayName: 'Production' },
+};
+
+export const mockComponents: ComponentKind[] = [
+  {
+    apiVersion: 'appstudio.redhat.com/v1alpha1',
+    kind: 'Component',
+    metadata: {
+      name: 'basic-node-js',
+      namespace: 'sbudhwar-1',
+      uid: 'bdec6527-db16-43da-9300-3a20d180e020',
+    },
+    spec: {
+      application: 'test-application',
+      build: {
+        containerImage: '',
+      },
+      componentName: 'basic-node-js',
+      resources: {},
+      source: {
+        git: {
+          url: 'https://github.com/nodeshift-starters/devfile-sample.git',
+        },
+      },
+    },
+    status: {
+      conditions: [
+        {
+          lastTransitionTime: '2022-03-16T04:45:09Z',
+          message: 'Component has been successfully created',
+          reason: 'OK',
+          status: 'True',
+          type: 'Created',
+        },
+      ],
+      containerImage: 'quay.io/redhat-appstudio/user-workload:sbudhwar-1-basic-node-js',
+      devfile:
+        "commands:\n- attributes:\n    api.devfile.io/imported-from: 'id: nodejs, registryURL: https://registry.devfile.io'\n  exec:\n    commandLine: npm install\n    component: runtime\n    group:\n      isDefault: true\n      kind: build\n    hotReloadCapable: false\n    workingDir: ${PROJECT_SOURCE}\n  id: install\n- attributes:\n    api.devfile.io/imported-from: 'id: nodejs, registryURL: https://registry.devfile.io'\n  exec:\n    commandLine: npm start\n    component: runtime\n    group:\n      isDefault: true\n      kind: run\n    hotReloadCapable: false\n    workingDir: ${PROJECT_SOURCE}\n  id: run\n- attributes:\n    api.devfile.io/imported-from: 'id: nodejs, registryURL: https://registry.devfile.io'\n  exec:\n    commandLine: npm run debug\n    component: runtime\n    group:\n      isDefault: true\n      kind: debug\n    hotReloadCapable: false\n    workingDir: ${PROJECT_SOURCE}\n  id: debug\n- attributes:\n    api.devfile.io/imported-from: 'id: nodejs, registryURL: https://registry.devfile.io'\n  exec:\n    commandLine: npm test\n    component: runtime\n    group:\n      isDefault: true\n      kind: test\n    hotReloadCapable: false\n    workingDir: ${PROJECT_SOURCE}\n  id: test\n- apply:\n    component: outerloop-build\n  id: build-image\n- apply:\n    component: outerloop-deploy\n  id: deployk8s\n- composite:\n    commands:\n    - build-image\n    - deployk8s\n    group:\n      isDefault: true\n      kind: deploy\n    parallel: false\n  id: deploy\ncomponents:\n- attributes:\n    api.devfile.io/imported-from: 'id: nodejs, registryURL: https://registry.devfile.io'\n  container:\n    dedicatedPod: true\n    endpoints:\n    - name: http-3000\n      secure: false\n      targetPort: 3000\n    image: registry.access.redhat.com/ubi8/nodejs-14:latest\n    memoryLimit: 1024Mi\n    mountSources: true\n  name: runtime\n- image:\n    dockerfile:\n      buildContext: .\n      rootRequired: false\n      uri: Dockerfile\n    imageName: nodejs-image:latest\n  name: outerloop-build\n- kubernetes:\n    uri: outerloop-deploy.yaml\n  name: outerloop-deploy\nmetadata:\n  attributes:\n    alpha.dockerimage-port: 3001\n  description: Stack with Node.js 14\n  displayName: Node.js Runtime\n  language: nodejs\n  name: nodejs\n  projectType: nodejs\n  provider: Red Hat\n  supportUrl: https://github.com/devfile-samples/devfile-support#support-information\n  tags:\n  - NodeJS\n  - Express\n  - ubi8\n  version: 1.0.1\nschemaVersion: 2.2.0\nstarterProjects:\n- attributes:\n    api.devfile.io/imported-from: 'id: nodejs, registryURL: https://registry.devfile.io'\n  git:\n    remotes:\n      origin: https://github.com/odo-devfiles/nodejs-ex.git\n  name: nodejs-starter\n",
+      gitops: {
+        repositoryURL:
+          'https://github.com/redhat-appstudio-appdata/purple-mermaid-app-sbudhwar-1-research-fig',
+      },
+    },
+  },
+  {
+    apiVersion: 'appstudio.redhat.com/v1alpha1',
+    kind: 'Component',
+    metadata: {
+      name: 'nodejs',
+      namespace: 'rorai',
+      uid: '5a14d4b4-480b-4ca5-b7ab-10c2cfffd3d9',
+    },
+    spec: {
+      application: 'test-application',
+      build: {
+        containerImage: '',
+      },
+      componentName: 'nodejs',
+      replicas: 1,
+      resources: {
+        requests: {
+          cpu: '0',
+          memory: '1Gi',
+        },
+      },
+      source: {
+        git: {
+          url: 'https://github.com/nodeshift-starters/devfile-sample',
+        },
+      },
+      targetPort: 3000,
+    },
+    status: {
+      conditions: [
+        {
+          lastTransitionTime: '2022-04-11T19:36:28Z',
+          message: 'Component has been successfully created',
+          reason: 'OK',
+          status: 'True',
+          type: 'Created',
+        },
+      ],
+      containerImage: 'quay.io/redhat-appstudio/user-workload:rorai-nodejs',
+      devfile:
+        "commands:\n- attributes:\n    api.devfile.io/imported-from: 'id: nodejs, registryURL: https://registry.devfile.io'\n  exec:\n    commandLine: npm install\n    component: runtime\n    group:\n      isDefault: true\n      kind: build\n    hotReloadCapable: false\n    workingDir: ${PROJECT_SOURCE}\n  id: install\n- attributes:\n    api.devfile.io/imported-from: 'id: nodejs, registryURL: https://registry.devfile.io'\n  exec:\n    commandLine: npm start\n    component: runtime\n    group:\n      isDefault: true\n      kind: run\n    hotReloadCapable: false\n    workingDir: ${PROJECT_SOURCE}\n  id: run\n- attributes:\n    api.devfile.io/imported-from: 'id: nodejs, registryURL: https://registry.devfile.io'\n  exec:\n    commandLine: npm run debug\n    component: runtime\n    group:\n      isDefault: true\n      kind: debug\n    hotReloadCapable: false\n    workingDir: ${PROJECT_SOURCE}\n  id: debug\n- attributes:\n    api.devfile.io/imported-from: 'id: nodejs, registryURL: https://registry.devfile.io'\n  exec:\n    commandLine: npm test\n    component: runtime\n    group:\n      isDefault: true\n      kind: test\n    hotReloadCapable: false\n    workingDir: ${PROJECT_SOURCE}\n  id: test\n- apply:\n    component: outerloop-build\n  id: build-image\n- apply:\n    component: outerloop-deploy\n  id: deployk8s\n- composite:\n    commands:\n    - build-image\n    - deployk8s\n    group:\n      isDefault: true\n      kind: deploy\n    parallel: false\n  id: deploy\ncomponents:\n- attributes:\n    api.devfile.io/imported-from: 'id: nodejs, registryURL: https://registry.devfile.io'\n    appstudio.has/replicas: 1\n  container:\n    cpuRequest: \"0\"\n    dedicatedPod: true\n    endpoints:\n    - name: http-3000\n      secure: false\n      targetPort: 3000\n    image: registry.access.redhat.com/ubi8/nodejs-14:latest\n    memoryLimit: 1024Mi\n    memoryRequest: 1Gi\n    mountSources: true\n  name: runtime\n- image:\n    dockerfile:\n      buildContext: .\n      rootRequired: false\n      uri: Dockerfile\n    imageName: nodejs-image:latest\n  name: outerloop-build\n- kubernetes:\n    uri: outerloop-deploy.yaml\n  name: outerloop-deploy\nmetadata:\n  attributes:\n    alpha.dockerimage-port: 3001\n  description: Stack with Node.js 14\n  displayName: Node.js Runtime\n  language: nodejs\n  name: nodejs\n  projectType: nodejs\n  provider: Red Hat\n  supportUrl: https://github.com/devfile-samples/devfile-support#support-information\n  tags:\n  - NodeJS\n  - Express\n  - ubi8\n  version: 1.0.1\nschemaVersion: 2.2.0\nstarterProjects:\n- attributes:\n    api.devfile.io/imported-from: 'id: nodejs, registryURL: https://registry.devfile.io'\n  git:\n    remotes:\n      origin: https://github.com/odo-devfiles/nodejs-ex.git\n  name: nodejs-starter\n",
+      gitops: {
+        repositoryURL:
+          'https://github.com/redhat-appstudio-appdata/test-application-rorai-hold-control',
+      },
+    },
+  },
+];

--- a/src/components/ApplicationEnvironment/__tests__/ApplicationEnvironmentDetailsView.spec.tsx
+++ b/src/components/ApplicationEnvironment/__tests__/ApplicationEnvironmentDetailsView.spec.tsx
@@ -1,0 +1,123 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { WatchK8sResource } from '../../../dynamic-plugin-sdk';
+import {
+  ApplicationGroupVersionKind,
+  ComponentGroupVersionKind,
+  EnvironmentGroupVersionKind,
+} from '../../../models';
+import { mockApplication, mockComponents, mockEnvironment } from '../__data__/mock-data';
+import { ApplicationEnvironmentDetailsView } from '../ApplicationEnvironmentDetailsView';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: jest.fn(() => ({ t: (x) => x })),
+}));
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  useK8sWatchResource: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useQuickstartCloseOnUnmount', () => ({
+  useQuickstartCloseOnUnmount: jest.fn(),
+}));
+
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  useChrome: () => ({ helpTopics: { setActiveTopic: jest.fn(), enableTopics: jest.fn() } }),
+}));
+
+jest.mock('react-router-dom', () => ({
+  Link: (props) => <a href={props.to}>{props.children}</a>,
+  useNavigate: () => {},
+}));
+
+jest.mock('../../modal/ModalProvider', () => ({
+  useModalLauncher: () => {},
+}));
+
+const watchResourceMock = useK8sWatchResource as jest.Mock;
+
+const getMockedResources = (kind: WatchK8sResource) => {
+  if (kind.groupVersionKind === ApplicationGroupVersionKind) {
+    return [mockApplication, true];
+  }
+  if (kind.groupVersionKind === EnvironmentGroupVersionKind) {
+    return [mockEnvironment, true];
+  }
+  if (kind.groupVersionKind === ComponentGroupVersionKind) {
+    return [mockComponents, true];
+  }
+  return [[], true];
+};
+
+class MockResizeObserver {
+  observe() {
+    // do nothing
+  }
+
+  unobserve() {
+    // do nothing
+  }
+
+  disconnect() {
+    // do nothing
+  }
+}
+
+window.ResizeObserver = MockResizeObserver;
+
+describe('ApplicationEnvironmentDetailsView', () => {
+  it('should render spinner if data is not loaded', () => {
+    watchResourceMock.mockReturnValue([[], false]);
+    render(
+      <ApplicationEnvironmentDetailsView
+        environmentName="production"
+        applicationName="test-application"
+      />,
+    );
+    screen.getByRole('progressbar');
+  });
+
+  it('should render environment display name if environment data is loaded', () => {
+    watchResourceMock.mockImplementation(getMockedResources);
+    render(
+      <ApplicationEnvironmentDetailsView
+        environmentName="production"
+        applicationName="test-application"
+      />,
+    );
+    screen.getAllByText(`${mockEnvironment.spec.displayName} environment`);
+  });
+
+  it('should render a list view of components by default', async () => {
+    watchResourceMock.mockImplementation(getMockedResources);
+    render(
+      <ApplicationEnvironmentDetailsView
+        environmentName="production"
+        applicationName="test-application"
+      />,
+    );
+    await waitFor(() => {
+      // const componentList = screen.getByTestId('application-environment-list');
+      const componentListItems = screen.getAllByTestId('application-environment-list-item');
+      expect(componentListItems.length).toBe(mockComponents.length);
+    });
+  });
+
+  it('should render a graph view when the user changes views', async () => {
+    watchResourceMock.mockImplementation(getMockedResources);
+
+    render(
+      <ApplicationEnvironmentDetailsView
+        environmentName="production"
+        applicationName="test-application"
+      />,
+    );
+    const graphToggle = await within(screen.getByTestId('graph-view-toggle')).findByRole('button');
+    expect(graphToggle).toBeTruthy();
+    fireEvent.click(graphToggle);
+
+    await waitFor(() => screen.getByTestId('application-environment-graph'));
+  });
+});

--- a/src/components/ApplicationEnvironment/__tests__/ApplicationEnvironmentDetailsView.spec.tsx
+++ b/src/components/ApplicationEnvironment/__tests__/ApplicationEnvironmentDetailsView.spec.tsx
@@ -9,7 +9,13 @@ import {
   ComponentGroupVersionKind,
   EnvironmentGroupVersionKind,
 } from '../../../models';
-import { mockApplication, mockComponents, mockEnvironment } from '../__data__/mock-data';
+import { GitOpsDeploymentGroupVersionKind } from '../../../models/gitops-deployment';
+import {
+  mockApplication,
+  mockComponents,
+  mockEnvironment,
+  mockGitOpsDeployments,
+} from '../__data__/mock-data';
 import { ApplicationEnvironmentDetailsView } from '../ApplicationEnvironmentDetailsView';
 
 jest.mock('react-i18next', () => ({
@@ -54,6 +60,36 @@ const getMockedResources = (kind: WatchK8sResource) => {
   if (kind.groupVersionKind === ComponentGroupVersionKind) {
     return [mockComponents, true];
   }
+  if (kind.groupVersionKind === GitOpsDeploymentGroupVersionKind) {
+    return [mockGitOpsDeployments, true];
+  }
+  return [[], true];
+};
+const getMockedEmptyComponents = (kind: WatchK8sResource) => {
+  if (kind.groupVersionKind === ApplicationGroupVersionKind) {
+    return [mockApplication, true];
+  }
+  if (kind.groupVersionKind === EnvironmentGroupVersionKind) {
+    return [mockEnvironment, true];
+  }
+  if (kind.groupVersionKind === GitOpsDeploymentGroupVersionKind) {
+    return [mockGitOpsDeployments, true];
+  }
+  return [[], true];
+};
+const getMockedLoadingComponents = (kind: WatchK8sResource) => {
+  if (kind.groupVersionKind === ApplicationGroupVersionKind) {
+    return [mockApplication, true];
+  }
+  if (kind.groupVersionKind === EnvironmentGroupVersionKind) {
+    return [mockEnvironment, true];
+  }
+  if (kind.groupVersionKind === GitOpsDeploymentGroupVersionKind) {
+    return [mockGitOpsDeployments, true];
+  }
+  if (kind.groupVersionKind === ComponentGroupVersionKind) {
+    return [[], false];
+  }
   return [[], true];
 };
 
@@ -88,6 +124,30 @@ const mockUseSearchParam = (name: string) => {
 describe('ApplicationEnvironmentDetailsView', () => {
   it('should render spinner if data is not loaded', () => {
     watchResourceMock.mockReturnValue([[], false]);
+    useSearchParamMock.mockImplementation(mockUseSearchParam);
+    render(
+      <ApplicationEnvironmentDetailsView
+        environmentName="production"
+        applicationName="test-application"
+      />,
+    );
+    screen.getByRole('progressbar');
+  });
+
+  it('should render the empty state if there are no components', () => {
+    watchResourceMock.mockImplementation(getMockedEmptyComponents);
+    useSearchParamMock.mockImplementation(mockUseSearchParam);
+    render(
+      <ApplicationEnvironmentDetailsView
+        environmentName="production"
+        applicationName="test-application"
+      />,
+    );
+    screen.getByTestId('env-details-empty-state');
+  });
+
+  it('should render spinner if components are not loaded', () => {
+    watchResourceMock.mockImplementation(getMockedLoadingComponents);
     useSearchParamMock.mockImplementation(mockUseSearchParam);
     render(
       <ApplicationEnvironmentDetailsView

--- a/src/components/ApplicationEnvironment/__tests__/ApplicationEnvironmentSidePanel.spec.tsx
+++ b/src/components/ApplicationEnvironment/__tests__/ApplicationEnvironmentSidePanel.spec.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { render, screen } from '@testing-library/react';
+import { useApplicationRoutes } from '../../../hooks';
+import { mockComponents } from '../__data__/mock-data';
+import ApplicationEnvironmentSidePanel from '../ApplicationEnvironmentSidePanel';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: jest.fn(() => ({ t: (x) => x })),
+}));
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  useK8sWatchResource: jest.fn(),
+}));
+
+jest.mock('react-router-dom', () => ({
+  Link: (props) => <a href={props.to}>{props.children}</a>,
+  useNavigate: () => {},
+}));
+
+const watchResourceMock = useK8sWatchResource as jest.Mock;
+
+jest.mock('../../../hooks/useApplicationRoutes', () => ({
+  useApplicationRoutes: jest.fn(),
+}));
+
+const applicationRoutesMock = useApplicationRoutes as jest.Mock;
+
+describe('ApplicationEnvironmentSidePanel', () => {
+  it('should render the component name in the title', () => {
+    watchResourceMock.mockReturnValue([[], false]);
+    applicationRoutesMock.mockReturnValue([[], true]);
+    render(<ApplicationEnvironmentSidePanel component={mockComponents[0]} onClose={() => {}} />);
+    screen.getAllByText(`${mockComponents[0].metadata.name}`);
+  });
+  it('should render a spinner while loading application routes', () => {
+    watchResourceMock.mockReturnValue([[], false]);
+    applicationRoutesMock.mockReturnValue([[], false]);
+    render(<ApplicationEnvironmentSidePanel component={mockComponents[0]} onClose={() => {}} />);
+    screen.getByRole('progressbar');
+  });
+});

--- a/src/components/ApplicationEnvironment/topology/actions/contextMenuActions.tsx
+++ b/src/components/ApplicationEnvironment/topology/actions/contextMenuActions.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { ContextMenuItem, ContextSubMenuItem } from '@patternfly/react-topology';
+import { getMenuOptionType } from '../../../../shared/components/action-menu/action-menu-utils';
+import ActionMenuItem from '../../../../shared/components/action-menu/ActionMenuItem';
+import {
+  Action,
+  GroupedMenuOption,
+  MenuOption,
+  MenuOptionType,
+} from '../../../../shared/components/action-menu/types';
+
+export const createContextMenuItems = (actions: MenuOption[]) => {
+  return actions.map((option: MenuOption) => {
+    const optionType = getMenuOptionType(option);
+    switch (optionType) {
+      case MenuOptionType.SUB_MENU:
+        return (
+          <ContextSubMenuItem label={option.label} key={option.id}>
+            {createContextMenuItems((option as GroupedMenuOption).children)}
+          </ContextSubMenuItem>
+        );
+      case MenuOptionType.GROUP_MENU:
+        return (
+          <React.Fragment key={option.id}>
+            {option.label && <h1 className="pf-c-dropdown__group-title">{option.label}</h1>}
+            {createContextMenuItems((option as GroupedMenuOption).children)}
+          </React.Fragment>
+        );
+      default:
+        return (
+          <ActionMenuItem key={option.id} action={option as Action} component={ContextMenuItem} />
+        );
+    }
+  });
+};

--- a/src/components/ApplicationEnvironment/topology/components/ActionsMenu.tsx
+++ b/src/components/ApplicationEnvironment/topology/components/ActionsMenu.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { Node } from '@patternfly/react-topology';
+import { useComponentActions } from '../../../ApplicationDetailsView/component-actions';
+import { createContextMenuItems } from '../actions/contextMenuActions';
+
+const ComponentNodeContextMenu: React.FC<{ element: Node }> = ({ element }) => {
+  const { component } = element.getData();
+  const actions = useComponentActions(component, component.metadata.name);
+
+  return <>{createContextMenuItems(actions)}</>;
+};
+
+export const componentContextMenuActions = (element: Node) => {
+  return [<ComponentNodeContextMenu key={element.getId()} element={element} />];
+};

--- a/src/components/ApplicationEnvironment/topology/components/ComponentNode.tsx
+++ b/src/components/ApplicationEnvironment/topology/components/ComponentNode.tsx
@@ -1,0 +1,150 @@
+import * as React from 'react';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
+import {
+  Decorator,
+  DEFAULT_LAYER,
+  DefaultNode,
+  getDefaultShapeDecoratorCenter,
+  Layer,
+  Node,
+  observer,
+  ScaleDetailsLevel,
+  TOP_LAYER,
+  TopologyQuadrant,
+  useHover,
+  WithContextMenuProps,
+  WithDragNodeProps,
+  WithSelectionProps,
+} from '@patternfly/react-topology';
+import { useApplicationRoutes } from '../../../../hooks';
+import catalogIcon from '../../../../imgs/catalog-icon.svg';
+import { ApplicationGroupVersionKind } from '../../../../models';
+import ExternalLink from '../../../../shared/components/links/ExternalLink';
+import { routeDecoratorIcon } from '../../../../shared/utils/git-utils';
+import { useNamespace } from '../../../../utils/namespace-context-utils';
+import { getComponentRouteWebURL } from '../../../../utils/route-utils';
+
+const SHOW_SOURCE_DECORATOR = false;
+const DEFAULT_DECORATOR_RADIUS = 12;
+
+type ComponentNodeProps = {
+  element: Node;
+} & Partial<WithSelectionProps> &
+  Partial<WithDragNodeProps> &
+  Partial<WithContextMenuProps>;
+
+const ComponentNode: React.FC<ComponentNodeProps> = ({ element, contextMenuOpen, ...rest }) => {
+  const namespace = useNamespace();
+  const component = element.getData()?.component;
+  const name = component.metadata.name;
+  const applicationName = component.metadata?.ownerReferences?.find(
+    (ref) => ref.kind === ApplicationGroupVersionKind.kind,
+  )?.name;
+  const [hover, hoverRef] = useHover();
+  const icon = catalogIcon;
+  const detailsLevel = element.getController().getGraph().getDetailsLevel();
+  const showDetails = contextMenuOpen || detailsLevel !== ScaleDetailsLevel.low;
+  const { width, height } = element.getDimensions();
+  const [routes] = useApplicationRoutes(applicationName, namespace);
+
+  const cx = width / 2;
+  const cy = height / 2;
+  const innerRadius = cx - 10;
+  const iconRadius = innerRadius - 10;
+
+  const sourceDecorator = React.useMemo(() => {
+    if (!SHOW_SOURCE_DECORATOR) {
+      return null;
+    }
+
+    const { x, y } = getDefaultShapeDecoratorCenter(TopologyQuadrant.lowerRight, element);
+    const url =
+      component.spec.source?.git?.url ||
+      (component.spec.containerImage.includes('http')
+        ? component.spec.containerImage
+        : `https://${component.spec.containerImage}`);
+
+    if (!url) {
+      return null;
+    }
+
+    const sourceIcon = routeDecoratorIcon(url);
+    return (
+      <Decorator
+        x={x}
+        y={y}
+        radius={DEFAULT_DECORATOR_RADIUS}
+        showBackground
+        icon={<ExternalLink href={url} text={sourceIcon} />}
+      />
+    );
+  }, [component.spec.containerImage, component.spec.source?.git?.url, element]);
+
+  const routeDecorator = React.useMemo(() => {
+    const componentRouteWebURL = routes?.length > 0 && getComponentRouteWebURL(routes, name);
+
+    if (!componentRouteWebURL) {
+      return null;
+    }
+
+    const { x, y } = getDefaultShapeDecoratorCenter(TopologyQuadrant.upperRight, element);
+
+    return (
+      <Decorator
+        x={x}
+        y={y}
+        radius={DEFAULT_DECORATOR_RADIUS}
+        showBackground
+        icon={
+          <ExternalLink href={componentRouteWebURL} text={<ExternalLinkAltIcon title="Route" />} />
+        }
+      />
+    );
+  }, [element, name, routes]);
+
+  return (
+    <Layer id={hover || contextMenuOpen ? TOP_LAYER : DEFAULT_LAYER}>
+      <g
+        ref={hoverRef}
+        data-test-id={element.getLabel()}
+        data-testid="application-environment-component-node"
+      >
+        <DefaultNode
+          element={element}
+          scaleNode={(hover || contextMenuOpen) && detailsLevel !== ScaleDetailsLevel.high}
+          contextMenuOpen={contextMenuOpen}
+          showStatusBackground={!showDetails}
+          attachments={
+            <>
+              {routeDecorator}
+              {sourceDecorator}
+            </>
+          }
+          {...rest}
+        >
+          <g data-test-id="base-node-handler">
+            {icon && showDetails && (
+              <>
+                <circle
+                  fill="var(--pf-global--palette--white)"
+                  cx={cx}
+                  cy={cy}
+                  r={innerRadius + 6}
+                />
+                <image
+                  x={cx - iconRadius}
+                  y={cy - iconRadius}
+                  width={iconRadius * 2}
+                  height={iconRadius * 2}
+                  xlinkHref={icon}
+                />
+              </>
+            )}
+          </g>
+        </DefaultNode>
+      </g>
+    </Layer>
+  );
+};
+
+export default observer(ComponentNode);

--- a/src/components/ApplicationEnvironment/topology/factories/componentFactory.ts
+++ b/src/components/ApplicationEnvironment/topology/factories/componentFactory.ts
@@ -1,0 +1,34 @@
+import { ComponentType } from 'react';
+import {
+  GraphElement,
+  ComponentFactory,
+  ModelKind,
+  GraphComponent,
+  withDragNode,
+  withContextMenu,
+  withSelection,
+  withPanZoom,
+} from '@patternfly/react-topology';
+import { componentContextMenuActions } from '../components/ActionsMenu';
+import ComponentNode from '../components/ComponentNode';
+
+const componentFactory: ComponentFactory = (
+  kind: ModelKind,
+  type: string,
+): ComponentType<{ element: GraphElement }> => {
+  switch (type) {
+    default:
+      switch (kind) {
+        case ModelKind.graph:
+          return withPanZoom()(GraphComponent);
+        case ModelKind.node:
+          return withSelection({ controlled: true })(
+            withDragNode()(withContextMenu(componentContextMenuActions)(ComponentNode)),
+          );
+        default:
+          return undefined;
+      }
+  }
+};
+
+export default componentFactory;

--- a/src/components/ApplicationEnvironment/topology/factories/layoutFactory.ts
+++ b/src/components/ApplicationEnvironment/topology/factories/layoutFactory.ts
@@ -1,0 +1,11 @@
+import { Graph, Layout, LayoutFactory, ColaLayout } from '@patternfly/react-topology';
+
+const COLA_LAYOUT = 'Cola';
+
+const DEFAULT_LAYOUT = COLA_LAYOUT;
+
+const layoutFactory: LayoutFactory = (type: string, graph: Graph): Layout | undefined => {
+  return type === COLA_LAYOUT ? new ColaLayout(graph, { layoutOnDrag: false }) : undefined;
+};
+
+export { COLA_LAYOUT, DEFAULT_LAYOUT, layoutFactory };

--- a/src/components/ApplicationListView/ApplicationListRow.tsx
+++ b/src/components/ApplicationListView/ApplicationListRow.tsx
@@ -23,10 +23,7 @@ const ApplicationListRow: React.FC<RowFunctionArgs<ApplicationKind>> = ({ obj })
   return (
     <>
       <TableData className={applicationTableColumnClasses.name}>
-        <Link
-          to={`/app-studio/applications?name=${obj.metadata.name}`}
-          title={obj.spec.displayName}
-        >
+        <Link to={`/app-studio/applications/${obj.metadata.name}`} title={obj.spec.displayName}>
           {obj.spec.displayName}
         </Link>
       </TableData>

--- a/src/components/Environment/ApplicationEnvironmentCards.tsx
+++ b/src/components/Environment/ApplicationEnvironmentCards.tsx
@@ -22,7 +22,7 @@ import { getEnvironmentDeploymentStrategyLabel } from '../../utils/environment-u
 type ApplicationEnvironmentCardProps = {
   environment: EnvironmentKind;
   isExpanded: boolean;
-  onSelect: () => void;
+  onSelect?: () => void;
 };
 
 const ApplicationEnvironmentCard: React.FC<ApplicationEnvironmentCardProps> = ({

--- a/src/components/Environment/ApplicationEnvironmentCards.tsx
+++ b/src/components/Environment/ApplicationEnvironmentCards.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  Button,
   Card,
   CardBody,
   CardExpandableContent,
@@ -18,12 +19,21 @@ import { global_palette_green_400 as greenColor } from '@patternfly/react-tokens
 import { useEnvironments } from '../../hooks/useEnvironments';
 import { EnvironmentKind } from '../../types';
 import { getEnvironmentDeploymentStrategyLabel } from '../../utils/environment-utils';
+import { OutlinedHelpPopperIcon } from '../OutlinedHelpTooltipIcon';
 
 type ApplicationEnvironmentCardProps = {
   environment: EnvironmentKind;
   isExpanded: boolean;
   onSelect?: () => void;
 };
+
+const ApplicationEnvironmentCardsEmptyState: React.FC = () => (
+  <Card isCompact isExpanded={false}>
+    <CardHeader>
+      <CardTitle>No environments available</CardTitle>
+    </CardHeader>
+  </Card>
+);
 
 const ApplicationEnvironmentCard: React.FC<ApplicationEnvironmentCardProps> = ({
   environment,
@@ -64,30 +74,58 @@ const ApplicationEnvironmentCard: React.FC<ApplicationEnvironmentCardProps> = ({
 };
 
 type ApplicationEnvironmentCardsProps = {
-  isExpanded: boolean;
   onSelect?: (selectedId: string) => void;
 };
 
 export const ApplicationEnvironmentCards: React.FC<ApplicationEnvironmentCardsProps> = ({
-  isExpanded,
   onSelect,
 }) => {
+  const [cardsExpanded, setCardExpanded] = React.useState<boolean>(true);
   const [environments, loaded] = useEnvironments();
+
   return (
-    <Flex alignItems={{ default: 'alignItemsCenter' }}>
-      {loaded && environments?.length > 0 ? (
-        environments.slice(0, 2).map((env) => (
-          <FlexItem key={env.metadata.uid}>
-            <ApplicationEnvironmentCard
-              environment={env}
-              isExpanded={isExpanded}
-              onSelect={() => onSelect && onSelect(env.metadata.name)}
-            />
+    <Flex direction={{ default: 'column' }} grow={{ default: 'grow' }}>
+      <Flex>
+        <FlexItem>
+          <b>Environments:</b>
+          {'  '}
+          <OutlinedHelpPopperIcon
+            heading="Application environments"
+            content="View components and their settings as deployed to environments. Component updates can be promoted between environments. Additional environments can be added via the workspace."
+          />
+        </FlexItem>
+        {loaded && environments.length ? (
+          <FlexItem align={{ default: 'alignRight' }}>
+            <Button
+              onClick={() => setCardExpanded((e) => !e)}
+              variant="link"
+              isInline
+              style={{ textDecoration: 'none' }}
+            >
+              {cardsExpanded ? 'Collapse' : 'Expand'}
+            </Button>
           </FlexItem>
-        ))
-      ) : (
-        <Spinner isSVG size="md" />
-      )}
+        ) : null}
+      </Flex>
+      <Flex alignItems={{ default: 'alignItemsCenter' }}>
+        {loaded ? (
+          environments?.length ? (
+            environments.map((env) => (
+              <FlexItem key={env.metadata.uid}>
+                <ApplicationEnvironmentCard
+                  environment={env}
+                  isExpanded={cardsExpanded}
+                  onSelect={() => onSelect && onSelect(env.metadata.name)}
+                />
+              </FlexItem>
+            ))
+          ) : (
+            <ApplicationEnvironmentCardsEmptyState />
+          )
+        ) : (
+          <Spinner isSVG size="md" />
+        )}
+      </Flex>
     </Flex>
   );
 };

--- a/src/components/Environment/ApplicationEnvironmentCards.tsx
+++ b/src/components/Environment/ApplicationEnvironmentCards.tsx
@@ -9,26 +9,30 @@ import {
   Flex,
   FlexItem,
   Label,
+  Spinner,
   Text,
   TextVariants,
 } from '@patternfly/react-core';
 import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
 import { global_palette_green_400 as greenColor } from '@patternfly/react-tokens/dist/js/global_palette_green_400';
 import { useEnvironments } from '../../hooks/useEnvironments';
+import { EnvironmentKind } from '../../types';
 import { getEnvironmentDeploymentStrategyLabel } from '../../utils/environment-utils';
 
 type ApplicationEnvironmentCardProps = {
-  environment: any;
+  environment: EnvironmentKind;
   isExpanded: boolean;
+  onSelect: () => void;
 };
 
 const ApplicationEnvironmentCard: React.FC<ApplicationEnvironmentCardProps> = ({
   environment,
   isExpanded,
+  onSelect,
 }) => {
   const strategy = getEnvironmentDeploymentStrategyLabel(environment);
   return (
-    <Card isCompact isExpanded={isExpanded}>
+    <Card isCompact isExpanded={isExpanded} isSelectable={!!onSelect} onClick={onSelect}>
       <CardHeader>
         <Flex>
           <CardTitle>{environment.spec.displayName}</CardTitle>
@@ -45,7 +49,9 @@ const ApplicationEnvironmentCard: React.FC<ApplicationEnvironmentCardProps> = ({
         </Flex>
       </CardHeader>
       <CardExpandableContent>
-        <CardBody>Environment Status</CardBody>
+        <CardBody>
+          <CheckCircleIcon color={greenColor.value} /> Healthy
+        </CardBody>
         <CardFooter>
           <small>Last Deployment:</small> {'  '}
           <Text component={TextVariants.small} style={{ color: 'var(--pf-global--Color--200)' }}>
@@ -59,21 +65,29 @@ const ApplicationEnvironmentCard: React.FC<ApplicationEnvironmentCardProps> = ({
 
 type ApplicationEnvironmentCardsProps = {
   isExpanded: boolean;
+  onSelect?: (selectedId: string) => void;
 };
 
 export const ApplicationEnvironmentCards: React.FC<ApplicationEnvironmentCardsProps> = ({
   isExpanded,
+  onSelect,
 }) => {
   const [environments, loaded] = useEnvironments();
   return (
-    <>
-      {loaded && environments?.length > 0
-        ? environments.slice(0, 2).map((env) => (
-            <FlexItem key={env.metadata.uid}>
-              <ApplicationEnvironmentCard environment={env} isExpanded={isExpanded} />
-            </FlexItem>
-          ))
-        : null}
-    </>
+    <Flex alignItems={{ default: 'alignItemsCenter' }}>
+      {loaded && environments?.length > 0 ? (
+        environments.slice(0, 2).map((env) => (
+          <FlexItem key={env.metadata.uid}>
+            <ApplicationEnvironmentCard
+              environment={env}
+              isExpanded={isExpanded}
+              onSelect={() => onSelect && onSelect(env.metadata.name)}
+            />
+          </FlexItem>
+        ))
+      ) : (
+        <Spinner isSVG size="md" />
+      )}
+    </Flex>
   );
 };

--- a/src/hacbs/components/ImportForm/ImportForm.tsx
+++ b/src/hacbs/components/ImportForm/ImportForm.tsx
@@ -52,7 +52,7 @@ const ImportForm: React.FunctionComponent<ImportFormProps> = ({ applicationName 
   const handleSubmit = React.useCallback(
     ({ application, inAppContext }: FormValues) => {
       const appName = inAppContext ? application : applicationDataRef.current?.metadata?.name;
-      navigate(`/app-studio/applications?name=${appName}`);
+      navigate(`/app-studio/applications/${appName}`);
     },
     [navigate],
   );

--- a/src/hacbs/components/ImportForm/__tests__/ImportForm.spec.tsx
+++ b/src/hacbs/components/ImportForm/__tests__/ImportForm.spec.tsx
@@ -54,6 +54,6 @@ describe('ImportForm', () => {
       });
     });
     wizardProps.onReset({}, {} as any);
-    expect(navigateMock).toHaveBeenCalledWith('/app-studio/applications?name=my-app');
+    expect(navigateMock).toHaveBeenCalledWith('/app-studio/applications/my-app');
   });
 });

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useApplicationRoutes } from './useApplicationRoutes';
 export { useEventListener } from './useEventListener';
 export { useLocalStorage } from './useLocalStorage';
+export { useComponentPipelineRun } from './useComponentPipelineRun';

--- a/src/hooks/useComponentPipelineRun.tsx
+++ b/src/hooks/useComponentPipelineRun.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { WatchK8sResource } from '../dynamic-plugin-sdk';
+import { PipelineRunGroupVersionKind } from '../shared';
+import { PipelineRunKind } from '../shared/components/pipeline-run-logs/types';
+
+const BUILD_COMPONENT_LABEL = 'build.appstudio.openshift.io/component';
+const BUILD_APPLICATION_LABEL = 'build.appstudio.openshift.io/application';
+
+export const useComponentPipelineRun = (
+  name: string,
+  application: string,
+  namespace: string,
+): { pipelineRun: PipelineRunKind; loaded: boolean } => {
+  const watchResource: WatchK8sResource = React.useMemo(() => {
+    const matchLabels = {
+      [BUILD_COMPONENT_LABEL]: name,
+      [BUILD_APPLICATION_LABEL]: application,
+    };
+
+    return {
+      groupVersionKind: PipelineRunGroupVersionKind,
+      namespace,
+      selector: { matchLabels },
+      isList: true,
+    };
+  }, [name, application, namespace]);
+
+  const [pipelineRuns, loaded, error] = useK8sWatchResource(watchResource);
+
+  const pipelineRun = React.useMemo(() => {
+    if (loaded && !error) {
+      return (pipelineRuns as PipelineRunKind[])?.sort?.(
+        (a, b) =>
+          new Date(b.metadata.creationTimestamp).getTime() -
+          new Date(a.metadata.creationTimestamp).getTime(),
+      )?.[0];
+    }
+    return undefined;
+  }, [pipelineRuns, loaded, error]);
+
+  return { loaded, pipelineRun };
+};

--- a/src/hooks/useGitOpsDeploymentCR.ts
+++ b/src/hooks/useGitOpsDeploymentCR.ts
@@ -6,8 +6,8 @@ import { GitOpsDeploymentKind } from './../types/gitops-deployment';
 export const useGitOpsDeploymentCR = (
   application: string,
   namespace: string,
-): [GitOpsDeploymentKind, boolean] => {
-  const [gitOpsDeployments, loaded] = useK8sWatchResource<GitOpsDeploymentKind[]>({
+): [GitOpsDeploymentKind, boolean, string] => {
+  const [gitOpsDeployments, loaded, error] = useK8sWatchResource<GitOpsDeploymentKind[]>({
     groupVersionKind: GitOpsDeploymentGroupVersionKind,
     namespace,
     isList: true,
@@ -22,5 +22,5 @@ export const useGitOpsDeploymentCR = (
     );
   }, [application, gitOpsDeployments]);
 
-  return [gitOpsDeployment, loaded];
+  return [gitOpsDeployment, loaded, `${error}`];
 };

--- a/src/pages/ApplicationDetailsPage.tsx
+++ b/src/pages/ApplicationDetailsPage.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import { useParams } from 'react-router-dom';
+import { useFeatureFlag } from '@openshift/dynamic-plugin-sdk';
+import ApplicationDetailsView from '../components/ApplicationDetailsView/ApplicationDetailsView';
+import NamespacedPage from '../components/NamespacedPage/NamespacedPage';
+import HacbsApplicationDetails from '../hacbs/components/ApplicationDetails/HacbsApplicationDetails';
+import { HACBS_FLAG } from '../hacbs/hacbsFeatureFlag';
+
+const ApplicationDetailsPage = () => {
+  const { appName } = useParams();
+  const [hacbs] = useFeatureFlag(HACBS_FLAG);
+
+  return (
+    <NamespacedPage>
+      <Helmet>
+        <title>Application Details Page</title>
+      </Helmet>
+      {hacbs ? (
+        <HacbsApplicationDetails applicationName={appName} />
+      ) : (
+        <ApplicationDetailsView applicationName={appName} />
+      )}
+    </NamespacedPage>
+  );
+};
+
+export default ApplicationDetailsPage;

--- a/src/pages/ApplicationEnvironmentDetailsPage.tsx
+++ b/src/pages/ApplicationEnvironmentDetailsPage.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
+import { useParams } from 'react-router-dom';
 import { ApplicationEnvironmentDetailsView } from '../components/ApplicationEnvironment/ApplicationEnvironmentDetailsView';
 import { GettingStartedModal } from '../components/modal/GettingStartedModal';
 import NamespacedPage from '../components/NamespacedPage/NamespacedPage';
 import { useQuickstartCloseOnUnmount } from '../hooks/useQuickstartCloseOnUnmount';
 import imageUrl from '../imgs/getting-started-illustration.svg';
-import { getQueryArgument } from '../shared/utils';
 
 const GETTING_STARTED_MODAL_KEY = 'application-environment-details-getting-started-modal';
 
 const ApplicationEnvironmentDetailsPage = () => {
   useQuickstartCloseOnUnmount();
-  const applicationName = getQueryArgument('application');
-  const environmentName = getQueryArgument('name');
+  const { appName, envName } = useParams();
 
   return (
     <NamespacedPage>
@@ -29,10 +28,7 @@ const ApplicationEnvironmentDetailsPage = () => {
       <Helmet>
         <title>Environment Details Page</title>
       </Helmet>
-      <ApplicationEnvironmentDetailsView
-        applicationName={applicationName}
-        environmentName={environmentName}
-      />
+      <ApplicationEnvironmentDetailsView applicationName={appName} environmentName={envName} />
     </NamespacedPage>
   );
 };

--- a/src/pages/ApplicationEnvironmentDetailsPage.tsx
+++ b/src/pages/ApplicationEnvironmentDetailsPage.tsx
@@ -7,7 +7,7 @@ import { useQuickstartCloseOnUnmount } from '../hooks/useQuickstartCloseOnUnmoun
 import imageUrl from '../imgs/getting-started-illustration.svg';
 import { getQueryArgument } from '../shared/utils';
 
-const GETTING_STARTED_MODAL_KEY = 'application-list-getting-started-modal';
+const GETTING_STARTED_MODAL_KEY = 'application-environment-details-getting-started-modal';
 
 const ApplicationEnvironmentDetailsPage = () => {
   useQuickstartCloseOnUnmount();

--- a/src/pages/ApplicationEnvironmentDetailsPage.tsx
+++ b/src/pages/ApplicationEnvironmentDetailsPage.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import { ApplicationEnvironmentDetailsView } from '../components/ApplicationEnvironment/ApplicationEnvironmentDetailsView';
+import { GettingStartedModal } from '../components/modal/GettingStartedModal';
+import NamespacedPage from '../components/NamespacedPage/NamespacedPage';
+import { useQuickstartCloseOnUnmount } from '../hooks/useQuickstartCloseOnUnmount';
+import imageUrl from '../imgs/getting-started-illustration.svg';
+import { getQueryArgument } from '../shared/utils';
+
+const GETTING_STARTED_MODAL_KEY = 'application-list-getting-started-modal';
+
+const ApplicationEnvironmentDetailsPage = () => {
+  useQuickstartCloseOnUnmount();
+  const applicationName = getQueryArgument('application');
+  const environmentName = getQueryArgument('name');
+
+  return (
+    <NamespacedPage>
+      <GettingStartedModal
+        imgClassName="pf-u-justify-content-center pf-u-px-4xl"
+        localStorageKey={GETTING_STARTED_MODAL_KEY}
+        title="Developing apps just got easier"
+        imgSrc={imageUrl}
+        imgAlt="Illustration showing users developing applications"
+      >
+        Build apps quickly, deploy and automate anywhere, and troubleshoot your apps - all in one
+        space.
+      </GettingStartedModal>
+      <Helmet>
+        <title>Environment Details Page</title>
+      </Helmet>
+      <ApplicationEnvironmentDetailsView
+        applicationName={applicationName}
+        environmentName={environmentName}
+      />
+    </NamespacedPage>
+  );
+};
+
+export default ApplicationEnvironmentDetailsPage;

--- a/src/pages/ApplicationsPage.tsx
+++ b/src/pages/ApplicationsPage.tsx
@@ -17,8 +17,8 @@ const GETTING_STARTED_MODAL_KEY = 'application-list-getting-started-modal';
 const ApplicationsPage = () => {
   useQuickstartCloseOnUnmount();
   const applicationName = getQueryArgument('name');
-  const [hacbs] = useFeatureFlag(HACBS_FLAG);
-
+  let [hacbs] = useFeatureFlag(HACBS_FLAG);
+  hacbs = hacbs && false;
   return (
     <NamespacedPage>
       {hacbs ? (

--- a/src/pages/ApplicationsPage.tsx
+++ b/src/pages/ApplicationsPage.tsx
@@ -1,24 +1,19 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
 import { useFeatureFlag } from '@openshift/dynamic-plugin-sdk';
-import ApplicationDetailsView from '../components/ApplicationDetailsView/ApplicationDetailsView';
 import ApplicationListView from '../components/ApplicationListView/ApplicationListView';
 import { GettingStartedModal } from '../components/modal/GettingStartedModal';
 import NamespacedPage from '../components/NamespacedPage/NamespacedPage';
-import HacbsApplicationDetails from '../hacbs/components/ApplicationDetails/HacbsApplicationDetails';
 import { GettingStartedModal as HacBSGettingStartedModal } from '../hacbs/components/Modals/GettingStartedModal';
 import { HACBS_FLAG } from '../hacbs/hacbsFeatureFlag';
 import { useQuickstartCloseOnUnmount } from '../hooks/useQuickstartCloseOnUnmount';
 import imageUrl from '../imgs/getting-started-illustration.svg';
-import { getQueryArgument } from '../shared/utils';
 
 const GETTING_STARTED_MODAL_KEY = 'application-list-getting-started-modal';
 
 const ApplicationsPage = () => {
   useQuickstartCloseOnUnmount();
-  const applicationName = getQueryArgument('name');
-  let [hacbs] = useFeatureFlag(HACBS_FLAG);
-  hacbs = hacbs && false;
+  const [hacbs] = useFeatureFlag(HACBS_FLAG);
   return (
     <NamespacedPage>
       {hacbs ? (
@@ -39,25 +34,10 @@ const ApplicationsPage = () => {
           space.
         </GettingStartedModal>
       )}
-      {applicationName ? (
-        <React.Fragment>
-          <Helmet>
-            <title>Application Details Page</title>
-          </Helmet>
-          {hacbs ? (
-            <HacbsApplicationDetails applicationName={applicationName} />
-          ) : (
-            <ApplicationDetailsView applicationName={applicationName} />
-          )}
-        </React.Fragment>
-      ) : (
-        <>
-          <Helmet>
-            <title>Application List Page</title>
-          </Helmet>
-          <ApplicationListView />
-        </>
-      )}
+      <Helmet>
+        <title>Application List Page</title>
+      </Helmet>
+      <ApplicationListView />
     </NamespacedPage>
   );
 };

--- a/src/shared/components/action-menu/ActionMenuContent.tsx
+++ b/src/shared/components/action-menu/ActionMenuContent.tsx
@@ -7,12 +7,12 @@ import { Action, GroupedMenuOption, MenuOption, MenuOptionType } from './types';
 
 type GroupMenuContentProps = {
   option: GroupedMenuOption;
-  onClick: () => void;
+  onClick?: () => void;
 };
 
 type ActionMenuContentProps = {
   options: MenuOption[];
-  onClick: () => void;
+  onClick?: () => void;
   focusItem?: MenuOption;
 };
 

--- a/src/shared/utils/git-utils.tsx
+++ b/src/shared/utils/git-utils.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { BitbucketIcon } from '@patternfly/react-icons/dist/js/icons/bitbucket-icon';
+import { GitAltIcon } from '@patternfly/react-icons/dist/js/icons/git-alt-icon';
+import { GithubIcon } from '@patternfly/react-icons/dist/js/icons/github-icon';
+import { GitlabIcon } from '@patternfly/react-icons/dist/js/icons/gitlab-icon';
+
+export enum GitProvider {
+  GITHUB = 'github',
+  BITBUCKET = 'bitbucket',
+  GITLAB = 'gitlab',
+  UNSURE = 'other',
+  INVALID = '',
+}
+
+export const gitUrlRegex =
+  /^((((ssh|git|https?:?):\/\/:?)(([^\s@]+@|[^@]:?)[-\w.]+(:\d\d+:?)?(\/[-\w.~/?[\]!$&'()*+,;=:@%]*:?)?:?))|([^\s@]+@[-\w.]+:[-\w.~/?[\]!$&'()*+,;=:@%]*?:?))$/;
+
+const hasDomain = (url: string, domain: string): boolean => {
+  return (
+    url.startsWith(`https://${domain}/`) ||
+    url.startsWith(`https://www.${domain}/`) ||
+    url.includes(`@${domain}:`)
+  );
+};
+
+export const detectGitType = (url: string): GitProvider => {
+  if (!gitUrlRegex.test(url)) {
+    // Not a URL
+    return GitProvider.INVALID;
+  }
+  if (hasDomain(url, 'github.com')) {
+    return GitProvider.GITHUB;
+  }
+  if (hasDomain(url, 'bitbucket.org')) {
+    return GitProvider.BITBUCKET;
+  }
+  if (hasDomain(url, 'gitlab.com')) {
+    return GitProvider.GITLAB;
+  }
+  // Not a known URL
+  return GitProvider.UNSURE;
+};
+
+export const routeDecoratorIcon = (routeURL: string): React.ReactElement => {
+  switch (detectGitType(routeURL)) {
+    case GitProvider.INVALID:
+      // Not a valid url and thus not safe to use
+      return null;
+    case GitProvider.GITHUB:
+      return <GithubIcon title="Source code" />;
+    case GitProvider.BITBUCKET:
+      return <BitbucketIcon title="Source code" />;
+    case GitProvider.GITLAB:
+      return <GitlabIcon title="Source code" />;
+    default:
+      return <GitAltIcon title="Source code" />;
+  }
+};

--- a/src/shared/utils/git-utils.tsx
+++ b/src/shared/utils/git-utils.tsx
@@ -3,6 +3,7 @@ import { BitbucketIcon } from '@patternfly/react-icons/dist/js/icons/bitbucket-i
 import { GitAltIcon } from '@patternfly/react-icons/dist/js/icons/git-alt-icon';
 import { GithubIcon } from '@patternfly/react-icons/dist/js/icons/github-icon';
 import { GitlabIcon } from '@patternfly/react-icons/dist/js/icons/gitlab-icon';
+import { gitUrlRegex } from '../../components/ImportForm/utils/validation-utils';
 
 export enum GitProvider {
   GITHUB = 'github',
@@ -11,9 +12,6 @@ export enum GitProvider {
   UNSURE = 'other',
   INVALID = '',
 }
-
-export const gitUrlRegex =
-  /^((((ssh|git|https?:?):\/\/:?)(([^\s@]+@|[^@]:?)[-\w.]+(:\d\d+:?)?(\/[-\w.~/?[\]!$&'()*+,;=:@%]*:?)?:?))|([^\s@]+@[-\w.]+:[-\w.~/?[\]!$&'()*+,;=:@%]*?:?))$/;
 
 const hasDomain = (url: string, domain: string): boolean => {
   return (

--- a/src/utils/environment-utils.ts
+++ b/src/utils/environment-utils.ts
@@ -1,7 +1,11 @@
+import { EnvironmentKind } from '../types';
+
 export enum EnvironmentDeploymentStrategy {
   AppStudioAutomated = 'Automatic',
   Manual = 'Manual',
 }
 
-export const getEnvironmentDeploymentStrategyLabel = (environment): EnvironmentDeploymentStrategy =>
+export const getEnvironmentDeploymentStrategyLabel = (
+  environment: EnvironmentKind,
+): EnvironmentDeploymentStrategy =>
   EnvironmentDeploymentStrategy[environment.spec.deploymentStrategy];


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-1943
https://issues.redhat.com/browse/HAC-1944

## Description
Updates the application details view to use the application environment cards as drill downs into an application's environment details view.
Add an application environment details view showing components in the application. This view is switchable from a list view to a topology graph view with a side panel showing more details for the selected component.

## Type of change
- [x] Feature

## Screen shots / Gifs for design review 
![image](https://user-images.githubusercontent.com/11633780/183645317-8c3d1d56-29f0-4f80-a60c-96222a12ada8.png)

![image](https://user-images.githubusercontent.com/11633780/183645352-22aa0154-7a9b-495e-be5a-8c2691dc4010.png)

![image](https://user-images.githubusercontent.com/11633780/183645400-f101b87e-dff2-45e4-892d-a72e6738d9b0.png)

![image](https://user-images.githubusercontent.com/11633780/183645438-f4767deb-add9-4ed8-aba9-6aae0e6bf951.png)

## How to test or reproduce?
Navigate to the application details view.
Select the environment card you wish to view details for.
Select a component in the environment to view the side panel details.
Use the graph/list icons to switch between list and graph views.

## Browser conformance: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

