### PR TITLE
remove /hac/hacbs route for enabling hacbs feature flag

### DIFF
--- a/config/remotePlugin.js
+++ b/config/remotePlugin.js
@@ -37,16 +37,6 @@ const hacbs = {
       },
     },
     {
-      type: 'core.page/route',
-      properties: {
-        path: '/hacbs',
-        exact: true,
-        component: {
-          $codeRef: 'HACBSFlag.EnableHACBSFlagRoute',
-        },
-      },
-    },
-    {
       type: 'console.page/route',
       properties: {
         path: '/app-studio/import',

--- a/src/hacbs/__tests__/hacbsFeatureFlag.spec.tsx
+++ b/src/hacbs/__tests__/hacbsFeatureFlag.spec.tsx
@@ -1,38 +1,4 @@
-import React from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useFeatureFlag } from '@openshift/dynamic-plugin-sdk';
-import { render } from '@testing-library/react';
-import {
-  HACBS_FLAG,
-  EnableHACBSFlagRoute,
-  enableHACBSFlagFromQueryParam,
-} from '../hacbsFeatureFlag';
-
-jest.mock('react-router-dom', () => ({
-  useNavigate: jest.fn(),
-}));
-
-jest.mock('@openshift/dynamic-plugin-sdk', () => ({
-  useFeatureFlag: jest.fn(),
-}));
-
-const useNavigateMock = useNavigate as jest.Mock;
-const useFeatureFlagMock = useFeatureFlag as jest.Mock;
-
-describe('hacbsFeatureFlag', () => {
-  it('should set hacbs flag and navigate to app studio', () => {
-    const setFlagMock = jest.fn();
-    useFeatureFlagMock.mockReturnValue([false, setFlagMock]);
-    const navigateMock = jest.fn();
-    useNavigateMock.mockReturnValue(navigateMock);
-
-    render(<EnableHACBSFlagRoute />);
-
-    expect(useFeatureFlag).toHaveBeenCalledWith(HACBS_FLAG);
-    expect(setFlagMock).toHaveBeenCalledWith(true);
-    expect(navigateMock).toHaveBeenCalledWith('/app-studio', { replace: true });
-  });
-});
+import { HACBS_FLAG, enableHACBSFlagFromQueryParam } from '../hacbsFeatureFlag';
 
 describe('hacbsFeatureFlag#enableHACBSFlagFromQueryParam', () => {
   let windowSpy;

--- a/src/hacbs/hacbsFeatureFlag.ts
+++ b/src/hacbs/hacbsFeatureFlag.ts
@@ -1,22 +1,6 @@
-import React from 'react';
-import { useNavigate } from 'react-router-dom';
-import { SetFeatureFlag, useFeatureFlag } from '@openshift/dynamic-plugin-sdk';
+import { SetFeatureFlag } from '@openshift/dynamic-plugin-sdk';
 
 export const HACBS_FLAG = 'HACBS';
-
-export const EnableHACBSFlagRoute: React.FC = () => {
-  const navigate = useNavigate();
-  const [, setFlag] = useFeatureFlag(HACBS_FLAG);
-  React.useEffect(() => {
-    setFlag(true);
-    /* eslint-disable-next-line no-console */
-    console.log('HACBS Flag enabled');
-    navigate('/app-studio', { replace: true });
-    // No deps because setting the flag only needs to run once.
-    /* eslint-disable-next-line react-hooks/exhaustive-deps */
-  }, []);
-  return null;
-};
 
 export const enableHACBSFlagFromQueryParam = (setFlag: SetFeatureFlag): void => {
   let enabled = false;


### PR DESCRIPTION
## Fixes 
When the query string method of `?hacbs=true` was introduced to enable the hacbs feature flag, the `/hac/hacbs` route method stopped working.

There's no benefit to keeping both methods around so I'm choosing to remove the route method. It is a method that isn't as usable as the query string method.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
no UI change

## How to test or reproduce?
visit `/hac/hacbs` and observe that the route is no longer available.

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
