### PR TITLE
update hacbs labels to correct values

### DIFF
--- a/src/hacbs/consts/pipelinerun.ts
+++ b/src/hacbs/consts/pipelinerun.ts
@@ -1,6 +1,6 @@
 export enum PipelineRunLabel {
-  APPLICATION = 'appstudio.openshift.io/application',
-  COMPONENT = 'appstudio.openshift.io/component',
+  APPLICATION = 'build.appstudio.openshift.io/application',
+  COMPONENT = 'build.appstudio.openshift.io/component',
   PIPELINE_TYPE = 'pipelines.appstudio.openshift.io/type',
 }
 


### PR DESCRIPTION
## Fixes 
Fix incorrect label constants.

## Description
HACBS labels need the `build.` prefix which is missing in the cosntants.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## How to test or reproduce?
- create an app
- go to the pipeline runs tab where you should see a pipeline run listed if the PR was merged

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
