### PR TITLE
add hook to get and set a URL search param like useState

### DIFF
--- a/src/hooks/__tests__/useSearchParam.spec.ts
+++ b/src/hooks/__tests__/useSearchParam.spec.ts
@@ -1,0 +1,107 @@
+import { useSearchParams } from 'react-router-dom';
+import { renderHook } from '@testing-library/react-hooks';
+import { useSearchParam } from '../useSearchParam';
+
+jest.mock('react-router-dom', () => ({
+  useSearchParams: jest.fn(),
+}));
+
+const useSearchParamsMock = useSearchParams as jest.Mock;
+
+describe('useSearchParam', () => {
+  let params: URLSearchParams;
+  beforeEach(() => {
+    params = new URLSearchParams();
+    useSearchParamsMock.mockImplementation(() => [
+      params,
+      (newParams: URLSearchParams) => {
+        params = newParams;
+      },
+    ]);
+  });
+
+  it('should set URL search param', () => {
+    const { result, rerender } = renderHook(() => useSearchParam('test', 'foo'));
+    let [value, set] = result.current;
+    expect(params.get('test')).toBeNull();
+
+    set('bar');
+    expect(params.get('test')).toBe('bar');
+    rerender();
+    [value] = result.current;
+    expect(value).toBe('bar');
+  });
+
+  it('should unset URL search param', () => {
+    params.set('test', 'foo');
+    const { result, rerender } = renderHook(() => useSearchParam('test'));
+    let [value, , unset] = result.current;
+    expect(value).toBe('foo');
+
+    unset();
+    expect(params.has('test')).toBe(false);
+    rerender();
+    [value] = result.current;
+    expect(value).toBe(null);
+  });
+
+  it('should return the same unset value as URLSearchParams', () => {
+    const { result } = renderHook(() => useSearchParam('test'));
+    const [value] = result.current;
+    expect(value).toBe(params.get('test'));
+  });
+
+  it('should return the default value when unset', async () => {
+    const { result, rerender } = renderHook(() => useSearchParam('test', 'default value'));
+    let [value, set, unset] = result.current;
+    expect(value).toBe('default value');
+
+    set('new value');
+    rerender();
+    [value, set, unset] = result.current;
+    expect(value).toBe('new value');
+
+    unset();
+    rerender();
+    [value] = result.current;
+    expect(value).toBe('default value');
+  });
+
+  it('should unset URL search param when set to default value', () => {
+    const { result } = renderHook(() => useSearchParam('test', 'default value'));
+    const [, set] = result.current;
+    set('new value');
+    expect(params.get('test')).toBe('new value');
+    expect(params.has('test')).toBe(true);
+    set('default value');
+    expect(params.get('test')).toBe(null);
+    expect(params.has('test')).toBe(false);
+  });
+
+  it('should not unset URL search param when set to default value', () => {
+    const { result } = renderHook(() =>
+      useSearchParam('test', 'default value', { unsetWhenDefaultValue: false }),
+    );
+    const [, set] = result.current;
+    set('new value');
+    expect(params.get('test')).toBe('new value');
+    expect(params.has('test')).toBe(true);
+    set('default value');
+    expect(params.get('test')).toBe('default value');
+    expect(params.has('test')).toBe(true);
+  });
+
+  it('should not allow the default value to change', () => {
+    const { result, rerender } = renderHook(
+      ({ defaultValue }) => useSearchParam('test', defaultValue),
+      { initialProps: { defaultValue: 'foo' } },
+    );
+
+    let [value] = result.current;
+    expect(value).toBe('foo');
+
+    rerender({ defaultValue: 'bar' });
+    [value] = result.current;
+    expect(value).toBe('foo');
+  });
+});

--- a/src/hooks/useSearchParam.ts
+++ b/src/hooks/useSearchParam.ts
@@ -1,0 +1,45 @@
+import React from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+/**
+ * Manage search param state reactively with react-router.
+ *
+ * Options:
+ *  - `unsetWhenDefaultValue`: if `true` the search param will be removed if the set value is equal the default value
+ */
+export const useSearchParam = (
+  name: string,
+  defaultValue: string = null,
+  options?: {
+    unsetWhenDefaultValue: boolean;
+  },
+): [string, (newValue: string) => void, () => void] => {
+  const defaultValueRef = React.useRef(defaultValue);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const value = searchParams.has(name) ? searchParams.get(name) : defaultValueRef.current;
+  const unsetWhenDefaultValue = options?.unsetWhenDefaultValue ?? true;
+  const set = React.useCallback(
+    (newValue: string) => {
+      if (searchParams.get(name) !== newValue) {
+        const newSearchParams = new URLSearchParams(searchParams);
+        if (unsetWhenDefaultValue && newValue === defaultValueRef.current) {
+          newSearchParams.delete(name);
+        } else {
+          newSearchParams.set(name, newValue);
+        }
+        setSearchParams(newSearchParams);
+      }
+    },
+    [name, searchParams, setSearchParams, unsetWhenDefaultValue],
+  );
+
+  const unset = React.useCallback(() => {
+    if (searchParams.has(name)) {
+      const newSearchParams = new URLSearchParams(searchParams);
+      newSearchParams.delete(name);
+      setSearchParams(newSearchParams);
+    }
+  }, [name, searchParams, setSearchParams]);
+
+  return [value, set, unset];
+};


### PR DESCRIPTION
## Description

Add a hook for working with a single URL search param in a way that mimics `useState`. Updates to the search param will be notified via react-router.

```
const [value, set, unset] = useSearchParam('name', '');
```

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): a shared hook util
