### PR TITLE
More complete changes to pipelinerun details page

### DIFF
--- a/src/hacbs/components/ApplicationDetails/tabs/overview/visualization/hooks/__data__/workflow-data.ts
+++ b/src/hacbs/components/ApplicationDetails/tabs/overview/visualization/hooks/__data__/workflow-data.ts
@@ -20,11 +20,147 @@ export const sampleBuildPipelines: PipelineRunKind[] = [
         'pipelines.openshift.io/strategy': 'docker',
         'tekton.dev/pipeline': 'docker-build',
         'pipelines.openshift.io/used-by': 'build-cloud',
+        'pipelinesascode.tekton.dev/sha': '010101010110',
         'build.appstudio.openshift.io/build': 'true',
         'build.appstudio.openshift.io/application': 'frontend-app',
         'build.appstudio.openshift.io/type': 'build',
         'pipelines.appstudio.openshift.io/type': 'build',
         'build.appstudio.openshift.io/version': '0.1',
+      },
+      annotations: {
+        'build.appstudio.openshift.io/component': '1-nodejs',
+        'pipelines.openshift.io/runtime': 'generic',
+      },
+    },
+    spec: {
+      params: [
+        {
+          name: 'git-url',
+          value: 'https://github.com/karthikjeeyar/demo-app',
+        },
+        {
+          name: 'output-image',
+          value: '',
+        },
+        {
+          name: 'dockerfile',
+          value: 'Dockerfile',
+        },
+        {
+          name: 'path-context',
+          value: '.',
+        },
+      ],
+      pipelineRef: {
+        bundle:
+          'quay.io/redhat-appstudio/build-templates-bundle:19cf17aa63a1c65eee897af8430dbb9c1682d77a',
+        name: 'docker-build',
+      },
+      serviceAccountName: 'pipeline',
+      timeout: '1h0m0s',
+      workspaces: [
+        {
+          name: 'workspace',
+          persistentVolumeClaim: {
+            claimName: 'appstudio',
+          },
+          subPath: '1-nodejs/initialbuild-2022-Feb-13_12-39-17',
+        },
+        {
+          name: 'registry-auth',
+          secret: {
+            secretName: 'redhat-appstudio-registry-pull-secret',
+          },
+        },
+      ],
+    },
+    status: {
+      pipelineSpec: {
+        tasks: [],
+      },
+      conditions: [
+        {
+          message: 'failed to create task run pod "1-nodejs-2bwzn-show-summary',
+          status: 'False',
+          type: 'Succeeded',
+        },
+      ],
+      taskRuns: {
+        '1-nodejs-2bwzn-show-summary': {
+          pipelineTaskName: 'show-summary',
+          status: {
+            completionTime: '2022-08-23T19:08:18Z',
+            conditions: [
+              {
+                lastTransitionTime: '2022-08-23T19:08:18Z',
+                message:
+                  'failed to create task run pod "1-nodejs-2bwzn-show-summary": Pod "1-nodejs-2bwzn-show-summary-pod" is invalid: spec.activeDeadlineSeconds: Invalid value: 0: must be between 1 and 2147483647, inclusive. Maybe missing or invalid Task mfrances/summary',
+                reason: 'CouldntGetTask',
+                status: 'False',
+                type: 'Succeeded',
+              },
+            ],
+            podName: '',
+            startTime: '2022-08-23T19:08:18Z',
+            taskSpec: {
+              description: 'App Studio Summary Pipeline Task.',
+              params: [
+                {
+                  description: 'pipeline-run to annotate',
+                  name: 'pipeline-run-name',
+                  type: 'string',
+                },
+                {
+                  description: 'Git URL',
+                  name: 'git-url',
+                  type: 'string',
+                },
+                {
+                  description: 'Image URL',
+                  name: 'image-url',
+                  type: 'string',
+                },
+              ],
+              steps: [
+                {
+                  image:
+                    'registry.redhat.io/openshift4/ose-cli@sha256:e6b307c51374607294d1756b871d3c702251c396efdd44d4ef8db68e239339d3',
+                  name: 'appstudio-summary',
+                  resources: {},
+                  script: [
+                    '#!/usr/bin/env bash\necho\necho "App Studio Build Summary:"\necho\necho "Build repository: $(params.git-url)"\necho "Generated Image is in : $(params.image-url)"\necho\noc annotate pipelinerun $(params.pipeline-run-name) build.appstudio.openshift.io/repo=$(params.git-url)\noc annotate pipelinerun $(params.pipeline-run-name) build.appstudio.openshift.io/image=$(params.image-url)\n\necho "Output is in the following annotations:"\n\necho "Build Repo is in \'build.appstudio.openshift.io/repo\' "\necho \'oc get pr $(params.pipeline-run-name) -o jsonpath="{.metadata.annotations.build\\.appstudio\\.openshift\\.io/repo}"\'\n\necho "Build Image is in \'build.appstudio.openshift.io/image\' "\necho \'oc get pr $(params.pipeline-run-name) -o jsonpath="{.metadata.annotations.build\\.appstudio\\.openshift\\.io/image}"\'\n\necho End Summary\n',
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    apiVersion: 'tekton.dev/v1beta1',
+    kind: 'PipelineRun',
+    metadata: {
+      name: '1-nodejs-2bwzn',
+      uid: '94c9a362-f5a5-4e67-b642-c61c6d1134dc',
+      namespace: 'karthik-jk',
+      labels: {
+        'build.appstudio.openshift.io/component': '1-nodejs',
+        'pipelines.openshift.io/runtime': 'generic',
+        'pipelines.openshift.io/strategy': 'docker',
+        'tekton.dev/pipeline': 'docker-build',
+        'pipelines.openshift.io/used-by': 'build-cloud',
+        'build.appstudio.openshift.io/build': 'true',
+        'build.appstudio.openshift.io/application': 'frontend-app',
+        'build.appstudio.openshift.io/type': 'build',
+        'pipelines.appstudio.openshift.io/type': 'build',
+        'build.appstudio.openshift.io/version': '0.1',
+        'pipelinesascode.tekton.dev/sha': '010101010110',
+      },
+      annotations: {
+        'build.appstudio.openshift.io/component': '1-nodejs',
+        'pipelines.openshift.io/runtime': 'generic',
       },
     },
     spec: {

--- a/src/hacbs/components/PipelineRunDetailsView/RelatedPipelineRuns.tsx
+++ b/src/hacbs/components/PipelineRunDetailsView/RelatedPipelineRuns.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { Button, Popover, Skeleton } from '@patternfly/react-core';
+import { PipelineRunGroupVersionKind } from '../../../shared';
+import { useNamespace } from '../../../utils/namespace-context-utils';
+import { PipelineRunLabel } from '../../consts/pipelinerun';
+import { PipelineRunKind } from '../../types';
+
+const RelatedPipelineRuns = ({ pipelineRun }) => {
+  const namespace = useNamespace();
+
+  const [relatedPipelineRuns, relatedPipelineRunsLoaded] = useK8sWatchResource<PipelineRunKind[]>({
+    groupVersionKind: PipelineRunGroupVersionKind,
+    namespace,
+    isList: true,
+    selector: {
+      matchLabels: {
+        [PipelineRunLabel.COMMIT_LABEL]:
+          pipelineRun.metadata?.labels[PipelineRunLabel.COMMIT_LABEL],
+      },
+    },
+  });
+
+  return relatedPipelineRunsLoaded ? (
+    <Popover
+      aria-label="Related pipelines"
+      headerContent="Related pipelines"
+      bodyContent={
+        relatedPipelineRuns.entries.length === 0
+          ? 'No related pipelines'
+          : relatedPipelineRuns?.map((relatedPipelineRun: PipelineRunKind) => (
+              <div key={relatedPipelineRun?.metadata?.uid}>
+                {relatedPipelineRun?.metadata?.name}
+              </div>
+            ))
+      }
+    >
+      <Button variant="link" isInline>
+        {`${relatedPipelineRuns?.entries.length} ${
+          relatedPipelineRuns?.entries.length === 1 ? 'pipeline' : 'pipelines'
+        }`}
+      </Button>
+    </Popover>
+  ) : (
+    <Skeleton width="50%" screenreaderText="Loading related pipelines" />
+  );
+};
+
+export default RelatedPipelineRuns;

--- a/src/hacbs/components/PipelineRunDetailsView/__tests__/PipelineRunDetailsView.spec.tsx
+++ b/src/hacbs/components/PipelineRunDetailsView/__tests__/PipelineRunDetailsView.spec.tsx
@@ -48,6 +48,56 @@ const mockApplication = {
         completionTime: '2022-08-04T16:24:02Z',
       },
     ],
+    taskRuns: {
+      'java-springboot-sample-b4trz-show-summary': {
+        pipelineTaskName: 'show-summary',
+        status: {
+          completionTime: '2022-08-23T19:08:18Z',
+          conditions: [
+            {
+              lastTransitionTime: '2022-08-23T19:08:18Z',
+              message:
+                'failed to create task run pod "java-springboot-sample-b4trz-show-summary": Pod "java-springboot-sample-b4trz-show-summary-pod" is invalid: spec.activeDeadlineSeconds: Invalid value: 0: must be between 1 and 2147483647, inclusive. Maybe missing or invalid Task mfrances/summary',
+              reason: 'CouldntGetTask',
+              status: 'False',
+              type: 'Succeeded',
+            },
+          ],
+          podName: '',
+          startTime: '2022-08-23T19:08:18Z',
+          taskSpec: {
+            description: 'App Studio Summary Pipeline Task.',
+            params: [
+              {
+                description: 'pipeline-run to annotate',
+                name: 'pipeline-run-name',
+                type: 'string',
+              },
+              {
+                description: 'Git URL',
+                name: 'git-url',
+                type: 'string',
+              },
+              {
+                description: 'Image URL',
+                name: 'image-url',
+                type: 'string',
+              },
+            ],
+            steps: [
+              {
+                image:
+                  'registry.redhat.io/openshift4/ose-cli@sha256:e6b307c51374607294d1756b871d3c702251c396efdd44d4ef8db68e239339d3',
+                name: 'appstudio-summary',
+                resources: {},
+                script:
+                  '#!/usr/bin/env bash\necho\necho "App Studio Build Summary:"\necho\necho "Build repository: $(params.git-url)"\necho "Generated Image is in : $(params.image-url)"\necho\noc annotate pipelinerun $(params.pipeline-run-name) build.appstudio.openshift.io/repo=$(params.git-url)\noc annotate pipelinerun $(params.pipeline-run-name) build.appstudio.openshift.io/image=$(params.image-url)\n\necho "Output is in the following annotations:"\n\necho "Build Repo is in \'build.appstudio.openshift.io/repo\' "\necho \'oc get pr $(params.pipeline-run-name) -o jsonpath="{.metadata.annotations.build\\.appstudio\\.openshift\\.io/repo}"\'\n\necho "Build Image is in \'build.appstudio.openshift.io/image\' "\necho \'oc get pr $(params.pipeline-run-name) -o jsonpath="{.metadata.annotations.build\\.appstudio\\.openshift\\.io/image}"\'\n\necho End Summary\n',
+              },
+            ],
+          },
+        },
+      },
+    },
   },
 };
 

--- a/src/hacbs/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
+++ b/src/hacbs/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
@@ -1,123 +1,210 @@
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import {
+  Button,
+  CodeBlock,
+  CodeBlockCode,
   DescriptionList,
   DescriptionListGroup,
   DescriptionListTerm,
   DescriptionListDescription,
+  Flex,
+  FlexItem,
+  Label,
+  LabelGroup,
   Title,
 } from '@patternfly/react-core';
-import { pipelineRunFilterReducer } from '../../../../shared/';
+import { pipelineRunFilterReducer } from '../../../../shared';
+import ExternalLink from '../../../../shared/components/links/ExternalLink';
 import { StatusIconWithText } from '../../../../shared/components/pipeline-run-logs/StatusIcon';
+import { Timestamp } from '../../../../shared/components/timestamp/Timestamp';
 import { PipelineRunLabel } from '../../../consts/pipelinerun';
 import { PipelineRunKind } from '../../../types';
 import { calculateDuration } from '../../../utils/pipeline-utils';
 import PipelineRunVisualization from '../PipelineRunVisualization';
+import RelatedPipelineRuns from '../RelatedPipelineRuns';
 
 type PipelineRunDetailsTabProps = {
   pipelineRun: PipelineRunKind;
 };
 const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({ pipelineRun }) => {
-  if (!pipelineRun || Object.keys(pipelineRun).length <= 0) {
-    return null;
-  }
   const duration = calculateDuration(
     typeof pipelineRun.status?.startTime === 'string' ? pipelineRun.status?.startTime : '',
     typeof pipelineRun.status?.completionTime === 'string'
       ? pipelineRun.status?.completionTime
       : '',
   );
+
+  const getMetadataList = (prop: Record<string, string>) => {
+    const labelArray = Object.entries(prop);
+
+    return (
+      <Flex>
+        <LabelGroup>
+          {labelArray.map((label, index) => (
+            <FlexItem key={index}>
+              <Label color="blue" isTruncated={label.toString().length > 100}>
+                {label.toString().replace(',', '=')}{' '}
+              </Label>
+            </FlexItem>
+          ))}
+        </LabelGroup>
+      </Flex>
+    );
+  };
+
   return (
     <>
       <Title headingLevel="h4" className="pf-c-title pf-u-mt-lg pf-u-mb-lg" size="lg">
         Pipeline run details
       </Title>
       <PipelineRunVisualization pipelineRun={pipelineRun} />
-      <DescriptionList
-        data-test="pipelinerun-details"
-        columnModifier={{
-          default: '2Col',
-        }}
-      >
-        <DescriptionListGroup>
-          <DescriptionListTerm>Name</DescriptionListTerm>
-          <DescriptionListDescription>{pipelineRun.metadata.name}</DescriptionListDescription>
-        </DescriptionListGroup>
-        <DescriptionListGroup>
-          <DescriptionListTerm>Status</DescriptionListTerm>
-          <DescriptionListDescription>
-            <StatusIconWithText status={pipelineRunFilterReducer(pipelineRun)} />
-          </DescriptionListDescription>
-        </DescriptionListGroup>
-        <DescriptionListGroup>
-          <DescriptionListTerm>Namespace</DescriptionListTerm>
-          <DescriptionListDescription>{pipelineRun.metadata.namespace}</DescriptionListDescription>
-        </DescriptionListGroup>
-        <DescriptionListGroup>
-          <DescriptionListTerm>Message</DescriptionListTerm>
-          <DescriptionListDescription>
-            {pipelineRun.status?.conditions[0].message}
-          </DescriptionListDescription>
-        </DescriptionListGroup>
-        <DescriptionListGroup>
-          <DescriptionListTerm>Labels</DescriptionListTerm>
-          <DescriptionListDescription>-</DescriptionListDescription>
-        </DescriptionListGroup>
-        <DescriptionListGroup>
-          <DescriptionListTerm>Log snippet</DescriptionListTerm>
-          <DescriptionListDescription>-</DescriptionListDescription>
-        </DescriptionListGroup>
-        <DescriptionListGroup>
-          <DescriptionListTerm>Created at</DescriptionListTerm>
-          <DescriptionListDescription>-</DescriptionListDescription>
-        </DescriptionListGroup>
-        <DescriptionListGroup>
-          <DescriptionListTerm>Pipeline</DescriptionListTerm>
-          <DescriptionListDescription>-</DescriptionListDescription>
-        </DescriptionListGroup>
-        <DescriptionListGroup>
-          <DescriptionListTerm>Owner</DescriptionListTerm>
-          <DescriptionListDescription>-</DescriptionListDescription>
-        </DescriptionListGroup>
-        <DescriptionListGroup>
-          <DescriptionListTerm>Triggered by</DescriptionListTerm>
-          <DescriptionListDescription>-</DescriptionListDescription>
-        </DescriptionListGroup>
-        <DescriptionListGroup>
-          <DescriptionListTerm>Duration</DescriptionListTerm>
-          <DescriptionListDescription>{duration}</DescriptionListDescription>
-        </DescriptionListGroup>
-        <DescriptionListGroup>
-          <DescriptionListTerm>Application</DescriptionListTerm>
-          <DescriptionListDescription>-</DescriptionListDescription>
-        </DescriptionListGroup>
-        <DescriptionListGroup />
-        <DescriptionListGroup>
-          <DescriptionListTerm>Component</DescriptionListTerm>
-          <DescriptionListDescription>
-            {pipelineRun.metadata.labels[PipelineRunLabel.COMPONENT]}
-          </DescriptionListDescription>
-        </DescriptionListGroup>
-        <DescriptionListGroup />
-        <DescriptionListGroup>
-          <DescriptionListTerm>Source</DescriptionListTerm>
-          <DescriptionListDescription>-</DescriptionListDescription>
-        </DescriptionListGroup>
-        <DescriptionListGroup />
-        <DescriptionListGroup>
-          <DescriptionListTerm>Workspace</DescriptionListTerm>
-          <DescriptionListDescription>-</DescriptionListDescription>
-        </DescriptionListGroup>
-        <DescriptionListGroup />
-        <DescriptionListGroup>
-          <DescriptionListTerm>Compliance</DescriptionListTerm>
-          <DescriptionListDescription>-</DescriptionListDescription>
-        </DescriptionListGroup>
-        <DescriptionListGroup />
-        <DescriptionListGroup>
-          <DescriptionListTerm>Environment</DescriptionListTerm>
-          <DescriptionListDescription>-</DescriptionListDescription>
-        </DescriptionListGroup>
-      </DescriptionList>
+      <Flex>
+        <Flex flex={{ default: 'flex_3' }}>
+          <FlexItem>
+            <DescriptionList
+              data-test="pipelinerun-details"
+              columnModifier={{
+                default: '1Col',
+              }}
+            >
+              <DescriptionListGroup>
+                <DescriptionListTerm>Name</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {pipelineRun.metadata?.name ?? '-'}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Namespace</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {pipelineRun.metadata?.namespace ?? '-'}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Labels</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {getMetadataList(pipelineRun.metadata?.labels)}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Annotations</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {getMetadataList(pipelineRun.metadata?.annotations)}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Created at</DescriptionListTerm>
+                <DescriptionListDescription>
+                  <Timestamp timestamp={pipelineRun.metadata.creationTimestamp ?? '-'} />
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Duration</DescriptionListTerm>
+                <DescriptionListDescription>{duration ?? '-'}</DescriptionListDescription>
+              </DescriptionListGroup>
+            </DescriptionList>
+          </FlexItem>
+        </Flex>
+
+        <Flex flex={{ default: 'flex_3' }}>
+          <FlexItem>
+            <DescriptionList
+              data-test="pipelinerun-details"
+              columnModifier={{
+                default: '1Col',
+              }}
+            >
+              <DescriptionListGroup>
+                <DescriptionListTerm>Status</DescriptionListTerm>
+                <DescriptionListDescription>
+                  <StatusIconWithText status={pipelineRunFilterReducer(pipelineRun)} />
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Message</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {pipelineRun.status?.conditions[0]?.message ?? '-'}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Log snippet</DescriptionListTerm>
+                <DescriptionListDescription>
+                  <CodeBlock>
+                    <CodeBlockCode id="code-content">
+                      {pipelineRun.status?.taskRuns[`${pipelineRun.metadata?.name}-show-summary`]
+                        ?.status?.taskSpec?.steps[0].script ?? '-'}
+                    </CodeBlockCode>
+                  </CodeBlock>
+                  <Button
+                    variant="link"
+                    isInline
+                    component={(props) => (
+                      <Link
+                        {...props}
+                        to={`/app-studio/pipelineruns/${pipelineRun.metadata?.name}?activeTab=logs`}
+                      />
+                    )}
+                  >
+                    See logs
+                  </Button>
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Pipeline</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {pipelineRun.metadata?.labels[PipelineRunLabel.PIPELINE_NAME] ?? '-'}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Application</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {pipelineRun.metadata?.labels?.[PipelineRunLabel.APPLICATION] ? (
+                    <Link
+                      to={`/app-studio/applications/${
+                        pipelineRun.metadata?.labels[PipelineRunLabel.APPLICATION]
+                      }`}
+                    >
+                      {pipelineRun.metadata?.labels[PipelineRunLabel.APPLICATION]}
+                    </Link>
+                  ) : (
+                    '-'
+                  )}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Source</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {pipelineRun.metadata?.annotations?.[
+                    PipelineRunLabel.COMMIT_FULL_REPO_URL_LABEL
+                  ] ? (
+                    <ExternalLink
+                      href={
+                        pipelineRun.metadata?.annotations[
+                          PipelineRunLabel.COMMIT_FULL_REPO_URL_LABEL
+                        ]
+                      }
+                    >
+                      {
+                        pipelineRun.metadata?.annotations[
+                          PipelineRunLabel.COMMIT_FULL_REPO_URL_LABEL
+                        ]
+                      }
+                    </ExternalLink>
+                  ) : (
+                    '-'
+                  )}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Related pipelines</DescriptionListTerm>
+                <DescriptionListDescription>
+                  <RelatedPipelineRuns pipelineRun={pipelineRun} />
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            </DescriptionList>
+          </FlexItem>
+        </Flex>
+      </Flex>
     </>
   );
 };

--- a/src/hacbs/components/PipelineRunDetailsView/tabs/__tests__/PipelineRunDetailsTab.spec.tsx
+++ b/src/hacbs/components/PipelineRunDetailsView/tabs/__tests__/PipelineRunDetailsTab.spec.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import '@testing-library/jest-dom';
+import { BrowserRouter } from 'react-router-dom';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { configure, render, screen } from '@testing-library/react';
 import { sampleBuildPipelines } from '../../../ApplicationDetails/tabs/overview/visualization/hooks/__data__/workflow-data';
 import { testPipelineRun } from '../../../topology/__data__/pipeline-test-data';
@@ -17,6 +19,8 @@ jest.mock('../../../topology/factories/VisualizationFactory', () => () => <div /
 
 configure({ testIdAttribute: 'data-test' });
 
+const watchResourceMock = useK8sWatchResource as jest.Mock;
+
 beforeEach(() => {
   const createElement = document.createElement.bind(document);
   document.createElement = (tagName) => {
@@ -32,23 +36,27 @@ beforeEach(() => {
 });
 
 describe('PipelineRunDetailsTab', () => {
-  it('should not render the pipelinerun details tab', () => {
-    render(<PipelineRunDetailsTab pipelineRun={null} />);
-    expect(screen.queryByText('Pipeline run details')).not.toBeInTheDocument();
-  });
-
   it('should render the pipelinerun details tab', () => {
-    render(<PipelineRunDetailsTab pipelineRun={sampleBuildPipelines[0]} />);
+    watchResourceMock.mockReturnValue([[], true]);
+    render(<PipelineRunDetailsTab pipelineRun={sampleBuildPipelines[0]} />, {
+      wrapper: BrowserRouter,
+    });
     screen.getByText('Pipeline run details');
   });
 
   it('should not render the pipelinerun visualization if the status field is missing', () => {
-    render(<PipelineRunDetailsTab pipelineRun={sampleBuildPipelines[0]} />);
+    watchResourceMock.mockReturnValue([[], true]);
+    render(<PipelineRunDetailsTab pipelineRun={sampleBuildPipelines[1]} />, {
+      wrapper: BrowserRouter,
+    });
     expect(screen.queryByTestId('hacbs-pipelinerun-graph')).not.toBeInTheDocument();
   });
 
   it('should render the pipelinerun visualization', () => {
-    render(<PipelineRunDetailsTab pipelineRun={testPipelineRun} />);
+    watchResourceMock.mockReturnValue([[], true]);
+    render(<PipelineRunDetailsTab pipelineRun={testPipelineRun} />, {
+      wrapper: BrowserRouter,
+    });
     screen.getByTestId('hacbs-pipelinerun-graph');
   });
 });

--- a/src/hacbs/consts/pipelinerun.ts
+++ b/src/hacbs/consts/pipelinerun.ts
@@ -1,7 +1,9 @@
 export enum PipelineRunLabel {
   APPLICATION = 'appstudio.openshift.io/application',
   COMPONENT = 'appstudio.openshift.io/component',
+  PIPELINE_USED_BY = 'pipelines.openshift.io/used-by',
   PIPELINE_TYPE = 'pipelines.appstudio.openshift.io/type',
+  PIPELINE_NAME = 'tekton.dev/pipeline',
   COMMIT_LABEL = 'pipelinesascode.tekton.dev/sha',
   COMMIT_URL_ANNOTATION = 'pipelinesascode.tekton.dev/sha-url',
   COMMIT_BRANCH_ANNOTATION = 'build.appstudio.redhat.com/target_branch',
@@ -9,6 +11,7 @@ export enum PipelineRunLabel {
   COMMIT_USER_LABEL = 'pipelinesascode.tekton.dev/sender',
   COMMIT_REPO_ORG_LABEL = 'pipelinesascode.tekton.dev/url-org',
   COMMIT_REPO_URL_LABEL = 'pipelinesascode.tekton.dev/url-repository',
+  COMMIT_FULL_REPO_URL_LABEL = 'pipelinesascode.tekton.dev/repo-url',
   COMMIT_PROVIDER_LABEL = 'pipelinesascode.tekton.dev/git-provider',
   COMMIT_SHA_TITLE_ANNOTATION = 'pipelinesascode.tekton.dev/sha-title',
 }

--- a/src/hacbs/utils/pipeline-utils.ts
+++ b/src/hacbs/utils/pipeline-utils.ts
@@ -17,15 +17,15 @@ export const getDuration = (seconds: number, long?: boolean): string => {
     min %= 60;
   }
   if (hr > 0) {
-    duration += long ? `${hr} hour` : `${hr} h`;
+    duration += long ? (hr === 1 ? `${hr} hour` : `${hr} hours`) : `${hr} h`;
     duration += ' ';
   }
   if (min > 0) {
-    duration += long ? `${min} minute` : `${min} m`;
+    duration += long ? (min === 1 ? `${min} minute` : `${min} minutes`) : `${min} m`;
     duration += ' ';
   }
   if (sec > 0) {
-    duration += long ? `${sec} second` : `${sec} s`;
+    duration += long ? (sec === 1 ? `${sec} second` : `${sec} seconds`) : `${sec} s`;
   }
 
   return duration.trim();


### PR DESCRIPTION
## Fixes 
Fixes [HACBS-1022](https://issues.redhat.com/browse/HACBS-1022) and [HACBS-1025](https://issues.redhat.com/browse/HACBS-1025).

## Description
Adds more detail to details page:
- Labels
- Log snippet
- Created at
- Pipeline
- ~~Owner~~
- ~~Triggered by~~
- Application
- Source
- ~~Workspace~~

As part of this PR, it also includes breadcrumb change so user can return to the pipelinerun list, and removal of the Enterprise Contract tab (1025). Also some minor changes to existing details code e.g. handling plural units in duration value.

## Type of change
- [x] Feature

## Screen shots / Gifs for design review (updated 10/5/22)
PLR Details top:
![plr-details-top](https://user-images.githubusercontent.com/39063664/194110758-74254572-a3d4-4577-9444-6acbabb76acd.png)

PLR Details bottom:
![plr-details-bottom](https://user-images.githubusercontent.com/39063664/194110790-1e815aec-acbf-4bae-99eb-20102bdb5bb3.png)

PLR Details w/ annotations and labels expanded:
![plr-details-labels-annotations-expanded](https://user-images.githubusercontent.com/39063664/194110809-a6596476-55df-4f22-b3cc-d250aac587ad.png)

## How to test or reproduce?
Select an existing pipelinerun to view the details page.

## Browser conformance: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [x] Code follows the style guidelines
- [x] Self-reviewed the code
- [x] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [x] Any dependent changes have been merged and published in downstream modules 
-->
