### PR TITLE
fix `No tests set` group label when tests are present

### DIFF
--- a/src/hacbs/components/ApplicationDetails/tabs/overview/visualization/hooks/__tests__/useAppWorkflowData.spec.ts
+++ b/src/hacbs/components/ApplicationDetails/tabs/overview/visualization/hooks/__tests__/useAppWorkflowData.spec.ts
@@ -16,6 +16,7 @@ import {
   sampleBuildPipelines,
   sampleComponents,
   sampleEnvironments,
+  sampleIntegrationTestScenarios,
 } from '../__data__/workflow-data';
 import { useAppWorkflowData } from '../useAppWorkflowData';
 
@@ -167,5 +168,22 @@ describe('useAppWorkflowData hook', () => {
     const [model] = result.current;
 
     expect(model.nodes.filter((n) => n.group)).toHaveLength(6);
+  });
+
+  it('should display empty integration test group node', () => {
+    const { result } = renderHook(() => useAppWorkflowData('test', true));
+    const [model] = result.current;
+    const testGroup = model.nodes.find((n) => n.id === 'tests');
+    expect(testGroup).not.toBeNull();
+    expect(testGroup.label).toBe('No tests set');
+  });
+
+  it('should display non-empty integration test group node', () => {
+    useIntegrationTestScenariosMock.mockReturnValue([sampleIntegrationTestScenarios, true]);
+    const { result } = renderHook(() => useAppWorkflowData('test', true));
+    const [model] = result.current;
+    const testGroup = model.nodes.find((n) => n.id === 'tests');
+    expect(testGroup).not.toBeNull();
+    expect(testGroup.label).toBe('Tests');
   });
 });

--- a/src/hacbs/components/ApplicationDetails/tabs/overview/visualization/hooks/useAppWorkflowData.ts
+++ b/src/hacbs/components/ApplicationDetails/tabs/overview/visualization/hooks/useAppWorkflowData.ts
@@ -57,9 +57,9 @@ export const useAppWorkflowData = (
       integrationTestsLoaded && applicationTestsLoaded
         ? groupToPipelineNode(
             'tests',
-            !componentIntegrationTestNodes?.length && !applicationIntegrationTestNodes.length
-              ? 'Tests'
-              : 'No tests set',
+            !applicationIntegrationTests?.length && !applicationIntegrationTests.length
+              ? 'No tests set'
+              : 'Tests',
             WorkflowNodeType.TESTS,
             buildTasks,
             expanded,


### PR DESCRIPTION
## Fixes 
`No tests set` displayed when there are tests
![image](https://user-images.githubusercontent.com/14068621/202273678-2bc98184-af49-458a-9e3c-f281575282e3.png)

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
![image](https://user-images.githubusercontent.com/14068621/202273911-99fd3383-a048-49e2-b2b1-83aea70ea839.png)
![image](https://user-images.githubusercontent.com/14068621/202273929-b017797a-147e-49d1-aa32-9026620b91d1.png)

App with no components and no tests:
![image](https://user-images.githubusercontent.com/14068621/202274404-b6dc05f3-e0ef-42e3-8b27-3431b9a6588f.png)


## How to test or reproduce?
Go to the overview tab and observe that 

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
