### PR TITLE
fix typo and remove old section in application overview tab

### DIFF
--- a/src/hacbs/components/ApplicationDetails/tabs/overview/sections/AppWorkflowSection.tsx
+++ b/src/hacbs/components/ApplicationDetails/tabs/overview/sections/AppWorkflowSection.tsx
@@ -48,7 +48,7 @@ const AppWorkflowSection: React.FC<AppWorkflowSectionProps> = ({ applicationName
       <Grid hasGutter className="hacbs-app-workflow">
         <GridItem>
           <TextContent>
-            <Text component={TextVariants.h3}>Appplication pipeline configuration.</Text>
+            <Text component={TextVariants.h3}>Application pipeline configuration.</Text>
             <Text component={TextVariants.p}>
               This is a visualization of your application pipeline, from source code, through tests
               to deployments.
@@ -56,8 +56,6 @@ const AppWorkflowSection: React.FC<AppWorkflowSectionProps> = ({ applicationName
                 learn more
               </Button>
             </Text>
-            <Text component={TextVariants.h3}>Appplication workflow</Text>
-            <Text component={TextVariants.p}>Manage your CI/CD workflow</Text>
           </TextContent>
         </GridItem>
         <GridItem>


### PR DESCRIPTION
## Fixes
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
1. fixed a typo in visualization heading
2. removed workflow section (old) in the overview tab.


<img width="1750" alt="Screenshot 2022-11-04 at 4 17 33 PM" src="https://user-images.githubusercontent.com/9964343/199957783-3e1b266d-2950-4f3e-a401-5bd236c79c5c.png">


cc: @MariaLeonova @abhinandan13jan 