### PR TITLE
Add HAC BS integration tests tab for applications

### DIFF
--- a/src/hacbs/components/ApplicationDetails/HacbsApplicationDetails.tsx
+++ b/src/hacbs/components/ApplicationDetails/HacbsApplicationDetails.tsx
@@ -12,6 +12,7 @@ import ApplicationOverviewTab from './tabs/ApplicationOverviewTab';
 import CommitsTab from './tabs/CommitsTab';
 import ComponentsTab from './tabs/ComponentsTab';
 import EnvironmentsTab from './tabs/EnvironmentsTab';
+import IntegrationTestsTab from './tabs/IntegrationTestsTab';
 import PipelineRunsTab from './tabs/PipelineRunsTab';
 
 type HacbsApplicationDetailsProps = {
@@ -132,6 +133,11 @@ const HacbsApplicationDetails: React.FC<HacbsApplicationDetailsProps> = ({ appli
             key: 'pipelineruns',
             label: 'Pipelineruns',
             component: <PipelineRunsTab applicationName={applicationName} />,
+          },
+          {
+            key: 'integrationtests',
+            label: 'Integration tests',
+            component: <IntegrationTestsTab applicationName={applicationName} />,
           },
           {
             key: 'environments',

--- a/src/hacbs/components/ApplicationDetails/tabs/EnvironmentsTab.tsx
+++ b/src/hacbs/components/ApplicationDetails/tabs/EnvironmentsTab.tsx
@@ -10,11 +10,11 @@ import {
 } from '@patternfly/react-core';
 import { OutlinedFileImageIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-file-image-icon';
 
-type EnvironmentTabProps = {
+type EnvironmentsTabProps = {
   applicationName: string;
 };
 
-const EnvironmentTab: React.FC<EnvironmentTabProps> = ({ applicationName }) => {
+const EnvironmentsTab: React.FC<EnvironmentsTabProps> = ({ applicationName }) => {
   return (
     <EmptyState>
       <EmptyStateIcon icon={OutlinedFileImageIcon} />
@@ -44,4 +44,4 @@ const EnvironmentTab: React.FC<EnvironmentTabProps> = ({ applicationName }) => {
   );
 };
 
-export default EnvironmentTab;
+export default EnvironmentsTab;

--- a/src/hacbs/components/ApplicationDetails/tabs/IntegrationTestsTab.tsx
+++ b/src/hacbs/components/ApplicationDetails/tabs/IntegrationTestsTab.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import IntegrationTestsListView from '../../IntegrationTestsListView/IntegrationTestsListView';
+
+type IntegrationTestsTabProps = {
+  applicationName: string;
+};
+
+const IntegrationTestsTab: React.FC<IntegrationTestsTabProps> = ({ applicationName }) => (
+  <IntegrationTestsListView applicationName={applicationName} />
+);
+
+export default IntegrationTestsTab;

--- a/src/hacbs/components/IntegrationTestsListView/IntegrationTestListHeader.ts
+++ b/src/hacbs/components/IntegrationTestsListView/IntegrationTestListHeader.ts
@@ -1,0 +1,35 @@
+export const integrationListTableColumnClasses = {
+  name: 'pf-m-width-25',
+  containerImage: 'pf-m-width-35 pf-l-flex',
+  mandatory: 'pf-m-width-20',
+  pipeline: 'pf-m-width-15',
+  kebab: 'pf-c-table__action pf-m-width-5',
+};
+
+export const IntegrationTestListHeader = () => {
+  return [
+    {
+      title: 'Name',
+      props: { className: integrationListTableColumnClasses.name },
+    },
+    {
+      title: 'Container image',
+      props: { className: integrationListTableColumnClasses.containerImage },
+    },
+    {
+      title: 'Mandatory for release',
+      props: { className: integrationListTableColumnClasses.mandatory },
+    },
+    {
+      title: 'Pipelines',
+      props: { className: integrationListTableColumnClasses.pipeline },
+    },
+    {
+      title: '',
+      props: {
+        className: integrationListTableColumnClasses.kebab,
+        style: { paddingRight: 64 },
+      },
+    },
+  ];
+};

--- a/src/hacbs/components/IntegrationTestsListView/IntegrationTestListRow.tsx
+++ b/src/hacbs/components/IntegrationTestsListView/IntegrationTestListRow.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
+import ActionMenu from '../../../shared/components/action-menu/ActionMenu';
+import ExternalLink from '../../../shared/components/links/ExternalLink';
+import { RowFunctionArgs, TableData } from '../../../shared/components/table';
+import { IntegrationTestScenarioKind } from '../../types/coreBuildService';
+import { integrationListTableColumnClasses } from './IntegrationTestListHeader';
+import { useIntegrationTestActions } from './useIntegrationTestActions';
+
+const IntegrationTestListRow: React.FC<RowFunctionArgs<IntegrationTestScenarioKind>> = ({
+  obj,
+}) => {
+  const actions = useIntegrationTestActions(obj);
+  const containerImageUrl = `https://${obj.spec.bundle}`;
+  return (
+    <>
+      <TableData
+        className={integrationListTableColumnClasses.name}
+        data-test="integration-tests__row-name"
+      >
+        {obj.metadata.name}
+      </TableData>
+      <TableData className={integrationListTableColumnClasses.containerImage}>
+        <ExternalLink
+          href={containerImageUrl}
+          text={
+            <span>
+              {containerImageUrl} <ExternalLinkAltIcon />
+            </span>
+          }
+          stopPropagation
+        />
+      </TableData>
+      <TableData className={integrationListTableColumnClasses.mandatory}>
+        {obj.spec.optional ? 'Optional' : 'Mandatory'}
+      </TableData>
+      <TableData className={integrationListTableColumnClasses.pipeline}>
+        {obj.spec.pipeline}
+      </TableData>
+      <TableData className={integrationListTableColumnClasses.kebab}>
+        <ActionMenu actions={actions} />
+      </TableData>
+    </>
+  );
+};
+
+export default IntegrationTestListRow;

--- a/src/hacbs/components/IntegrationTestsListView/IntegrationTestsListView.tsx
+++ b/src/hacbs/components/IntegrationTestsListView/IntegrationTestsListView.tsx
@@ -1,0 +1,210 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import {
+  Bullseye,
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateSecondaryActions,
+  Spinner,
+  Text,
+  TextContent,
+  TextInput,
+  TextVariants,
+  Title,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import { Flex, FlexItem } from '@patternfly/react-core/dist/js/layouts';
+import { CodeBranchIcon } from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
+import { FilterIcon, SearchIcon } from '@patternfly/react-icons/dist/js/icons';
+import { Table } from '../../../shared';
+import ExternalLink from '../../../shared/components/links/ExternalLink';
+import { useNamespace } from '../../../utils/namespace-context-utils';
+import { IntegrationTestScenarioGroupVersionKind } from '../../models';
+import { IntegrationTestScenarioKind } from '../../types/coreBuildService';
+import { IntegrationTestListHeader } from './IntegrationTestListHeader';
+import IntegrationTestListRow from './IntegrationTestListRow';
+
+type IntegrationTestsListViewProps = {
+  applicationName: string;
+};
+
+const IntegrationTestsEmptyState: React.FC = () => (
+  <EmptyState data-test="integration-tests__empty">
+    <EmptyStateIcon icon={CodeBranchIcon} />
+    <Title headingLevel="h4" size="lg">
+      Add an integration test pipeline to test all your components after you commit code
+    </Title>
+    <EmptyStateBody>
+      No integration test pipelines found yet.
+      <br />
+      To get started, create an environment or connect to a release environment.
+      <ExternalLink
+        href="#"
+        text={
+          <Flex
+            className="pf-u-mt-sm"
+            spaceItems={{ default: 'spaceItemsXs' }}
+            justifyContent={{ default: 'justifyContentCenter' }}
+          >
+            <FlexItem>Learn more about setting up an integration test pipeline</FlexItem>
+            <FlexItem>
+              <ExternalLinkAltIcon />
+            </FlexItem>
+          </Flex>
+        }
+      />
+    </EmptyStateBody>
+    <EmptyStateSecondaryActions>
+      <Button isDisabled component={(props) => <Link {...props} to="#" />} variant="primary">
+        Add integration test
+      </Button>
+    </EmptyStateSecondaryActions>
+  </EmptyState>
+);
+
+const IntegrationTestsFilteredState: React.FC<{ onClearFilters: () => void }> = ({
+  onClearFilters,
+}) => (
+  <EmptyState data-test="integration-tests__all-filtered">
+    <EmptyStateIcon icon={SearchIcon} />
+    <Title headingLevel="h2" size="lg">
+      No results found
+    </Title>
+    <EmptyStateBody>
+      No results match the filter criteria. Remove filters or clear all filters to show results.
+    </EmptyStateBody>
+    <EmptyStateSecondaryActions>
+      <Button variant="link" onClick={onClearFilters} data-test="integration-tests__clear-filters">
+        Clear all filters
+      </Button>
+    </EmptyStateSecondaryActions>
+  </EmptyState>
+);
+const IntegrationTestsListView: React.FC<IntegrationTestsListViewProps> = ({ applicationName }) => {
+  const namespace = useNamespace();
+  const [integrationTests, integrationTestsLoaded] = useK8sWatchResource<
+    IntegrationTestScenarioKind[]
+  >({
+    groupVersionKind: IntegrationTestScenarioGroupVersionKind,
+    namespace,
+    isList: true,
+  });
+  const [nameFilter, setNameFilter] = React.useState<string>('');
+
+  const applicationIntegrationTests = React.useMemo(
+    () =>
+      integrationTestsLoaded
+        ? integrationTests?.filter((test) => test.spec.application === applicationName)
+        : [],
+    [integrationTests, applicationName, integrationTestsLoaded],
+  );
+
+  const filteredIntegrationTests = React.useMemo(
+    () =>
+      nameFilter
+        ? applicationIntegrationTests.filter(
+            (test) => test.metadata.name.indexOf(nameFilter) !== -1,
+          )
+        : applicationIntegrationTests,
+    [nameFilter, applicationIntegrationTests],
+  );
+
+  const loading = (
+    <Bullseye className="pf-u-mt-md" data-test="integration-tests__loading">
+      <Spinner />
+    </Bullseye>
+  );
+
+  if (!integrationTestsLoaded) {
+    return loading;
+  }
+
+  if (!applicationIntegrationTests?.length) {
+    return <IntegrationTestsEmptyState />;
+  }
+  const onClearFilters = () => setNameFilter('');
+  const onNameInput = (name: string) => setNameFilter(name);
+
+  return (
+    <>
+      <Title headingLevel="h4" className="pf-u-mt-lg pf-u-mb-sm">
+        Integration test pipelines
+      </Title>
+      <Flex spaceItems={{ default: 'spaceItemsXs' }}>
+        <FlexItem>
+          <TextContent>
+            <Text component={TextVariants.small}>
+              Add an integration test pipeline to test all your components after you commit code.
+            </Text>
+          </TextContent>
+        </FlexItem>
+        <FlexItem>
+          <ExternalLink
+            href="#"
+            text={
+              <Flex
+                spaceItems={{ default: 'spaceItemsXs' }}
+                justifyContent={{ default: 'justifyContentCenter' }}
+              >
+                <FlexItem className="pf-u-font-size-sm">
+                  Learn more about setting up an integration test pipeline
+                </FlexItem>
+                <FlexItem>
+                  <ExternalLinkAltIcon />
+                </FlexItem>
+              </Flex>
+            }
+          />
+        </FlexItem>
+      </Flex>
+      <>
+        <Toolbar data-testid="component-list-toolbar" clearAllFilters={onClearFilters}>
+          <ToolbarContent>
+            <ToolbarGroup alignment={{ default: 'alignLeft' }}>
+              <ToolbarItem>
+                <Button variant="control">
+                  <FilterIcon /> {'Name'}
+                </Button>
+              </ToolbarItem>
+              <ToolbarItem>
+                <TextInput
+                  name="nameInput"
+                  data-test="name-input-filter"
+                  type="search"
+                  aria-label="name filter"
+                  placeholder="Filter by name..."
+                  onChange={(name) => onNameInput(name)}
+                  value={nameFilter}
+                />
+              </ToolbarItem>
+            </ToolbarGroup>
+          </ToolbarContent>
+        </Toolbar>
+        {filteredIntegrationTests.length ? (
+          <Table
+            data-test="integration-tests__table"
+            data={filteredIntegrationTests}
+            aria-label="Integration tests"
+            Header={IntegrationTestListHeader}
+            Row={IntegrationTestListRow}
+            loaded
+            getRowProps={(obj: IntegrationTestScenarioKind) => ({
+              id: obj.metadata.name,
+            })}
+          />
+        ) : (
+          <IntegrationTestsFilteredState onClearFilters={onClearFilters} />
+        )}
+      </>
+    </>
+  );
+};
+
+export default IntegrationTestsListView;

--- a/src/hacbs/components/IntegrationTestsListView/__data__/mock-integration-tests.ts
+++ b/src/hacbs/components/IntegrationTestsListView/__data__/mock-integration-tests.ts
@@ -1,0 +1,48 @@
+export const MockIntegrationTests = [
+  {
+    apiVersion: 'appstudio.redhat.com/v1alpha1',
+    kind: 'IntegrationTestScenario',
+    metadata: {
+      annotations: {
+        'app.kubernetes.io/display-name': 'Test 1',
+      },
+      name: 'test-app-test-1',
+      namespace: 'test-namespace',
+      uid: 'ed722704-74bc-4152-b27b-bee29cc7bfd2',
+    },
+    spec: {
+      application: 'test-app',
+      bundle: 'quay.io/test-rep/test-bundle:test-1',
+      contexts: [
+        {
+          description: 'Application testing 1',
+          name: 'application',
+        },
+      ],
+      pipeline: 'pipeline-1',
+    },
+  },
+  {
+    apiVersion: 'appstudio.redhat.com/v1alpha1',
+    kind: 'IntegrationTestScenario',
+    metadata: {
+      annotations: {
+        'app.kubernetes.io/display-name': 'Test 2',
+      },
+      name: 'test-app-test-2',
+      namespace: 'test-namespace',
+      uid: 'ed722704-74bc-4152-b27b-bee29cc7bfd3',
+    },
+    spec: {
+      application: 'test-app',
+      bundle: 'quay.io/test-rep/test-bundle:test-2',
+      contexts: [
+        {
+          description: 'Application testing 2',
+          name: 'application',
+        },
+      ],
+      pipeline: 'pipeline-2',
+    },
+  },
+];

--- a/src/hacbs/components/IntegrationTestsListView/__tests__/IntegrationTestsListRow.spec.tsx
+++ b/src/hacbs/components/IntegrationTestsListView/__tests__/IntegrationTestsListRow.spec.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { MockIntegrationTests } from '../__data__/mock-integration-tests';
+import IntegrationTestListRow from '../IntegrationTestListRow';
+
+describe('IntegrationTestListRow', () => {
+  it('should render integration test info', () => {
+    const integrationTest = MockIntegrationTests[0];
+    const wrapper = render(<IntegrationTestListRow obj={integrationTest} columns={[]} />, {
+      container: document.createElement('tr'),
+    });
+    const cells = wrapper.container.getElementsByTagName('td');
+
+    expect(cells[0].innerHTML).toBe(integrationTest.metadata.name);
+    expect(cells[1].innerHTML.includes(integrationTest.spec.bundle)).toBeTruthy();
+    expect(cells[3].innerHTML).toBe(integrationTest.spec.pipeline);
+  });
+});

--- a/src/hacbs/components/IntegrationTestsListView/__tests__/IntegrationTestsListView.spec.tsx
+++ b/src/hacbs/components/IntegrationTestsListView/__tests__/IntegrationTestsListView.spec.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { configure } from '@testing-library/react';
+import { routerRenderer } from '../../../../utils/test-utils';
+import { MockIntegrationTests } from '../__data__/mock-integration-tests';
+import IntegrationTestsListView from '../IntegrationTestsListView';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: jest.fn(() => ({ t: (x) => x })),
+}));
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  useK8sWatchResource: jest.fn(),
+}));
+
+const useK8sWatchResourceMock = useK8sWatchResource as jest.Mock;
+
+configure({ testIdAttribute: 'data-test' });
+
+describe('IntegrationTestsListView', () => {
+  it('should render the skeleton table if integration tests data is not loaded', () => {
+    useK8sWatchResourceMock.mockReturnValue([[], false]);
+    const wrapper = routerRenderer(<IntegrationTestsListView applicationName="test-app" />);
+    expect(wrapper.findByText('No integration test pipelines found yet.')).toBeTruthy();
+  });
+
+  it('should render the empty state if there are no integration tests', () => {
+    useK8sWatchResourceMock.mockReturnValue([[], true, undefined]);
+    const wrapper = routerRenderer(<IntegrationTestsListView applicationName="test-app" />);
+    expect(wrapper.findByText('No integration test pipelines found yet.')).toBeTruthy();
+  });
+
+  it('should render a table when there are integration tests', () => {
+    useK8sWatchResourceMock.mockReturnValue([MockIntegrationTests, true, undefined]);
+    const wrapper = routerRenderer(<IntegrationTestsListView applicationName="test-app" />);
+    expect(wrapper.container.getElementsByTagName('table')).toHaveLength(1);
+  });
+});

--- a/src/hacbs/components/IntegrationTestsListView/useIntegrationTestActions.tsx
+++ b/src/hacbs/components/IntegrationTestsListView/useIntegrationTestActions.tsx
@@ -1,0 +1,25 @@
+import { createDeleteModalLauncher } from '../../../components/modal/DeleteResourceModal';
+import { useModalLauncher } from '../../../components/modal/ModalProvider';
+import { Action } from '../../../shared/components/action-menu/types';
+import { IntegrationTestScenarioModel } from '../../models';
+import { IntegrationTestScenarioKind } from '../../types/coreBuildService';
+
+export const integrationTestDeleteModal = (integrationTestObj: IntegrationTestScenarioKind) =>
+  createDeleteModalLauncher(integrationTestObj.kind)({
+    obj: integrationTestObj,
+    model: IntegrationTestScenarioModel,
+    displayName: integrationTestObj.metadata.name,
+  });
+
+export const useIntegrationTestActions = (
+  integrationTest: IntegrationTestScenarioKind,
+): Action[] => {
+  const showModal = useModalLauncher();
+  return [
+    {
+      cta: () => showModal(integrationTestDeleteModal(integrationTest)),
+      id: `delete-${integrationTest.metadata.name.toLowerCase()}`,
+      label: 'Remove',
+    },
+  ];
+};

--- a/src/hacbs/components/PipelineRunListView/PipelineRunListHeader.ts
+++ b/src/hacbs/components/PipelineRunListView/PipelineRunListHeader.ts
@@ -27,7 +27,7 @@ export const PipelineRunListHeader = () => {
     },
     {
       title: 'Type',
-      props: { className: pipelineRunTableColumnClasses.duration },
+      props: { className: pipelineRunTableColumnClasses.type },
     },
     {
       title: '',


### PR DESCRIPTION
## Fixes 
Fixes: https://issues.redhat.com/browse/HACBS-997

## Description
Lists all integration tests associated with the application. Currently only the `Delete` action is available.

## Type of change
- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
![image](https://user-images.githubusercontent.com/11633780/184934650-529676fe-80ba-4ff1-a369-49cdc2b961f9.png)

![image](https://user-images.githubusercontent.com/11633780/184934688-1a60fb0d-7afe-486d-a848-aa3a8f85989f.png)

![image](https://user-images.githubusercontent.com/11633780/184934720-4084dc17-a83f-4ce6-9668-35edd728e9f5.png)

## How to test or reproduce?
Create an application with an integration test
Go to the application details Integration tests tab

## Browser conformance: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

