### PR TITLE
fix workflow visualization with non existing parent environment

### DIFF
--- a/src/hacbs/components/ApplicationDetails/tabs/overview/visualization/hooks/__data__/workflow-data.ts
+++ b/src/hacbs/components/ApplicationDetails/tabs/overview/visualization/hooks/__data__/workflow-data.ts
@@ -202,6 +202,33 @@ export const sampleEnvironments: EnvironmentKind[] = [
   },
 ];
 
+export const sampleEnvironmentsWithInvalidParentEnvironment: EnvironmentKind[] = [
+  ...sampleEnvironments,
+  {
+    apiVersion: 'appstudio.redhat.com/v1alpha1',
+    kind: 'Environment',
+    metadata: {
+      name: 'testing-environment',
+      uid: '210d9440-2ebf-49c7-a6df-1fa5d21cb111',
+    },
+    spec: {
+      configuration: {
+        env: [
+          {
+            name: 'env',
+            value: 'prod',
+          },
+        ],
+      },
+      parentEnvironment: 'invalid-environment',
+      deploymentStrategy: 'Manual',
+      displayName: 'Staging Environment',
+      tags: ['prod'],
+      type: 'poc',
+    },
+  },
+];
+
 export const sampleIntegrationTestScenarios: IntegrationTestScenarioKind[] = [
   {
     apiVersion: 'appstudio.redhat.com/v1alpha1',

--- a/src/hacbs/components/ApplicationDetails/tabs/overview/visualization/hooks/useAppWorkflowData.ts
+++ b/src/hacbs/components/ApplicationDetails/tabs/overview/visualization/hooks/useAppWorkflowData.ts
@@ -7,7 +7,7 @@ import {
   useBuildPipelines,
 } from '../../../../../../hooks';
 import { Workflow, WorkflowNode, WorkflowNodeType } from '../types';
-import { getLastEnvironment, workflowToNodes } from '../utils/visualization-utils';
+import { getLastEnvironments, workflowToNodes } from '../utils/visualization-utils';
 
 export const useAppWorkflowData = (
   applicationName: string,
@@ -118,7 +118,7 @@ export const useAppWorkflowData = (
       },
       runBefore: [],
       runAfter: isResourcesAvailable(environments)
-        ? [getLastEnvironment(environments)]
+        ? getLastEnvironments(environments)
         : ['static-env'],
     },
   };

--- a/src/hacbs/components/ApplicationDetails/tabs/overview/visualization/utils/__tests__/visualization-utils.spec.ts
+++ b/src/hacbs/components/ApplicationDetails/tabs/overview/visualization/utils/__tests__/visualization-utils.spec.ts
@@ -1,14 +1,16 @@
 import { DAG } from '../../../../../../topology/dag';
 import { NodeType } from '../../const';
-import { sampleEnvironments } from '../../hooks/__data__/workflow-data';
+import {
+  sampleEnvironments,
+  sampleEnvironmentsWithInvalidParentEnvironment,
+} from '../../hooks/__data__/workflow-data';
 import { Workflow, WorkflowNodeType } from '../../types';
 import {
   dagtoNodes,
-  getLastEnvironment,
+  getLastEnvironments,
   getMaxName,
   getTopologyNodesEdges,
   getWorkflowNodes,
-  sortEnvironments,
   workflowToNodes,
 } from '../visualization-utils';
 
@@ -130,60 +132,49 @@ describe('workflowToNodes', () => {
   });
 });
 
