### PR TITLE
Fix wrong CDQ loading status

### DIFF
--- a/src/components/ImportForm/utils/cdq-utils.ts
+++ b/src/components/ImportForm/utils/cdq-utils.ts
@@ -74,6 +74,15 @@ export const useComponentDetection = (
     return undefined;
   }, [source, cdqName, loaded, cdq]);
 
+  const detectionCompleted = React.useMemo(() => {
+    if (cdqName && loaded && cdq) {
+      return cdq?.status?.conditions?.some(
+        (condition) => condition.type === 'Completed' && condition.reason === 'OK',
+      );
+    }
+    return false;
+  }, [cdqName, loaded, cdq]);
+
   const error = React.useMemo(() => {
     if (createError) {
       return createError;
@@ -95,7 +104,7 @@ export const useComponentDetection = (
     }
   }, [cdq, cdqName, createError, detectedComponents, loadError, loaded]);
 
-  return [detectedComponents, cdq && loaded, error];
+  return [detectedComponents, detectionCompleted, error];
 };
 
 export const mapDetectedComponents = (detectedComponents: DetectedComponents) => {


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
- https://issues.redhat.com/browse/HAC-2206

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- The CDQ loaded status was dependent on the watch resource hook returning the loaded value but it is not correct if we want to make sure the component detection is actually completed.
- This resulted in the error state of `No components detected` being shown when the detection was not complete yet.
- This PR updates the logic for loaded value of `useComponentDetection` to actually use completed status from CDQ. 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


https://user-images.githubusercontent.com/6041994/191248964-455d1631-7361-4ffc-a674-136b11a69ccb.mov



## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge