### PR TITLE
Fix component creation without targetPort

### DIFF
--- a/src/utils/__tests__/create-utils.spec.ts
+++ b/src/utils/__tests__/create-utils.spec.ts
@@ -170,6 +170,46 @@ describe('Create Utils', () => {
     });
   });
 
+  it('Should create component with target port', async () => {
+    const mockComponentDataWithTargetPort = {
+      ...mockComponent,
+      targetPort: 8080,
+    };
+    await createComponent(mockComponentDataWithTargetPort, 'test-application', 'test-ns');
+
+    expect(k8sCreateResource).toHaveBeenCalledWith({
+      model: ComponentModel,
+      queryOptions: {
+        name: 'test-component',
+        ns: 'test-ns',
+      },
+      resource: {
+        ...mockComponentData,
+        spec: {
+          ...mockComponentData.spec,
+          targetPort: 8080,
+        },
+      },
+    });
+  });
+
+  it('Should create component without target port, if it is not passed', async () => {
+    const mockComponentDataWithoutTargetPort = {
+      ...mockComponent,
+      targetPort: undefined,
+    };
+    await createComponent(mockComponentDataWithoutTargetPort, 'test-application', 'test-ns');
+
+    expect(k8sCreateResource).toHaveBeenCalledWith({
+      model: ComponentModel,
+      queryOptions: {
+        name: 'test-component',
+        ns: 'test-ns',
+      },
+      resource: mockComponentData,
+    });
+  });
+
   it('Should call k8s create util with pipelines-as-code annotations', async () => {
     await createComponent(
       mockComponentWithDevfile,

--- a/src/utils/create-utils.ts
+++ b/src/utils/create-utils.ts
@@ -4,6 +4,7 @@ import {
   k8sUpdateResource,
 } from '@openshift/dynamic-plugin-sdk-utils';
 import isEqual from 'lodash/isEqual';
+import isNumber from 'lodash/isNumber';
 import merge from 'lodash/merge';
 import uniqueId from 'lodash/uniqueId';
 import {
@@ -106,7 +107,7 @@ export const createComponent = (
       secret,
       containerImage,
       replicas,
-      targetPort,
+      ...(isNumber(targetPort) && { targetPort }),
       resources,
       env,
     },


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
[HACBS-1008](https://issues.redhat.com/browse/HACBS-1008)

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When trying to create a component that doesn't need to use any port, if I leave the "Target port" text box empty, nothing happens when I click on the "Create components & continue".


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

**Before fix:** 

![without_targetPort_before](https://user-images.githubusercontent.com/9964343/203275311-0969a4b4-59e0-418f-898a-16ecfe1ed440.gif)

**After fix:** 
![without_targetPort_after](https://user-images.githubusercontent.com/9964343/203275324-0e8c4bd0-f413-40cf-9d40-4ca41ed2145c.gif)


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

 In component review section, remove the tagertPort value under `Deploy Configuration` section and click on `create component & continue` button

## Unit tests:
```
Create Utils
    ✓ Should create component with target port
    ✓ Should create component without target port, if it is not passed (1 ms)
```
## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
