### PR TITLE
Do not include quickstarts in shared deps

### DIFF
--- a/config/remotePlugin.js
+++ b/config/remotePlugin.js
@@ -468,7 +468,7 @@ module.exports = {
     'react-redux': { singleton: true, import: false },
     '@openshift/dynamic-plugin-sdk-utils': { singleton: true, import: false },
     '@scalprum/react-core': { singleton: true, import: false },
-    '@patternfly/quickstarts': { singleton: true, eager: true },
+    '@patternfly/quickstarts': { singleton: true },
     '@unleash/proxy-client-react': { singleton: true },
     '@openshift/dynamic-plugin-sdk': { singleton: true, import: false },
   },


### PR DESCRIPTION
## Fixes 

Allows to use quickstarts dependency.

[RHCLOUD-23088](https://issues.redhat.com//browse/RHCLOUD-23088)

## Description

When using quickstarts from patternfly the page doesn't load and there's an error that eager consumption of react is not ready. This PR removes the quickstarts from shared dependency list to allow usage of `@patternfly/quickstarts` package.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):