### PR TITLE
Enable Pipelines as code in HACBS workflow

### DIFF
--- a/src/components/ImportForm/utils/submit-utils.ts
+++ b/src/components/ImportForm/utils/submit-utils.ts
@@ -9,6 +9,7 @@ export const createComponents = async (
   namespace: string,
   secret?: string,
   dryRun?: boolean,
+  enablePac?: boolean,
 ) => {
   const createComponentPromises = components.map((component) => {
     const componentData = component.componentStub;
@@ -18,7 +19,16 @@ export const createComponents = async (
       replicas: componentData.replicas && Number(componentData.replicas),
       targetPort: componentData.targetPort && Number(componentData.targetPort),
     };
-    return createComponent(componentValues, application, namespace, secret, dryRun);
+    return createComponent(
+      componentValues,
+      application,
+      namespace,
+      secret,
+      dryRun,
+      null,
+      'create',
+      enablePac,
+    );
   });
 
   return Promise.all(createComponentPromises);

--- a/src/hacbs/components/ImportForm/BuildSection.tsx
+++ b/src/hacbs/components/ImportForm/BuildSection.tsx
@@ -20,6 +20,7 @@ import { PipelineRunGroupVersionKind } from '../../../shared';
 import ExternalLink from '../../../shared/components/links/ExternalLink';
 import { PipelineKind } from '../../../shared/components/pipeline-run-logs/types';
 import { useNamespace } from '../../../utils/namespace-context-utils';
+import { PipelineRunLabel, PipelineRunType } from '../../consts/pipelinerun';
 import { FormValues } from './types';
 
 const BuildSection: React.FunctionComponent = () => {
@@ -37,20 +38,20 @@ const BuildSection: React.FunctionComponent = () => {
     selector: {
       matchExpressions: [
         {
-          key: 'build.appstudio.openshift.io/component',
+          key: PipelineRunLabel.COMPONENT,
           operator: 'In',
           // find all pipelines related to the newly created components
           values: components.map((component) => component.componentStub.componentName),
         },
         {
-          key: 'build.appstudio.openshift.io/type',
-          operator: 'Equals',
-          values: ['build'],
-        },
-        {
-          key: 'build.appstudio.openshift.io/application',
+          key: PipelineRunLabel.APPLICATION,
           operator: 'Equals',
           values: [applicationName],
+        },
+        {
+          key: PipelineRunLabel.PIPELINE_TYPE,
+          operator: 'Equals',
+          values: [PipelineRunType.BUILD],
         },
       ],
     },
@@ -61,8 +62,7 @@ const BuildSection: React.FunctionComponent = () => {
         if (
           pipelineRuns.find(
             ({ metadata: { labels } }) =>
-              labels?.['build.appstudio.openshift.io/component'] ===
-              component.componentStub.componentName,
+              labels?.[PipelineRunLabel.COMPONENT] === component.componentStub.componentName,
           )
         ) {
           acc.push(component);

--- a/src/hacbs/components/ImportForm/__tests__/BuildSection.spec.tsx
+++ b/src/hacbs/components/ImportForm/__tests__/BuildSection.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { render } from '@testing-library/react';
+import { PipelineRunLabel } from '../../../consts/pipelinerun';
 import BuildSection from '../BuildSection';
 
 jest.mock('../../../../components/NamespacedPage/NamespacedPage', () => ({
@@ -61,13 +62,13 @@ describe('BuildSection', () => {
         {
           metadata: {
             name: 'p1',
-            labels: { ['build.appstudio.openshift.io/component']: 'nodejs' },
+            labels: { [PipelineRunLabel.COMPONENT]: 'nodejs' },
           },
         },
         {
           metadata: {
             name: 'p2',
-            labels: { ['build.appstudio.openshift.io/component']: 'nodejs' },
+            labels: { [PipelineRunLabel.COMPONENT]: 'nodejs' },
           },
         },
       ],

--- a/src/hacbs/components/ImportForm/utils/__tests__/submit-utils-spec.ts
+++ b/src/hacbs/components/ImportForm/utils/__tests__/submit-utils-spec.ts
@@ -192,6 +192,9 @@ describe('Submit Utils', () => {
         'test-ns',
         'my-secret',
         false, // dryRun
+        null,
+        'create',
+        true, // enabledPAC
       );
     });
   });

--- a/src/hacbs/components/ImportForm/utils/submit-utils.ts
+++ b/src/hacbs/components/ImportForm/utils/submit-utils.ts
@@ -16,7 +16,7 @@ export const onComponentsSubmit = async (
 ) => {
   const applicationName = inAppContext ? application : applicationData.metadata.name;
   try {
-    await createComponents(components, applicationName, namespace, secret, false);
+    await createComponents(components, applicationName, namespace, secret, false, true);
   } catch (error) {
     const message = error.code === 409 ? 'Component name already exists' : error.message;
     const errorComponent = error.json.details.name;

--- a/src/hacbs/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
+++ b/src/hacbs/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
@@ -6,6 +6,7 @@ import {
   DescriptionListDescription,
   Title,
 } from '@patternfly/react-core';
+import { PipelineRunLabel } from '../../../consts/pipelinerun';
 import { calculateDuration } from '../../../utils/pipeline-utils';
 
 type PipelineRunDetailsTabProps = {
@@ -85,7 +86,7 @@ const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({ pipelineR
         <DescriptionListGroup>
           <DescriptionListTerm>Component</DescriptionListTerm>
           <DescriptionListDescription>
-            {pipelineRun.metadata.labels['build.appstudio.openshift.io/component']}
+            {pipelineRun.metadata.labels[PipelineRunLabel.COMPONENT]}
           </DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup />

--- a/src/hacbs/components/PipelineRunListView/PipelineRunListRow.tsx
+++ b/src/hacbs/components/PipelineRunListView/PipelineRunListRow.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
 import { RowFunctionArgs, TableData } from '../../../shared/components/table';
 import { Timestamp } from '../../../shared/components/timestamp/Timestamp';
+import { PipelineRunLabel } from '../../consts/pipelinerun';
 import { PipelineRunKind } from '../../types';
 import { calculateDuration } from '../../utils/pipeline-utils';
 import { pipelineRunTableColumnClasses } from './PipelineRunListHeader';
@@ -35,7 +36,7 @@ const PipelineListRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({ obj }) =>
         {obj.status?.conditions[0].status === 'False' ? 'Failed' : 'Succeeded'}
       </TableData>
       <TableData className={pipelineRunTableColumnClasses.type}>
-        {capitalize(obj.metadata.labels['pipelines.appstudio.openshift.io/type'])}
+        {capitalize(obj.metadata.labels[PipelineRunLabel.PIPELINE_TYPE])}
       </TableData>
       <TableData className={pipelineRunTableColumnClasses.kebab}>
         <Dropdown

--- a/src/hacbs/components/PipelineRunListView/PipelineRunsListView.tsx
+++ b/src/hacbs/components/PipelineRunListView/PipelineRunsListView.tsx
@@ -14,6 +14,7 @@ import {
 import { OutlinedFileImageIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-file-image-icon';
 import { Table } from '../../../shared';
 import { useNamespace } from '../../../utils/namespace-context-utils';
+import { PipelineRunLabel } from '../../consts/pipelinerun';
 import { PipelineRunGroupVersionKind } from '../../models';
 import { PipelineRunKind } from '../../types';
 import { PipelineRunListHeader } from './PipelineRunListHeader';
@@ -29,7 +30,7 @@ const PipelineRunsListView: React.FC<PipelineRunsListViewProps> = ({ application
     isList: true,
     selector: {
       matchLabels: {
-        'build.appstudio.openshift.io/application': applicationName,
+        [PipelineRunLabel.APPLICATION]: applicationName,
       },
     },
   });

--- a/src/hacbs/consts/pipelinerun.ts
+++ b/src/hacbs/consts/pipelinerun.ts
@@ -1,0 +1,11 @@
+export enum PipelineRunLabel {
+  APPLICATION = 'appstudio.openshift.io/application',
+  COMPONENT = 'appstudio.openshift.io/component',
+  PIPELINE_TYPE = 'pipelines.appstudio.openshift.io/type',
+}
+
+export enum PipelineRunType {
+  BUILD = 'build',
+  RELEASE = 'release',
+  TEST = 'test',
+}

--- a/src/hacbs/hooks/useBuildPipelines.ts
+++ b/src/hacbs/hooks/useBuildPipelines.ts
@@ -1,6 +1,7 @@
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { PipelineRunGroupVersionKind } from '../../shared';
 import { PipelineRunKind } from '../../shared/components/pipeline-run-logs/types';
+import { PipelineRunLabel, PipelineRunType } from '../consts/pipelinerun';
 
 export const useBuildPipelines = (
   namespace: string,
@@ -11,8 +12,8 @@ export const useBuildPipelines = (
     namespace,
     selector: {
       matchLabels: {
-        ['build.appstudio.openshift.io/type']: 'build',
-        ['build.appstudio.openshift.io/application']: applicationName,
+        [PipelineRunLabel.PIPELINE_TYPE]: PipelineRunType.BUILD,
+        [PipelineRunLabel.APPLICATION]: applicationName,
       },
     },
     isList: true,

--- a/src/utils/__tests__/create-utils.spec.ts
+++ b/src/utils/__tests__/create-utils.spec.ts
@@ -86,6 +86,16 @@ const mockComponentDataWithDevfile = {
   },
 };
 
+const mockComponentDataWithPAC = {
+  ...mockComponentDataWithDevfile,
+  metadata: {
+    ...mockComponentDataWithDevfile.metadata,
+    annotations: {
+      pipelinesascode: '1',
+    },
+  },
+};
+
 const mockCDQData = {
   apiVersion: `${ComponentDetectionQueryModel.apiGroup}/${ComponentDetectionQueryModel.apiVersion}`,
   kind: ComponentDetectionQueryModel.kind,
@@ -157,6 +167,64 @@ describe('Create Utils', () => {
         ns: 'test-ns',
       },
       resource: mockComponentDataWithDevfile,
+    });
+  });
+
+  it('Should call k8s create util with pipelines-as-code annotations', async () => {
+    await createComponent(
+      mockComponentWithDevfile,
+      'test-application',
+      'test-ns',
+      undefined,
+      false,
+      null,
+      'create',
+      true,
+    );
+
+    expect(k8sCreateResource).toHaveBeenCalledWith({
+      model: ComponentModel,
+      queryOptions: {
+        name: 'test-component',
+        ns: 'test-ns',
+      },
+      resource: mockComponentDataWithPAC,
+    });
+  });
+
+  it('Should not update pipelines-as-code annotations for the existing components without pac annotations', async () => {
+    await createComponent(
+      mockComponentWithDevfile,
+      'test-application',
+      'test-ns',
+      undefined,
+      false,
+      mockComponentDataWithDevfile,
+      'update',
+      true,
+    );
+
+    expect(k8sUpdateResource).toHaveBeenCalledWith({
+      model: ComponentModel,
+      resource: mockComponentDataWithDevfile,
+    });
+  });
+
+  it('Should contain pipelines-as-code annotations for the existing components with pac annotations', async () => {
+    await createComponent(
+      mockComponentWithDevfile,
+      'test-application',
+      'test-ns',
+      undefined,
+      false,
+      mockComponentDataWithPAC,
+      'update',
+      true,
+    );
+
+    expect(k8sUpdateResource).toHaveBeenCalledWith({
+      model: ComponentModel,
+      resource: mockComponentDataWithPAC,
     });
   });
 

--- a/src/utils/create-utils.ts
+++ b/src/utils/create-utils.ts
@@ -80,6 +80,7 @@ export const createComponent = (
   dryRun?: boolean,
   originalComponent?: ComponentKind,
   verb: 'create' | 'update' = 'create',
+  enablePac: boolean = false,
 ): any => {
   const { componentName, containerImage, source, replicas, resources, env, targetPort } = component;
 
@@ -96,6 +97,12 @@ export const createComponent = (
     metadata: {
       name,
       namespace,
+      ...(enablePac &&
+        verb === 'create' && {
+          annotations: {
+            pipelinesascode: '1',
+          },
+        }),
     },
     spec: {
       componentName,


### PR DESCRIPTION


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Enable the PAC on HACBS workflow by adding the `pipelinesascode` annotation in component creation flow.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

https://user-images.githubusercontent.com/9964343/185442410-bee55725-b1f7-476f-b6be-f3b89b5d9b8c.mov



## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->
1. Fork a devfile repository eg: https://github.com/devfile-samples/devfile-sample-go-basic 
2. Install this Appstudio staging  [GitHub App](https://github.com/apps/appstudio-staging-ci) in your forked repository.
3. use the forked repository to create component in the UI.

## Unit Tests:
```
Create Utils
    ✓ Should call k8s create util with pipelines-as-code annotations (1 ms)
    ✓ Should not update pipelines-as-code annotations for the existing components without pac annotations (2 ms)
    ✓ Should contain pipelines-as-code annotations for the existing components with pac annotations (1 ms) 
```
## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
