### PR TITLE
Add ability to add an integration test to an application

### DIFF
--- a/config/remotePlugin.js
+++ b/config/remotePlugin.js
@@ -6,6 +6,7 @@ const hacbs = {
     PipelineRuns: resolve(__dirname, '../src/hacbs/pages/PipelineRunPage'),
     HACBSFlag: resolve(__dirname, '../src/hacbs/hacbsFeatureFlag'),
     HACBSImport: resolve(__dirname, '../src/hacbs/pages/ImportPage'),
+    HACBSIntegrationTest: resolve(__dirname, '../src/hacbs/pages/IntegrationTestPage'),
   },
   extensions: [
     {
@@ -58,6 +59,32 @@ const hacbs = {
         exact: true,
         component: {
           $codeRef: 'HACBSImport',
+        },
+      },
+      flags: {
+        required: ['HACBS'],
+      },
+    },
+    {
+      type: 'console.page/route',
+      properties: {
+        path: '/app-studio/applications/:appName/integration-test',
+        exact: true,
+        component: {
+          $codeRef: 'HACBSIntegrationTest',
+        },
+      },
+      flags: {
+        required: ['HACBS'],
+      },
+    },
+    {
+      type: 'core.page/route',
+      properties: {
+        path: '/app-studio/applications/:appName/integration-test',
+        exact: true,
+        component: {
+          $codeRef: 'HACBSIntegrationTest',
         },
       },
       flags: {

--- a/src/hacbs/components/ApplicationDetails/HacbsApplicationDetails.tsx
+++ b/src/hacbs/components/ApplicationDetails/HacbsApplicationDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
@@ -75,15 +75,22 @@ const HacbsApplicationDetails: React.FC<HacbsApplicationDetailsProps> = ({ appli
           },
           {
             key: 'add-environment',
-            label: 'Add Environement',
+            label: 'Add Environment',
             href: '',
             isDisabled: true,
           },
           {
-            key: 'add-integration-tests',
+            key: 'add-integration-test',
             label: 'Add Integration test',
-            href: '',
-            isDisabled: true,
+            component: (
+              <Link
+                title="Add integration test"
+                to={`/app-studio/applications/${applicationName}/integration-test`}
+              >
+                Add integration test
+              </Link>
+            ),
+            isDisabled: false,
           },
           {
             key: 'delete-application',

--- a/src/hacbs/components/ImportForm/useImportSteps.tsx
+++ b/src/hacbs/components/ImportForm/useImportSteps.tsx
@@ -11,9 +11,9 @@ import {
   applicationValidationSchema,
 } from '../../../components/ImportForm/utils/validation-utils';
 import { ApplicationKind } from '../../../types';
+import IntegrationTestSection from '../IntegrationTestForm/IntegrationTestSection';
 import BuildSection from './BuildSection';
 import { createAppIntegrationTest } from './create-utils';
-import IntegrationTestSection from './IntegrationTestSection';
 import { FormValues } from './types';
 import { onApplicationSubmit, onComponentsSubmit } from './utils/submit-utils';
 import { integrationTestValidationSchema } from './utils/validation-utils';

--- a/src/hacbs/components/IntegrationTestForm/IntegrationTestForm.tsx
+++ b/src/hacbs/components/IntegrationTestForm/IntegrationTestForm.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import {
+  PageSection,
+  FormSection,
+  Form,
+  TextContent,
+  PageSectionVariants,
+} from '@patternfly/react-core';
+import { FormikProps, FormikValues } from 'formik';
+import isEmpty from 'lodash/isEmpty';
+import PageLayout from '../../../components/PageLayout/PageLayout';
+import { FormFooter } from '../../../shared';
+import IntegrationTestSection, { IntegrationTestDescription } from './IntegrationTestSection';
+
+import '../../../shared/style.scss';
+
+type IntegrationTestFormProps = {
+  applicationName: string;
+};
+
+const IntegrationTestForm: React.FunctionComponent<
+  FormikProps<FormikValues> & IntegrationTestFormProps
+> = ({ applicationName, handleSubmit, handleReset, isSubmitting, status, errors }) => {
+  const footer = (
+    <FormFooter
+      submitLabel="Save"
+      handleCancel={handleReset}
+      handleSubmit={handleSubmit}
+      isSubmitting={isSubmitting}
+      disableSubmit={!isEmpty(errors) || isSubmitting}
+      errorMessage={status?.submitError}
+    />
+  );
+
+  return (
+    <PageLayout
+      breadcrumbs={[
+        { path: '/app-studio/applications', name: 'Applications' },
+        { path: `/app-studio/applications?name=${applicationName}`, name: applicationName },
+        { path: '#', name: 'Integration test pipeline' },
+      ]}
+      title="Add integration test pipeline"
+      description={
+        <TextContent>
+          <IntegrationTestDescription />
+        </TextContent>
+      }
+      footer={footer}
+    >
+      <PageSection isFilled variant={PageSectionVariants.light}>
+        <Form onSubmit={handleSubmit}>
+          <FormSection>
+            <IntegrationTestSection isInPage />
+          </FormSection>
+        </Form>
+      </PageSection>
+    </PageLayout>
+  );
+};
+
+export default IntegrationTestForm;

--- a/src/hacbs/components/IntegrationTestForm/IntegrationTestForm.tsx
+++ b/src/hacbs/components/IntegrationTestForm/IntegrationTestForm.tsx
@@ -20,7 +20,7 @@ const IntegrationTestForm: React.FunctionComponent<IntegrationTestFormProps> = (
   const { dirty, handleSubmit, handleReset, isSubmitting, status, errors } = useFormikContext();
   const footer = (
     <FormFooter
-      submitLabel="Save"
+      submitLabel="Add integration test pipeline"
       handleCancel={handleReset}
       handleSubmit={handleSubmit}
       isSubmitting={isSubmitting}

--- a/src/hacbs/components/IntegrationTestForm/IntegrationTestForm.tsx
+++ b/src/hacbs/components/IntegrationTestForm/IntegrationTestForm.tsx
@@ -1,16 +1,12 @@
 import React from 'react';
-import {
-  PageSection,
-  FormSection,
-  Form,
-  TextContent,
-  PageSectionVariants,
-} from '@patternfly/react-core';
-import { FormikProps, FormikValues } from 'formik';
+import { Form, FormSection, PageSection, PageSectionVariants } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/js/icons';
+import { useFormikContext } from 'formik';
 import isEmpty from 'lodash/isEmpty';
 import PageLayout from '../../../components/PageLayout/PageLayout';
 import { FormFooter } from '../../../shared';
-import IntegrationTestSection, { IntegrationTestDescription } from './IntegrationTestSection';
+import ExternalLink from '../../../shared/components/links/ExternalLink';
+import IntegrationTestSection from './IntegrationTestSection';
 
 import '../../../shared/style.scss';
 
@@ -18,16 +14,17 @@ type IntegrationTestFormProps = {
   applicationName: string;
 };
 
-const IntegrationTestForm: React.FunctionComponent<
-  FormikProps<FormikValues> & IntegrationTestFormProps
-> = ({ applicationName, handleSubmit, handleReset, isSubmitting, status, errors }) => {
+const IntegrationTestForm: React.FunctionComponent<IntegrationTestFormProps> = ({
+  applicationName,
+}) => {
+  const { dirty, handleSubmit, handleReset, isSubmitting, status, errors } = useFormikContext();
   const footer = (
     <FormFooter
       submitLabel="Save"
       handleCancel={handleReset}
       handleSubmit={handleSubmit}
       isSubmitting={isSubmitting}
-      disableSubmit={!isEmpty(errors) || isSubmitting}
+      disableSubmit={!dirty || !isEmpty(errors) || isSubmitting}
       errorMessage={status?.submitError}
     />
   );
@@ -41,9 +38,17 @@ const IntegrationTestForm: React.FunctionComponent<
       ]}
       title="Add integration test pipeline"
       description={
-        <TextContent>
-          <IntegrationTestDescription />
-        </TextContent>
+        <>
+          Add an integration test pipeline to test all your components.
+          <br />
+          By default, previous GitHub credentials will be used to validate your URL. If it fails,
+          you must revalidate with a different repo.
+          <br />
+          <br />
+          <ExternalLink href="#">
+            Learn more about setting up an integration test pipeline <ExternalLinkAltIcon />
+          </ExternalLink>
+        </>
       }
       footer={footer}
     >

--- a/src/hacbs/components/IntegrationTestForm/IntegrationTestSection.tsx
+++ b/src/hacbs/components/IntegrationTestForm/IntegrationTestSection.tsx
@@ -13,19 +13,6 @@ import { CheckboxField, HelpTooltipIcon, InputField } from '../../../shared';
 import ExternalLink from '../../../shared/components/links/ExternalLink';
 import { FormValues } from '../ImportForm/types';
 
-const IntegrationTestDescription: React.FunctionComponent = () => (
-  <>
-    <Text component={TextVariants.p}>
-      Add an integration test pipeline to test all your components.
-      <br />
-      By default, previous GitHub credentials will be used to validate your URL. If it fails, you
-      must revalidate with a different repo.
-    </Text>
-    <ExternalLink href="#">
-      Learn more about setting up an integration test pipeline <ExternalLinkAltIcon />
-    </ExternalLink>
-  </>
-);
 const IntegrationTestSection: React.FunctionComponent<{ isInPage?: boolean }> = ({ isInPage }) => {
   const [infoAlert, setInfoAlert] = React.useState<boolean>(true);
   const { setTouched } = useFormikContext<FormValues>();
@@ -40,14 +27,23 @@ const IntegrationTestSection: React.FunctionComponent<{ isInPage?: boolean }> = 
     <>
       {!isInPage ? (
         <>
-          <TextContent>
+          <TextContent data-test="integration-test-section-header">
             <Text component={TextVariants.h1}>Add integration test pipeline</Text>
-            <IntegrationTestDescription />
+            <Text component={TextVariants.p}>
+              Add an integration test pipeline to test all your components.
+              <br />
+              By default, previous GitHub credentials will be used to validate your URL. If it
+              fails, you fails, you must revalidate with a different repo.
+            </Text>
+            <ExternalLink href="#">
+              Learn more about setting up an integration test pipeline <ExternalLinkAltIcon />
+            </ExternalLink>
           </TextContent>
         </>
       ) : null}
       <FormSection>
         <InputField
+          aria-label="Display name"
           label="Display name"
           name="integrationTest.name"
           placeholder="Enter the integration test pipeline name"
@@ -55,11 +51,13 @@ const IntegrationTestSection: React.FunctionComponent<{ isInPage?: boolean }> = 
         />
         <InputField
           required
+          aria-label="Container image"
           label="Container image"
           labelIcon={<HelpTooltipIcon content={'Provide your image bundle'} />}
           name="integrationTest.bundle"
         />
         <InputField
+          aria-label="Pipeline specified in container image"
           label="Pipeline specified in container image"
           name="integrationTest.pipeline"
           helpText="Specify the pipeline name as it appears in the image bundle."
@@ -67,6 +65,7 @@ const IntegrationTestSection: React.FunctionComponent<{ isInPage?: boolean }> = 
         />
         <CheckboxField
           name="integrationTest.optional"
+          aria-label="Mark as optional for release"
           label="Mark as optional for release"
           helpText="Passing this test is optional, and it cannot prevent the application from being deployed or released."
         />
@@ -93,4 +92,4 @@ const IntegrationTestSection: React.FunctionComponent<{ isInPage?: boolean }> = 
   );
 };
 
-export { IntegrationTestSection as default, IntegrationTestDescription };
+export default IntegrationTestSection;

--- a/src/hacbs/components/IntegrationTestForm/IntegrationTestSection.tsx
+++ b/src/hacbs/components/IntegrationTestForm/IntegrationTestSection.tsx
@@ -11,9 +11,22 @@ import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/js/icons';
 import { useFormikContext } from 'formik';
 import { CheckboxField, HelpTooltipIcon, InputField } from '../../../shared';
 import ExternalLink from '../../../shared/components/links/ExternalLink';
-import { FormValues } from './types';
+import { FormValues } from '../ImportForm/types';
 
-const IntegrationTestSection: React.FunctionComponent = () => {
+const IntegrationTestDescription: React.FunctionComponent = () => (
+  <>
+    <Text component={TextVariants.p}>
+      Add an integration test pipeline to test all your components.
+      <br />
+      By default, previous GitHub credentials will be used to validate your URL. If it fails, you
+      must revalidate with a different repo.
+    </Text>
+    <ExternalLink href="#">
+      Learn more about setting up an integration test pipeline <ExternalLinkAltIcon />
+    </ExternalLink>
+  </>
+);
+const IntegrationTestSection: React.FunctionComponent<{ isInPage?: boolean }> = ({ isInPage }) => {
   const [infoAlert, setInfoAlert] = React.useState<boolean>(true);
   const { setTouched } = useFormikContext<FormValues>();
 
@@ -25,18 +38,14 @@ const IntegrationTestSection: React.FunctionComponent = () => {
 
   return (
     <>
-      <TextContent>
-        <Text component={TextVariants.h1}>Add integration test pipeline</Text>
-        <Text component={TextVariants.p}>
-          Add an integration test pipeline to test all your components.
-          <br />
-          By default, previous GitHub credentials will be used to validate your URL. If it fails,
-          you must revalidate with a different repo.
-        </Text>
-        <ExternalLink href="#">
-          Learn more about setting up an integration test pipeline <ExternalLinkAltIcon />
-        </ExternalLink>
-      </TextContent>
+      {!isInPage ? (
+        <>
+          <TextContent>
+            <Text component={TextVariants.h1}>Add integration test pipeline</Text>
+            <IntegrationTestDescription />
+          </TextContent>
+        </>
+      ) : null}
       <FormSection>
         <InputField
           label="Display name"
@@ -84,4 +93,4 @@ const IntegrationTestSection: React.FunctionComponent = () => {
   );
 };
 
-export default IntegrationTestSection;
+export { IntegrationTestSection as default, IntegrationTestDescription };

--- a/src/hacbs/components/IntegrationTestForm/IntegrationTestView.tsx
+++ b/src/hacbs/components/IntegrationTestForm/IntegrationTestView.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Formik } from 'formik';
-import { reviewValidationSchema } from '../../../components/ImportForm/utils/validation-utils';
 import { useNamespace } from '../../../utils/namespace-context-utils';
 import { createIntegrationTest } from '../ImportForm/create-utils';
+import { integrationTestValidationSchema } from '../ImportForm/utils/validation-utils';
 import IntegrationTestForm from './IntegrationTestForm';
 
 type IntegrationTestViewProps = {
@@ -45,7 +45,7 @@ const IntegrationTestView: React.FunctionComponent<IntegrationTestViewProps> = (
       onSubmit={handleSubmit}
       onReset={() => navigate(-1)}
       initialValues={initialValues}
-      validationSchema={reviewValidationSchema}
+      validationSchema={integrationTestValidationSchema}
     >
       {(props) => <IntegrationTestForm applicationName={applicationName} {...props} />}
     </Formik>

--- a/src/hacbs/components/IntegrationTestForm/IntegrationTestView.tsx
+++ b/src/hacbs/components/IntegrationTestForm/IntegrationTestView.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Formik } from 'formik';
+import { reviewValidationSchema } from '../../../components/ImportForm/utils/validation-utils';
+import { useNamespace } from '../../../utils/namespace-context-utils';
+import { createIntegrationTest } from '../ImportForm/create-utils';
+import IntegrationTestForm from './IntegrationTestForm';
+
+type IntegrationTestViewProps = {
+  applicationName: string;
+  integrationTestName?: string;
+};
+
+const IntegrationTestView: React.FunctionComponent<IntegrationTestViewProps> = ({
+  applicationName,
+}) => {
+  const navigate = useNavigate();
+  const namespace = useNamespace();
+
+  const initialValues = {
+    integrationTest: {
+      name: '',
+      bundle: '',
+      pipeline: '',
+      optional: false,
+    },
+    isDetected: true,
+  };
+
+  const handleSubmit = (values, actions) => {
+    return createIntegrationTest(values.integrationTest, applicationName, namespace)
+      .then(() => {
+        navigate(`/app-studio/applications?name=${applicationName}&activeTab=integrationtests`);
+      })
+      .catch((error) => {
+        // eslint-disable-next-line no-console
+        console.warn('Error while submitting integration test:', error);
+        actions.setSubmitting(false);
+        actions.setStatus({ submitError: error.message });
+      });
+  };
+
+  return (
+    <Formik
+      onSubmit={handleSubmit}
+      onReset={() => navigate(-1)}
+      initialValues={initialValues}
+      validationSchema={reviewValidationSchema}
+    >
+      {(props) => <IntegrationTestForm applicationName={applicationName} {...props} />}
+    </Formik>
+  );
+};
+
+export default IntegrationTestView;

--- a/src/hacbs/components/IntegrationTestForm/__tests__/IntegrationTestSection.spec.tsx
+++ b/src/hacbs/components/IntegrationTestForm/__tests__/IntegrationTestSection.spec.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { configure, render } from '@testing-library/react';
+import { useField, useFormikContext } from 'formik';
+import IntegrationTestSection from '../IntegrationTestSection';
+
+const navigateMock = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  Link: (props) => <a href={props.to}>{props.children}</a>,
+  useNavigate: () => navigateMock,
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: jest.fn(() => ({ t: (x) => x })),
+}));
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  useK8sWatchResource: jest.fn(),
+}));
+
+const useK8sWatchResourceMock = useK8sWatchResource as jest.Mock;
+
+jest.mock('formik', () => ({
+  useFormikContext: jest.fn(),
+  useField: jest.fn(),
+}));
+
+const useFormikContextMock = useFormikContext as jest.Mock;
+
+const useFieldMock = useField as jest.Mock;
+
+configure({ testIdAttribute: 'data-test' });
+
+describe('IntegrationTestSection', () => {
+  it('should render the page header by default', async () => {
+    useK8sWatchResourceMock.mockReturnValue([[], false]);
+    useFormikContextMock.mockReturnValue({
+      setTouched: () => {},
+      values: { source: 'test-source', secret: null },
+      setFieldValue: jest.fn(),
+      useField: () => ['', { touched: false, error: undefined }],
+      setStatus: jest.fn(),
+    });
+    useFieldMock.mockReturnValue([{ value: false }, { touched: false, error: null }]);
+    const wrapper = render(<IntegrationTestSection />);
+    await expect(wrapper).toBeTruthy();
+    expect(wrapper.getByTestId('integration-test-section-header')).toBeTruthy();
+  });
+  it('should hide the page header when isInPage is set', async () => {
+    useK8sWatchResourceMock.mockReturnValue([[], false]);
+    useFormikContextMock.mockReturnValue({
+      setTouched: () => {},
+      values: { source: 'test-source', secret: null },
+      setFieldValue: jest.fn(),
+      useField: () => ['', { touched: false, error: undefined }],
+      setStatus: jest.fn(),
+    });
+    useFieldMock.mockReturnValue([{ value: false }, { touched: false, error: null }]);
+    const wrapper = render(<IntegrationTestSection isInPage />);
+    let found;
+    try {
+      wrapper.getByTestId('integration-test-section-header');
+      found = true;
+    } catch {
+      found = false;
+    }
+    expect(found).toEqual(false);
+  });
+});

--- a/src/hacbs/components/IntegrationTestForm/__tests__/IntegrationTestView.spec.tsx
+++ b/src/hacbs/components/IntegrationTestForm/__tests__/IntegrationTestView.spec.tsx
@@ -56,14 +56,14 @@ describe('IntegrationTestView', () => {
     wrapper.getByLabelText('Display name');
     wrapper.getByLabelText('Container image');
     wrapper.getByLabelText('Pipeline specified in container image');
-    wrapper.getByRole('button', { name: 'Save' });
+    wrapper.getByRole('button', { name: 'Add integration test pipeline' });
   });
 
   it('should enable the submit button when there are no errors', async () => {
     const wrapper = render(<IntegrationTestView applicationName="test-app" />);
     await expect(wrapper).toBeTruthy();
 
-    const submitButton = wrapper.getByRole('button', { name: 'Save' });
+    const submitButton = wrapper.getByRole('button', { name: 'Add integration test pipeline' });
     expect(submitButton).toBeDisabled();
     fillIntegrationTestForm(wrapper);
     expect(submitButton).toBeEnabled();
@@ -80,7 +80,7 @@ describe('IntegrationTestView', () => {
 
     fillIntegrationTestForm(wrapper);
 
-    const submitButton = wrapper.getByRole('button', { name: 'Save' });
+    const submitButton = wrapper.getByRole('button', { name: 'Add integration test pipeline' });
     expect(submitButton).toBeTruthy();
     expect(submitButton).toBeEnabled();
 

--- a/src/hacbs/components/IntegrationTestForm/__tests__/IntegrationTestView.spec.tsx
+++ b/src/hacbs/components/IntegrationTestForm/__tests__/IntegrationTestView.spec.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { configure, fireEvent, render, RenderResult, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { createIntegrationTest } from '../../ImportForm/create-utils';
+import IntegrationTestView from '../IntegrationTestView';
+
+const navigateMock = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  Link: (props) => <a href={props.to}>{props.children}</a>,
+  useNavigate: () => navigateMock,
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: jest.fn(() => ({ t: (x) => x })),
+}));
+
+jest.mock('../../ImportForm/create-utils', () => ({
+  createIntegrationTest: jest.fn(),
+}));
+
+const createIntegrationTestMock = createIntegrationTest as jest.Mock;
+
+configure({ testIdAttribute: 'data-test' });
+
+class MockResizeObserver {
+  observe() {
+    // do nothing
+  }
+
+  unobserve() {
+    // do nothing
+  }
+
+  disconnect() {
+    // do nothing
+  }
+}
+
+window.ResizeObserver = MockResizeObserver;
+
+describe('IntegrationTestView', () => {
+  const fillIntegrationTestForm = (wrapper: RenderResult) => {
+    fireEvent.input(wrapper.getByLabelText('Display name'), { target: { value: 'new test name' } });
+    fireEvent.input(wrapper.getByLabelText('Container image'), {
+      target: { value: 'quay.io/kpavic/test-bundle:pipeline' },
+    });
+    fireEvent.input(wrapper.getByLabelText('Pipeline specified in container image'), {
+      target: { value: 'new-test-pipeline' },
+    });
+  };
+  it('should render the form by default', async () => {
+    const wrapper = render(<IntegrationTestView applicationName="test-app" />);
+    await expect(wrapper).toBeTruthy();
+
+    wrapper.getByLabelText('Display name');
+    wrapper.getByLabelText('Container image');
+    wrapper.getByLabelText('Pipeline specified in container image');
+    wrapper.getByRole('button', { name: 'Save' });
+  });
+
+  it('should enable the submit button when there are no errors', async () => {
+    const wrapper = render(<IntegrationTestView applicationName="test-app" />);
+    await expect(wrapper).toBeTruthy();
+
+    const submitButton = wrapper.getByRole('button', { name: 'Save' });
+    expect(submitButton).toBeDisabled();
+    fillIntegrationTestForm(wrapper);
+    expect(submitButton).toBeEnabled();
+  });
+
+  it('should navigate to the integration test tab on submit', async () => {
+    createIntegrationTestMock.mockImplementation(() => {
+      return new Promise<void>((resolve) => {
+        resolve();
+      });
+    });
+    const wrapper = render(<IntegrationTestView applicationName="test-app" />);
+    await expect(wrapper).toBeTruthy();
+
+    fillIntegrationTestForm(wrapper);
+
+    const submitButton = wrapper.getByRole('button', { name: 'Save' });
+    expect(submitButton).toBeTruthy();
+    expect(submitButton).toBeEnabled();
+
+    await waitFor(() => fireEvent.click(submitButton));
+    await waitFor(() => expect(createIntegrationTestMock).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith(
+        '/app-studio/applications?name=test-app&activeTab=integrationtests',
+      ),
+    );
+  });
+});

--- a/src/hacbs/components/IntegrationTestsListView/IntegrationTestsListView.tsx
+++ b/src/hacbs/components/IntegrationTestsListView/IntegrationTestsListView.tsx
@@ -35,7 +35,9 @@ type IntegrationTestsListViewProps = {
   applicationName: string;
 };
 
-const IntegrationTestsEmptyState: React.FC = () => (
+const IntegrationTestsEmptyState: React.FC<IntegrationTestsListViewProps> = ({
+  applicationName,
+}) => (
   <EmptyState data-test="integration-tests__empty">
     <EmptyStateIcon icon={CodeBranchIcon} />
     <Title headingLevel="h4" size="lg">
@@ -62,7 +64,12 @@ const IntegrationTestsEmptyState: React.FC = () => (
       />
     </EmptyStateBody>
     <EmptyStateSecondaryActions>
-      <Button isDisabled component={(props) => <Link {...props} to="#" />} variant="primary">
+      <Button
+        component={(props) => (
+          <Link {...props} to={`/app-studio/applications/${applicationName}/integration-test`} />
+        )}
+        variant="primary"
+      >
         Add integration test
       </Button>
     </EmptyStateSecondaryActions>
@@ -127,7 +134,7 @@ const IntegrationTestsListView: React.FC<IntegrationTestsListViewProps> = ({ app
   }
 
   if (!applicationIntegrationTests?.length) {
-    return <IntegrationTestsEmptyState />;
+    return <IntegrationTestsEmptyState applicationName={applicationName} />;
   }
   const onClearFilters = () => setNameFilter('');
   const onNameInput = (name: string) => setNameFilter(name);

--- a/src/hacbs/components/IntegrationTestsListView/IntegrationTestsListView.tsx
+++ b/src/hacbs/components/IntegrationTestsListView/IntegrationTestsListView.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import {
   Bullseye,
   Button,
+  ButtonVariant,
   EmptyState,
   EmptyStateBody,
   EmptyStateIcon,
@@ -35,9 +36,7 @@ type IntegrationTestsListViewProps = {
   applicationName: string;
 };
 
-const IntegrationTestsEmptyState: React.FC<IntegrationTestsListViewProps> = ({
-  applicationName,
-}) => (
+const IntegrationTestsEmptyState: React.FC<{ handleAddTest: () => void }> = ({ handleAddTest }) => (
   <EmptyState data-test="integration-tests__empty">
     <EmptyStateIcon icon={CodeBranchIcon} />
     <Title headingLevel="h4" size="lg">
@@ -65,10 +64,9 @@ const IntegrationTestsEmptyState: React.FC<IntegrationTestsListViewProps> = ({
     </EmptyStateBody>
     <EmptyStateSecondaryActions>
       <Button
-        component={(props) => (
-          <Link {...props} to={`/app-studio/applications/${applicationName}/integration-test`} />
-        )}
-        variant="primary"
+        variant={ButtonVariant.primary}
+        onClick={handleAddTest}
+        data-test="add-integration-test"
       >
         Add integration test
       </Button>
@@ -96,6 +94,7 @@ const IntegrationTestsFilteredState: React.FC<{ onClearFilters: () => void }> = 
 );
 const IntegrationTestsListView: React.FC<IntegrationTestsListViewProps> = ({ applicationName }) => {
   const namespace = useNamespace();
+  const navigate = useNavigate();
   const [integrationTests, integrationTestsLoaded] = useK8sWatchResource<
     IntegrationTestScenarioKind[]
   >({
@@ -123,6 +122,10 @@ const IntegrationTestsListView: React.FC<IntegrationTestsListViewProps> = ({ app
     [nameFilter, applicationIntegrationTests],
   );
 
+  const handleAddTest = React.useCallback(() => {
+    navigate(`/app-studio/applications/${applicationName}/integration-test`);
+  }, [navigate, applicationName]);
+
   const loading = (
     <Bullseye className="pf-u-mt-md" data-test="integration-tests__loading">
       <Spinner />
@@ -134,7 +137,7 @@ const IntegrationTestsListView: React.FC<IntegrationTestsListViewProps> = ({ app
   }
 
   if (!applicationIntegrationTests?.length) {
-    return <IntegrationTestsEmptyState applicationName={applicationName} />;
+    return <IntegrationTestsEmptyState handleAddTest={handleAddTest} />;
   }
   const onClearFilters = () => setNameFilter('');
   const onNameInput = (name: string) => setNameFilter(name);

--- a/src/hacbs/components/IntegrationTestsListView/__tests__/IntegrationTestsListView.spec.tsx
+++ b/src/hacbs/components/IntegrationTestsListView/__tests__/IntegrationTestsListView.spec.tsx
@@ -1,9 +1,15 @@
 import * as React from 'react';
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
-import { configure } from '@testing-library/react';
-import { routerRenderer } from '../../../../utils/test-utils';
+import { configure, fireEvent, waitFor, render } from '@testing-library/react';
 import { MockIntegrationTests } from '../__data__/mock-integration-tests';
 import IntegrationTestsListView from '../IntegrationTestsListView';
+
+const navigateMock = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  Link: (props) => <a href={props.to}>{props.children}</a>,
+  useNavigate: () => navigateMock,
+}));
 
 jest.mock('react-i18next', () => ({
   useTranslation: jest.fn(() => ({ t: (x) => x })),
@@ -20,19 +26,32 @@ configure({ testIdAttribute: 'data-test' });
 describe('IntegrationTestsListView', () => {
   it('should render the skeleton table if integration tests data is not loaded', () => {
     useK8sWatchResourceMock.mockReturnValue([[], false]);
-    const wrapper = routerRenderer(<IntegrationTestsListView applicationName="test-app" />);
+    const wrapper = render(<IntegrationTestsListView applicationName="test-app" />);
     expect(wrapper.findByText('No integration test pipelines found yet.')).toBeTruthy();
   });
 
   it('should render the empty state if there are no integration tests', () => {
     useK8sWatchResourceMock.mockReturnValue([[], true, undefined]);
-    const wrapper = routerRenderer(<IntegrationTestsListView applicationName="test-app" />);
+    const wrapper = render(<IntegrationTestsListView applicationName="test-app" />);
     expect(wrapper.findByText('No integration test pipelines found yet.')).toBeTruthy();
   });
 
   it('should render a table when there are integration tests', () => {
     useK8sWatchResourceMock.mockReturnValue([MockIntegrationTests, true, undefined]);
-    const wrapper = routerRenderer(<IntegrationTestsListView applicationName="test-app" />);
+    const wrapper = render(<IntegrationTestsListView applicationName="test-app" />);
     expect(wrapper.container.getElementsByTagName('table')).toHaveLength(1);
+  });
+
+  it('should show the add integration test page on Add action', async () => {
+    useK8sWatchResourceMock.mockReturnValue([[], true, undefined]);
+    const wrapper = render(<IntegrationTestsListView applicationName="test-app" />);
+    const addButton = wrapper.getByTestId('add-integration-test');
+    fireEvent.click(addButton);
+
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith(
+        '/app-studio/applications/test-app/integration-test',
+      ),
+    );
   });
 });

--- a/src/hacbs/pages/IntegrationTestPage.tsx
+++ b/src/hacbs/pages/IntegrationTestPage.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import { useParams } from 'react-router-dom';
+import NamespacedPage from '../../components/NamespacedPage/NamespacedPage';
+import IntegrationTestView from '../components/IntegrationTestForm/IntegrationTestView';
+
+const IntegrationTestPage: React.FunctionComponent = () => {
+  const { appName } = useParams();
+
+  return (
+    <NamespacedPage>
+      <Helmet>
+        <title>Create integration test</title>
+      </Helmet>
+      <IntegrationTestView applicationName={appName} />
+    </NamespacedPage>
+  );
+};
+
+export default IntegrationTestPage;


### PR DESCRIPTION
## Fixes 
Fixes [HACBS-820](https://issues.redhat.com/browse/HACBS-820)

## Description
Allows users to add an integration test to an existing application, either from the empty state or from the actions menu for an application.


## Type of change
- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
![image](https://user-images.githubusercontent.com/11633780/185650302-9948926e-7f49-46cf-af33-50cb99282fd4.png)

![image](https://user-images.githubusercontent.com/11633780/185650499-16adf40a-dc81-4f43-b3d7-e6ea01cbaab4.png)

## How to test or reproduce?

Navigate to an Application.
From the `Actions` menu, select `Add integration test`

Navigate to an application that has no integration tests.
Click the `Add integration test` button.

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
