### PR TITLE
Send context dir while creating components

### DIFF
--- a/src/utils/create-utils.ts
+++ b/src/utils/create-utils.ts
@@ -85,11 +85,6 @@ export const createComponent = (
   const { componentName, containerImage, source, replicas, resources, env, targetPort } = component;
 
   const name = component.componentName.split(/ |\./).join('-').toLowerCase();
-  // const uniqueName = uniqueId(name);
-
-  // FIXME - context is not supported by the HAS API correctly yet.
-  // Remove after https://issues.redhat.com/browse/DEVHAS-115 is fixed.
-  delete source?.git?.context;
 
   const newComponent = {
     apiVersion: `${ComponentModel.apiGroup}/${ComponentModel.apiVersion}`,


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
- https://issues.redhat.com/browse/HAC-2376

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- Due to an earlier HAS issue we could not send the context dir value while creating components. That issue has been fixed so this PR updates the code to send the context value.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
- No UI change.


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
