### PR TITLE
HACBS: Adds unit tests for PLR list and details

### DIFF
--- a/src/hacbs/components/PipelineRunDetailsView/__tests__/PipelineRunDetailsView.spec.tsx
+++ b/src/hacbs/components/PipelineRunDetailsView/__tests__/PipelineRunDetailsView.spec.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { render, screen } from '@testing-library/react';
+import { PipelineRunDetailsView } from '../PipelineRunDetailsView';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  useK8sWatchResource: jest.fn(),
+}));
+
+jest.mock('react-router-dom', () => ({
+  Link: (props) => <a href={props.to}>{props.children}</a>,
+  useNavigate: () => {},
+}));
+
+const watchResourceMock = useK8sWatchResource as jest.Mock;
+
+const pipelineRunName = 'java-springboot-sample-b4trz';
+const mockApplication = {
+  apiVersion: 'tekton.dev/v1beta1',
+  kind: 'PipelineRun',
+  metadata: {
+    annotations: {},
+    creationTimestamp: '2022-04-11T19:36:25Z',
+    finalizers: ['chains.tekton.dev/pipelinerun', 'pipelineruns.tekton.dev'],
+    name: 'java-springboot-sample-b4trz',
+    namespace: 'test',
+    resourceVersion: '933786813',
+    uid: 'f5dff823-52c5-43ee-a7de-a05915357689',
+    labels: {
+      'build.appstudio.openshift.io/component': 'java-springboot-sample',
+    },
+  },
+  spec: {
+    appModelRepository: {
+      url: '',
+    },
+    displayName: 'Test Application',
+    gitOpsRepository: {
+      url: '',
+    },
+  },
+  status: {
+    conditions: [
+      {
+        startTime: '2022-08-04T16:23:43Z',
+        completionTime: '2022-08-04T16:24:02Z',
+      },
+    ],
+  },
+};
+
+describe('PipelineRunDetailsView', () => {
+  it('should render spinner if pipelinerun data is not loaded', () => {
+    watchResourceMock.mockReturnValue([[], false]);
+    render(<PipelineRunDetailsView pipelineRunName={pipelineRunName} />);
+    screen.getByRole('progressbar');
+  });
+
+  it('should render application display name if application data is loaded', () => {
+    watchResourceMock.mockReturnValueOnce([mockApplication, true]).mockReturnValue([[], true]);
+    render(<PipelineRunDetailsView pipelineRunName={pipelineRunName} />);
+    screen.getAllByText(pipelineRunName);
+  });
+
+  it('should render application if components data is loaded', () => {
+    watchResourceMock.mockReturnValueOnce([mockApplication, true]).mockReturnValue([[], true]);
+    render(<PipelineRunDetailsView pipelineRunName={pipelineRunName} />);
+    expect(screen.queryByText('Pipelinerun details')).toBeInTheDocument();
+    expect(screen.queryByText('Status')).toBeInTheDocument();
+    expect(screen.queryByText('Message')).toBeInTheDocument();
+    expect(screen.queryByText('Namespace')).toBeInTheDocument();
+    expect(screen.queryByText('Message')).toBeInTheDocument();
+  });
+});

