### PR TITLE
Run docker as host user.

### DIFF
--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -8,5 +8,6 @@ RUN microdnf install --assumeyes which && \
     curl -L -o /tmp/oc.tar ${OC_DOWNLOAD_URL} && \
     tar -xf /tmp/oc.tar -C /usr/bin
 
-RUN groupadd -r hacdev && useradd -r -g hacdev hacdev
-USER hacdev:hacdev
+RUN chmod 777 /home/cypress && \
+    mkdir -p /home/cypress/.config/Cypress/cy/production && \
+    chmod 777 /home/cypress/.config/Cypress/cy/production

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -63,15 +63,34 @@ cd ..
 
 mkdir -p $WORKSPACE/artifacts
 
+ID="$(id -u):$(id -g)"
+COMMON_SETUP="-u $ID \
+    -v $WORKSPACE/artifacts:/e2e/cypress:Z \
+    -v $PWD/integration-tests:/e2e:Z \
+    -v /etc/passwd:/etc/passwd:ro \
+    -w /e2e \
+    -e CYPRESS_CACHE_FOLDER=/e2e/.cache \
+    -e CYPRESS_PR_CHECK=true \
+    -e CYPRESS_HAC_BASE_URL=https://${HOSTNAME}/hac/app-studio \
+    -e CYPRESS_USERNAME=`echo ${B64_USER} | base64 -d` \
+    -e CYPRESS_PASSWORD=`echo ${B64_PASS} | base64 -d`"
+TEST_IMAGE="quay.io/hacdev/hac-tests:latest"
+
 set +e
 
-docker run -v $WORKSPACE/artifacts:/e2e/cypress:Z -v $PWD/integration-tests:/e2e:Z -w /e2e -e CYPRESS_PR_CHECK=true -e CYPRESS_HAC_BASE_URL=https://${HOSTNAME}/hac/app-studio -e CYPRESS_USERNAME=`echo ${B64_USER} | base64 -d` -e CYPRESS_PASSWORD=`echo ${B64_PASS} | base64 -d` -e CYPRESS_GH_TOKEN=${CYPRESS_GH_TOKEN} -e CYPRESS_QUAY_TOKEN=${CYPRESS_QUAY_TOKEN} quay.io/hacdev/hac-tests:latest bash -c "startcypress run"
+docker run ${COMMON_SETUP} \
+    -e CYPRESS_GH_TOKEN=${CYPRESS_GH_TOKEN} \
+    -e CYPRESS_QUAY_TOKEN=${CYPRESS_QUAY_TOKEN} \
+    ${TEST_IMAGE} \
+    bash -c "startcypress run"
 TEST_RUN=$?
-docker run -v $WORKSPACE/artifacts:/e2e/cypress:Z -v $PWD/integration-tests:/e2e:Z -w /e2e -e CYPRESS_PR_CHECK=true -e CYPRESS_HAC_BASE_URL=https://${HOSTNAME}/hac/app-studio -e CYPRESS_USERNAME=`echo ${B64_USER} | base64 -d` -e CYPRESS_PASSWORD=`echo ${B64_PASS} | base64 -d` -e CYPRESS_GH_PASSWORD=${CYPRESS_GH_PASSWORD} quay.io/hacdev/hac-tests:latest bash -c "startcypress run -e configFile=experimental"
+
+docker run ${COMMON_SETUP} \
+    -e CYPRESS_GH_PASSWORD=${CYPRESS_GH_PASSWORD} \
+    ${TEST_IMAGE} \
+    bash -c "startcypress run -e configFile=experimental"
 TEST_RUN=$(($TEST_RUN || $?))
 
-# This needs to stay there to grant Jenkins rights to clean the workspace 
-docker run -u 0 -v $WORKSPACE/artifacts:/e2e/cypress:Z -v $PWD/integration-tests:/e2e:Z -w /e2e quay.io/hacdev/hac-tests:latest bash -c "chmod -v -R a+rwx,-t /e2e/cypress"
 bonfire namespace release ${NAMESPACE}
 
 # teardown_docker


### PR DESCRIPTION
## Description
Run tests in a docker as a host user. Currently, if a job is interrupted during running tests, Jenkins fails to remove files generated by this test. Running as a host user should help to solve that.