### PR TITLE
render log viewer in PLR logs tab

### DIFF
--- a/src/hacbs/components/PipelineRunDetailsView/tabs/PipelineRunLogsTab.tsx
+++ b/src/hacbs/components/PipelineRunDetailsView/tabs/PipelineRunLogsTab.tsx
@@ -1,25 +1,13 @@
 import * as React from 'react';
-import { EmptyState, EmptyStateIcon, Title, EmptyStateBody } from '@patternfly/react-core';
-import { OutlinedFileImageIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-file-image-icon';
+import { PipelineRunLogs } from '../../../../shared';
+import { PipelineRunKind } from '../../../types';
 
 type PipelineRunLogsTabProps = {
-  pipelineRun: any;
+  pipelineRun: PipelineRunKind;
 };
 
-const PipelineRunLogsTab: React.FC<PipelineRunLogsTabProps> = () => {
-  return (
-    <EmptyState>
-      <EmptyStateIcon icon={OutlinedFileImageIcon} />
-      <Title headingLevel="h4" size="lg">
-        View logs for this pipelinerun
-      </Title>
-      <EmptyStateBody>
-        No logs found yet.
-        <br />
-        To get Started, create a pipelinerun or connect to a pipelinerun environment.
-      </EmptyStateBody>
-    </EmptyState>
-  );
-};
+const PipelineRunLogsTab: React.FC<PipelineRunLogsTabProps> = ({ pipelineRun }) => (
+  <PipelineRunLogs obj={pipelineRun} />
+);
 
 export default PipelineRunLogsTab;


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Adds the PipelineRun log viewer to the Logs tab of the PipelineRun details page.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
![image](https://user-images.githubusercontent.com/14068621/184220303-ff7e05a5-6e00-465d-b205-abb47543645e.png)


## How to test or reproduce?
Create an application and component.
Go to the application details `PipelineRuns` tab. 
Click on a pipeline run name to go to the PLR details page.
Go to the `Logs` tab.

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

