### PR TITLE
Reset formik error check after runtime is selected

### DIFF
--- a/src/components/ImportForm/ReviewSection/RuntimeSelector.tsx
+++ b/src/components/ImportForm/ReviewSection/RuntimeSelector.tsx
@@ -80,6 +80,7 @@ export const RuntimeSelector: React.FC<RuntimeSelectorProps> = ({ detectedCompon
       setDetecting(false);
       // To avoid formik validating on old values due to a formik bug - https://github.com/jaredpalmer/formik/issues/2083
       setTimeout(() => setFieldValue('isDetected', true));
+      setTimeout(() => setFieldValue('detectionFailed', false));
       const componentValues = transformComponentValues(detectedComponents)[0];
       const component = patchSourceUrl(componentValues.componentStub, source);
       setFieldValue(`${fieldPrefix}.componentStub`, component);

--- a/src/components/ImportForm/ReviewSection/__tests__/RuntimeSelector.spec.tsx
+++ b/src/components/ImportForm/ReviewSection/__tests__/RuntimeSelector.spec.tsx
@@ -6,10 +6,20 @@ import '@testing-library/jest-dom';
 import { useDevfileSamples } from '../../utils/useDevfileSamples';
 import { RuntimeSelector } from '../RuntimeSelector';
 
+const setFieldValueMock = jest.fn();
+
 jest.mock('../../utils/cdq-utils', () => ({ useComponentDetection: jest.fn() }));
 
 jest.mock('../../utils/useDevfileSamples', () => ({
   useDevfileSamples: jest.fn(),
+}));
+
+jest.mock('formik', () => ({
+  ...(jest as any).requireActual('formik'),
+  useFormikContext: jest.fn(() => ({
+    ...(jest as any).requireActual('formik').useFormikContext(),
+    setFieldValue: setFieldValueMock,
+  })),
 }));
 
 const useComponentDetectionMock = useComponentDetection as jest.Mock;
@@ -53,7 +63,7 @@ describe('RuntimeSelector', () => {
     expect(screen.getByText('Basic Nodejs')).toBeVisible();
   });
 
-  it('should fetch cdq on select', async () => {
+  it('should run cdq & set proper validation state on select', async () => {
     useDevfileSamplesMock.mockReturnValue([
       [
         {
@@ -95,5 +105,7 @@ describe('RuntimeSelector', () => {
       undefined,
       undefined,
     );
+    expect(setFieldValueMock).toHaveBeenCalledWith('detectionFailed', false);
+    expect(setFieldValueMock).toHaveBeenCalledWith('isDetected', true);
   });
 });


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-2299
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
Reset the `detectionFailed` formik field after runtime is manually selected.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

https://user-images.githubusercontent.com/20013884/196224248-ffc6c858-553a-473b-88f4-05d62f7df27d.mp4

<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
Use a repo whose runtime cannot be detected, and then manually select a runtime for it.
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
