### PR TITLE
fix useSearchParam using stale value with multiple update

### DIFF
--- a/src/hacbs/components/Environment/__tests__/EnvironmentListView.spec.tsx
+++ b/src/hacbs/components/Environment/__tests__/EnvironmentListView.spec.tsx
@@ -3,8 +3,11 @@ import '@testing-library/jest-dom';
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { render, screen, configure, cleanup, fireEvent } from '@testing-library/react';
 import { EnvironmentKind } from '../../../../types';
+import { mockLocation } from '../../../../utils/test-utils';
 import EnvironmentListView from '../EnvironmentListView';
 import { EnvironmentType } from '../utils';
+
+mockLocation();
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   useK8sWatchResource: jest.fn(),
@@ -15,7 +18,14 @@ jest.mock('react-i18next', () => ({
 }));
 
 jest.mock('react-router-dom', () => ({
-  useSearchParams: () => React.useState(() => new URLSearchParams()),
+  useSearchParams: () => {
+    const [params, setParams] = React.useState(() => new URLSearchParams());
+    const setParamsCb = React.useCallback((newParams: URLSearchParams) => {
+      setParams(newParams);
+      window.location.search = `?${newParams.toString()}`;
+    }, []);
+    return [params, setParamsCb];
+  },
   Link: (props) => <a href={props.to}>{props.children}</a>,
 }));
 

--- a/src/hooks/__tests__/useSearchParam.spec.ts
+++ b/src/hooks/__tests__/useSearchParam.spec.ts
@@ -1,6 +1,9 @@
 import { useSearchParams } from 'react-router-dom';
 import { renderHook } from '@testing-library/react-hooks';
+import { mockLocation } from '../../utils/test-utils';
 import { useSearchParam } from '../useSearchParam';
+
+mockLocation();
 
 jest.mock('react-router-dom', () => ({
   useSearchParams: jest.fn(),
@@ -16,6 +19,7 @@ describe('useSearchParam', () => {
       params,
       (newParams: URLSearchParams) => {
         params = newParams;
+        window.location.search = `?${newParams.toString()}`;
       },
     ]);
   });

--- a/src/hooks/useSearchParam.ts
+++ b/src/hooks/useSearchParam.ts
@@ -22,8 +22,8 @@ export const useSearchParam = (
   const replace = options?.replace ?? true;
   const set = React.useCallback(
     (newValue: string) => {
-      if (searchParams.get(name) !== newValue) {
-        const newSearchParams = new URLSearchParams(searchParams);
+      const newSearchParams = new URLSearchParams(window.location.search);
+      if (newSearchParams.get(name) !== newValue) {
         if (unsetWhenDefaultValue && newValue === defaultValueRef.current) {
           newSearchParams.delete(name);
         } else {
@@ -32,16 +32,16 @@ export const useSearchParam = (
         setSearchParams(newSearchParams, { replace });
       }
     },
-    [name, searchParams, setSearchParams, unsetWhenDefaultValue, replace],
+    [name, setSearchParams, unsetWhenDefaultValue, replace],
   );
 
   const unset = React.useCallback(() => {
-    if (searchParams.has(name)) {
-      const newSearchParams = new URLSearchParams(searchParams);
+    const newSearchParams = new URLSearchParams(window.location.search);
+    if (newSearchParams.has(name)) {
       newSearchParams.delete(name);
       setSearchParams(newSearchParams);
     }
-  }, [name, searchParams, setSearchParams]);
+  }, [name, setSearchParams]);
 
   return [value, set, unset];
 };

--- a/src/utils/test-utils.tsx
+++ b/src/utils/test-utils.tsx
@@ -39,3 +39,22 @@ export const routerRenderer = (
     wrapper: ({ children }) => <BrowserRouter>{children}</BrowserRouter>,
     ...options,
   });
+
+export const mockLocation = (location?: {
+  hash?: string;
+  port?: number;
+  pathname?: string;
+  search?: string;
+  origin?: string;
+}) => {
+  const windowLocation = JSON.stringify(window.location);
+  delete window.location;
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    writable: true,
+    value: JSON.parse(windowLocation),
+  });
+  if (location) {
+    Object.assign(window.location, location);
+  }
+};


### PR DESCRIPTION
## Description
If there are multiple uses of `useSearchParam` where the search params are updated multiple times in the same thread of execution, after the first update, subsequent updates are using a stale value of the previous search params.

The fix is to read directly from `window.location.search` when performing an update .

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?

- Enable HACBS.
- Go to `Settings` page
- Ensure there is at least one environment; create if necessary
- Enter a name filter that matches no environments
- Set a type filter
- When there are no matches, the empty state shows a "Clear all filters" button
- Click "clear all filters"

Observe that it requires 2 clicks to clear all the filters because the first click only clears the type filter. 

With the fix, both the type filter and name filter would be cleared.

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

cc @jeff-phillips-18 