### PR TITLE
fix breadcrumb links

### DIFF
--- a/src/components/ApplicationDetailsView/ApplicationDetailsView.tsx
+++ b/src/components/ApplicationDetailsView/ApplicationDetailsView.tsx
@@ -115,7 +115,7 @@ const ApplicationDetailsView: React.FunctionComponent<ApplicationViewProps> = ({
         breadcrumbs={[
           { path: '/app-studio/applications', name: 'Applications' },
           {
-            path: `/app-studio/applications/:${application?.metadata?.name}`,
+            path: `/app-studio/applications/${application?.metadata?.name}`,
             name: application?.spec?.displayName,
           },
         ]}

--- a/src/hacbs/components/ApplicationDetails/HacbsApplicationDetails.tsx
+++ b/src/hacbs/components/ApplicationDetails/HacbsApplicationDetails.tsx
@@ -63,7 +63,7 @@ const HacbsApplicationDetails: React.FC<HacbsApplicationDetailsProps> = ({ appli
         breadcrumbs={[
           { path: '/app-studio/applications', name: 'Applications' },
           {
-            path: `/app-studio/applications/:${applicationName}`,
+            path: `/app-studio/applications/${applicationName}`,
             name: appDisplayName,
           },
         ]}

--- a/src/hacbs/components/PipelineRunDetailsView/PipelineRunDetailsView.tsx
+++ b/src/hacbs/components/PipelineRunDetailsView/PipelineRunDetailsView.tsx
@@ -45,11 +45,11 @@ export const PipelineRunDetailsView: React.FC<PipelineRunDetailsViewProps> = ({
               name: applicationName,
             },
             {
-              path: `/app-studio/applications/:${pipelineRunName}?activeTab=pipelineRuns`,
+              path: `/app-studio/applications/${applicationName}?activeTab=pipelineRuns`,
               name: 'Pipeline runs',
             },
             {
-              path: `/app-studio/applications/:${pipelineRunName}`,
+              path: `/app-studio/applications/${pipelineRunName}`,
               name: pipelineRunName,
             },
           ]}


### PR DESCRIPTION
## Fixes 
Some bread crumbs links contained an extra `:` in the URL.
Although this was only noticeable on the pipeline run details page because the last segment of a breadcrumb does not show a URL right now.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## How to test or reproduce?
Go to pipeline run details page and click the `pipeline runs` breadcrumb to go to the application details page on the pipeline runs tab.

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