-describe('sortEnvironments', () => {
-  test('should return empty array for invalid values', () => {
-    expect(sortEnvironments(null)).toHaveLength(0);
-    expect(sortEnvironments(undefined)).toHaveLength(0);
-    expect(sortEnvironments([])).toHaveLength(0);
+describe('getLastEnvironments', () => {
+  test('should return default environment for invalid values', () => {
+    expect(getLastEnvironments([])).toEqual(['static-env']);
+    expect(getLastEnvironments(null)).toEqual(['static-env']);
+    expect(getLastEnvironments(undefined)).toEqual(['static-env']);
   });
 
-  test('should return sorted array of environments', () => {
-    const sortedEnvironments = sortEnvironments(sampleEnvironments);
-    expect(sortedEnvironments).toHaveLength(3);
-    expect(sortedEnvironments[0]).toBe('test-environment');
-    expect(sortedEnvironments[1]).toBe('staging-environment');
-    expect(sortedEnvironments[2]).toBe('production-environment');
+  test('should return the last environments in the list', () => {
+    expect(getLastEnvironments(sampleEnvironments)).toEqual(['production-environment']);
+  });
+
+  test('should contain the environments with non existing parent name', () => {
+    expect(getLastEnvironments(sampleEnvironmentsWithInvalidParentEnvironment)).toEqual([
+      'production-environment',
+      'testing-environment',
+    ]);
   });
 });
 
-describe('getLastEnvironment', () => {
-  test('should return default environment for invalid values', () => {
-    expect(getLastEnvironment([])).toBe('static-env');
-    expect(getLastEnvironment(null)).toBe('static-env');
-    expect(getLastEnvironment(undefined)).toBe('static-env');
-  });
+describe('getMaxName', () => {
+  test('should return the max length resources', () => {
+    expect(getMaxName([])).toBe(null);
+    expect(getMaxName(undefined)).toBe(null);
+    expect(getMaxName(null)).toBe(null);
 
-  test('should return the last environment in the list', () => {
-    expect(getLastEnvironment(sampleEnvironments)).toBe('production-environment');
-  });
-
-  describe('getMaxName', () => {
-    test('should return the max length resources', () => {
-      expect(getMaxName([])).toBe(null);
-      expect(getMaxName(undefined)).toBe(null);
-      expect(getMaxName(null)).toBe(null);
-    });
-
-    test('should return the max length resources', () => {
-      const comp1 = {
-        ...sampleEnvironments[0],
-        metadata: {
-          name: 'one',
-        },
-      };
-      const comp2 = {
-        ...sampleEnvironments[0],
-        metadata: {
-          name: 'two',
-        },
-      };
-      const comp3 = {
-        ...sampleEnvironments[0],
-        metadata: {
-          name: 'three',
-        },
-      };
-      expect(getMaxName([comp1, comp2, comp3])).toBe('three');
-    });
+    const comp1 = {
+      ...sampleEnvironments[0],
+      metadata: {
+        name: 'one',
+      },
+    };
+    const comp2 = {
+      ...sampleEnvironments[0],
+      metadata: {
+        name: 'two',
+      },
+    };
+    const comp3 = {
+      ...sampleEnvironments[0],
+      metadata: {
+        name: 'three',
+      },
+    };
+    expect(getMaxName([comp1, comp2, comp3])).toBe('three');
   });
 });


### PR DESCRIPTION
## Fixes

https://issues.redhat.com/browse/HACBS-1061

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Handle Workflow visualization with environments that has `parentEnvironment` set to a non-existing environment name.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
Before:
<img width="1480" alt="image" src="https://user-images.githubusercontent.com/9964343/186743626-39df7a2d-ac67-4393-8b74-5493a7a25d78.png">

After: 
<img width="1486" alt="image" src="https://user-images.githubusercontent.com/9964343/186742187-11d3298f-10f3-4163-a9ef-3e8cfde50c61.png">


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->


Create an Environment in an application with invalid parentEnvironment name

```
apiVersion: appstudio.redhat.com/v1alpha1
kind: Environment
metadata:
  name: poc
spec:
  type: poc
  deploymentController: appstudio
  deploymentStrategy: Manual
  displayName: Test Environment
  parentEnvironment: non-existing-environment 
  tags:
    - test
  clusterCredentials:
    apiServerURL: http://example.com/prod
  configuration:
    env:
      - name: env
        value: test
```

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