--- a/src/hacbs/components/PipelineRunListView/__tests__/PipelineRunListView.spec.tsx
+++ b/src/hacbs/components/PipelineRunListView/__tests__/PipelineRunListView.spec.tsx
@@ -1,0 +1,127 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { render, screen } from '@testing-library/react';
+import { PipelineRunKind } from '../../../types';
+import PipelineRunsListView from '../PipelineRunsListView';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  useK8sWatchResource: jest.fn(),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: jest.fn(() => ({ t: (x) => x })),
+}));
+
+jest.mock('react-router-dom', () => ({
+  Link: (props) => <a href={props.to}>{props.children}</a>,
+}));
+
+const appName = 'my-test-app';
+
+const pipelineRuns: PipelineRunKind[] = [
+  {
+    kind: 'PipelineRun',
+    apiVersion: 'tekton.dev/v1beta1',
+    metadata: {
+      creationTimestamp: '2022-08-04T16:23:43Z',
+      finalizers: Array['chains.tekton.dev/pipelinerun'],
+      name: 'basic-node-js-first',
+      namespace: 'test',
+      ownerReferences: [
+        {
+          apiVersion: 'appstudio.redhat.com/v1alpha1',
+          kind: 'Component',
+          name: 'basic-node-js',
+          uid: '6b79df0c-1bee-40c0-81ee-7c4d1c9a422f',
+        },
+      ],
+      resourceVersion: '497868251',
+      uid: '9c1f121c-1eb6-490f-b2d9-befbfc658df1',
+    },
+    spec: {
+      key: 'key1',
+    },
+  },
+  {
+    kind: 'PipelineRun',
+    apiVersion: 'tekton.dev/v1beta1',
+    metadata: {
+      creationTimestamp: '2022-08-04T16:23:43Z',
+      finalizers: Array['chains.tekton.dev/pipelinerun'],
+      name: 'basic-node-js-second',
+      namespace: 'test',
+      ownerReferences: [
+        {
+          apiVersion: 'appstudio.redhat.com/v1alpha1',
+          kind: 'Component',
+          name: 'basic-node-js',
+          uid: '6b79df0c-1bee-40c0-81ee-7c4d1c9a422f',
+        },
+      ],
+      resourceVersion: '497868252',
+      uid: '9c1f121c-1eb6-490f-b2d9-befbfc658dfb',
+    },
+    spec: {
+      key: 'key2',
+    },
+  },
+  {
+    kind: 'PipelineRun',
+    apiVersion: 'tekton.dev/v1beta1',
+    metadata: {
+      creationTimestamp: '2022-08-04T16:23:43Z',
+      finalizers: Array['chains.tekton.dev/pipelinerun'],
+      name: 'basic-node-js-third',
+      namespace: 'test',
+      ownerReferences: [
+        {
+          apiVersion: 'appstudio.redhat.com/v1alpha1',
+          kind: 'Component',
+          name: 'basic-node-js',
+          uid: '6b79df0c-1bee-40c0-81ee-7c4d1c9a422f',
+        },
+      ],
+      resourceVersion: '497868253',
+      uid: '9c1f121c-1eb6-490f-b2d9-befbfc658dfc',
+    },
+    spec: {
+      key: 'key3',
+    },
+  },
+];
+
+const watchResourceMock = useK8sWatchResource as jest.Mock;
+
+describe('Pipelinerun List', () => {
+  it('should render spinner if application data is not loaded', () => {
+    watchResourceMock.mockReturnValue([[], false]);
+    render(<PipelineRunsListView applicationName={appName} />);
+    screen.getByRole('progressbar');
+  });
+
+  it('should render empty state if no application is present', () => {
+    watchResourceMock.mockReturnValue([[], true]);
+    render(<PipelineRunsListView applicationName={appName} />);
+    screen.getByText(/No pipeline run triggered yet./);
+    screen.getByText(
+      /To get Started, create components and merge their pull request for build pipeline/,
+    );
+    const button = screen.getByText('Go to components tab');
+    expect(button).toBeInTheDocument();
+    expect(button.closest('a').href).toContain(
+      `/app-studio/applications?name=${appName}&activeTab=components`,
+    );
+  });
+
+  it('should render pipelineRuns list when pipelineRuns are present', () => {
+    watchResourceMock.mockReturnValue([pipelineRuns, true]);
+    render(<PipelineRunsListView applicationName={appName} />);
+    screen.getByText(/Pipelineruns/);
+    screen.getByText('Name');
+    screen.getByText('Started');
+    screen.getByText('Duration');
+    screen.getByText('Status');
+    screen.getByText('Type');
+  });
+});


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HACBS-991

## Description
For the initial early phase of the hacbs project, unit tests were encouraged but not required, as all code residing under /hacbs was temporarily exempt from code coverage. Most functionality still included unit tests as part of their merge as good practice, except for the pipelineruns list and details pages. Now that the exemption for /hacbs has been lifted, we need to add these unit tests so our test coverage remains high.

## Type of change
- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): unit tests

## Screen shots / Gifs for design review 
N/A - unit tests only

## How to test or reproduce?
Verify that the tests pass as part of the build

## Browser conformance: 
N/A
