### PR TITLE
fix 'Go to application' from wizard

### DIFF
--- a/src/hacbs/components/ImportForm/__tests__/ImportForm.spec.tsx
+++ b/src/hacbs/components/ImportForm/__tests__/ImportForm.spec.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { render } from '@testing-library/react';
 import { FormikWizard } from 'formik-pf';
+import { act } from 'react-dom/test-utils';
 import ImportForm from '../ImportForm';
+import { useImportSteps } from '../useImportSteps';
 
 jest.mock('../../../../components/NamespacedPage/NamespacedPage', () => ({
   useNamespace: jest.fn(() => 'test'),
@@ -16,8 +18,13 @@ jest.mock('formik-pf', () => ({
   FormikWizard: jest.fn(() => null),
 }));
 
+jest.mock('../useImportSteps', () => ({
+  useImportSteps: jest.fn(),
+}));
+
 const useNavigateMock = useNavigate as jest.Mock;
 const FormikWizardMock = FormikWizard as jest.Mock;
+const useImportStepsMock = useImportSteps as jest.Mock;
 
 describe('ImportForm', () => {
   it('should handle form reset', () => {
@@ -34,18 +41,19 @@ describe('ImportForm', () => {
     wizardProps.onReset({}, {} as any);
     expect(navigateMock).toHaveBeenCalledWith(-1);
 
-    // navigate to application page when an application has been created
     navigateMock.mockReset();
-    wizardProps.onReset(
-      {
-        applicationData: {
-          metadata: {
-            name: 'my-app',
-          },
+
+    // navigate to application page when an application has been created
+    expect(useImportStepsMock).toHaveBeenCalledTimes(1);
+    const { onApplicationCreated } = useImportStepsMock.mock.calls[0][1];
+    act(() => {
+      onApplicationCreated({
+        metadata: {
+          name: 'my-app',
         },
-      },
-      {} as any,
-    );
+      });
+    });
+    wizardProps.onReset({}, {} as any);
     expect(navigateMock).toHaveBeenCalledWith('/app-studio/applications?name=my-app');
   });
 });

--- a/src/hacbs/components/ImportForm/utils/submit-utils.ts
+++ b/src/hacbs/components/ImportForm/utils/submit-utils.ts
@@ -41,6 +41,7 @@ export const onApplicationSubmit = async (
     await createApplication(application, namespace, true);
     const applicationData = await createApplication(application, namespace, false);
     formikBag.setFieldValue('applicationData', applicationData);
+    return applicationData;
   } catch (error) {
     const message = error.code === 409 ? 'Application name already exists.' : error.message;
     formikBag.setFieldError('application', message);


### PR DESCRIPTION
## Fixes
Fix the "Go to application" link in the from the wizard not navigating to the application page.

## Description
The "Go to application" link would always navigate to the application list instead of the application details page.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

With HACBS enabled.
Start the create application wizard.
Enter an application name and click next.
Click the "Go to application" link.


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
