### PR TITLE
add optional label to mark a integration test as optional

### DIFF
--- a/src/hacbs/components/ImportForm/create-utils.ts
+++ b/src/hacbs/components/ImportForm/create-utils.ts
@@ -6,11 +6,12 @@ import {
   IntegrationTestScenarioModel,
 } from '../../models/hacbs';
 import { IntegrationTestScenarioKind } from '../../types/coreBuildService';
-import { FormValues, IntegrationTestFormValues } from './types';
-
-export enum IntegrationTestAnnotations {
-  DISPLAY_NAME = 'app.kubernetes.io/display-name',
-}
+import {
+  FormValues,
+  IntegrationTestAnnotations,
+  IntegrationTestFormValues,
+  IntegrationTestLabels,
+} from './types';
 
 // /**
 //  * Create integrationTestScenario CR
@@ -36,6 +37,7 @@ export const createIntegrationTest = (
     metadata: {
       name,
       namespace,
+      ...(optional && { labels: { [IntegrationTestLabels.OPTIONAL]: optional.toString() } }),
       annotations: {
         [IntegrationTestAnnotations.DISPLAY_NAME]: displayName,
       },
@@ -44,7 +46,6 @@ export const createIntegrationTest = (
       application,
       bundle,
       pipeline,
-      optional,
       contexts: [
         {
           description: 'Application testing',

--- a/src/hacbs/components/ImportForm/types.ts
+++ b/src/hacbs/components/ImportForm/types.ts
@@ -8,6 +8,14 @@ export type IntegrationTestFormValues = {
   optional: boolean;
 };
 
+export enum IntegrationTestAnnotations {
+  DISPLAY_NAME = 'app.kubernetes.io/display-name',
+}
+
+export enum IntegrationTestLabels {
+  OPTIONAL = 'test.appstudio.openshift.io/optional',
+}
+
 export type FormValues = ImportFormValues & {
   applicationData?: K8sResourceCommon;
   integrationTest: IntegrationTestFormValues;

--- a/src/hacbs/components/ImportForm/utils/__tests__/create-utils.spec.ts
+++ b/src/hacbs/components/ImportForm/utils/__tests__/create-utils.spec.ts
@@ -1,6 +1,7 @@
 import { k8sCreateResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { IntegrationTestScenarioModel } from '../../../../models/hacbs';
-import { createIntegrationTest, IntegrationTestAnnotations } from '../../create-utils';
+import { createIntegrationTest } from '../../create-utils';
+import { IntegrationTestAnnotations, IntegrationTestLabels } from '../../types';
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   k8sCreateResource: jest.fn(),
@@ -20,7 +21,6 @@ const integrationTestData = {
   },
   spec: {
     application: 'Test Application',
-    optional: false,
     bundle: '',
     contexts: [
       {
@@ -59,6 +59,27 @@ describe('Create Utils', () => {
     );
     expect(resource.metadata.annotations).toBeDefined();
     expect(resource.metadata.annotations[IntegrationTestAnnotations.DISPLAY_NAME]).toBe('app test');
+  });
+
+  it('Should contain the optional test value in the labels', async () => {
+    createResourceMock.mockImplementation(({ resource }) => resource);
+    const resource = await createIntegrationTest(
+      { name: 'app test', bundle: '', pipeline: '', optional: true },
+      'Test Application',
+      'test-ns',
+    );
+    expect(resource.metadata.labels).toBeDefined();
+    expect(resource.metadata.labels[IntegrationTestLabels.OPTIONAL]).toBe('true');
+  });
+
+  it('Should not contain the optional label if the test is mandatory', async () => {
+    createResourceMock.mockImplementation(({ resource }) => resource);
+    const resource = await createIntegrationTest(
+      { name: 'app test', bundle: '', pipeline: '', optional: false },
+      'Test Application',
+      'test-ns',
+    );
+    expect(resource.metadata.labels).not.toBeDefined();
   });
 
   it('Should contain kubernetes formatted resource name', async () => {

--- a/src/hacbs/components/IntegrationTestsListView/IntegrationTestListRow.tsx
+++ b/src/hacbs/components/IntegrationTestsListView/IntegrationTestListRow.tsx
@@ -3,6 +3,7 @@ import ActionMenu from '../../../shared/components/action-menu/ActionMenu';
 import ExternalLink from '../../../shared/components/links/ExternalLink';
 import { RowFunctionArgs, TableData } from '../../../shared/components/table';
 import { IntegrationTestScenarioKind } from '../../types/coreBuildService';
+import { IntegrationTestLabels } from '../ImportForm/types';
 import { integrationListTableColumnClasses } from './IntegrationTestListHeader';
 import { useIntegrationTestActions } from './useIntegrationTestActions';
 
@@ -23,7 +24,9 @@ const IntegrationTestListRow: React.FC<RowFunctionArgs<IntegrationTestScenarioKi
         <ExternalLink href={containerImageUrl} text={containerImageUrl} stopPropagation />
       </TableData>
       <TableData className={integrationListTableColumnClasses.mandatory}>
-        {obj.spec.optional ? 'Optional' : 'Mandatory'}
+        {obj.metadata.labels?.[IntegrationTestLabels.OPTIONAL] === 'true'
+          ? 'Optional'
+          : 'Mandatory'}
       </TableData>
       <TableData className={integrationListTableColumnClasses.pipeline}>
         {obj.spec.pipeline}

--- a/src/hacbs/components/IntegrationTestsListView/__data__/mock-integration-tests.ts
+++ b/src/hacbs/components/IntegrationTestsListView/__data__/mock-integration-tests.ts
@@ -1,8 +1,13 @@
+import { IntegrationTestLabels } from '../../ImportForm/types';
+
 export const MockIntegrationTests = [
   {
     apiVersion: 'appstudio.redhat.com/v1alpha1',
     kind: 'IntegrationTestScenario',
     metadata: {
+      labels: {
+        [IntegrationTestLabels.OPTIONAL]: 'true',
+      },
       annotations: {
         'app.kubernetes.io/display-name': 'Test 1',
       },

--- a/src/hacbs/components/IntegrationTestsListView/__tests__/IntegrationTestsListRow.spec.tsx
+++ b/src/hacbs/components/IntegrationTestsListView/__tests__/IntegrationTestsListRow.spec.tsx
@@ -15,4 +15,22 @@ describe('IntegrationTestListRow', () => {
     expect(cells[1].innerHTML.includes(integrationTest.spec.bundle)).toBeTruthy();
     expect(cells[3].innerHTML).toBe(integrationTest.spec.pipeline);
   });
+
+  it('should read the optional field from label', () => {
+    const optionalIntegrationTest = MockIntegrationTests[0];
+    const wrapper = render(<IntegrationTestListRow obj={optionalIntegrationTest} columns={[]} />, {
+      container: document.createElement('tr'),
+    });
+    const cells = wrapper.container.getElementsByTagName('td');
+    expect(cells[2].innerHTML).toBe('Optional');
+  });
+
+  it('should show mandatory value if the optional labels are not set', () => {
+    const mandatoryIntegrationTest = MockIntegrationTests[1];
+    const wrapper = render(<IntegrationTestListRow obj={mandatoryIntegrationTest} columns={[]} />, {
+      container: document.createElement('tr'),
+    });
+    const cells = wrapper.container.getElementsByTagName('td');
+    expect(cells[2].innerHTML).toBe('Mandatory');
+  });
 });


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/HACBS-1362

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Add `test.appstudio.openshift.io/optional: true/false` to mark an `integrationTestScenario` optional instead of `spec.optional` (no longer valid).


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix



## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

1. Add an Integration test and mark it as optional.
2. The integration test CR should contain the optional labels.

## Unit tests
```
  Create Utils
    ✓ Should contain the optional test value in the labels (1 ms)
    ✓ Should not contain the optional label if the test is mandatory
```

```
  IntegrationTestListRow
    ✓ should read the optional field from label (8 ms)
    ✓ should show mandatory value if the optional labels are not set (8 ms)
```


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


