### PR TITLE
HACBS: Fix url for enterprise contracts release policies.

### DIFF
--- a/src/hacbs/components/EnterpriseContractView/const.ts
+++ b/src/hacbs/components/EnterpriseContractView/const.ts
@@ -1,7 +1,7 @@
 export const HACBS_ENTERPRISE_CONTRACT_INFO_LINK =
   'https://red-hat-hybrid-application-cloud-build-services-documentation.pages.redhat.com/hacbs-documentation/ec-policies/release_policy.html';
 export const HACBS_ENTERPRISE_CONTRACT_POLICIES_DATA =
-  'https://hacbs-contract.github.io/ec-policies/ec-policies/data.json';
+  'https://hacbs-contract.github.io/ec-policies/data.json';
 
 export const BASE_INFO_URL =
   'https://red-hat-hybrid-application-cloud-build-services-documentation.pages.redhat.com/hacbs-documentation/ec-policies/release_policy.html';


### PR DESCRIPTION
## Fixes 
Fixes [HACBS-1290](https://issues.redhat.com/browse/HACBS-1290)

## Description
The URL for the json data for release policies has changed

## Type of change
- [x] Bugfix

