### PR TITLE
Enable unleash client from chroming service

### DIFF
--- a/config/remotePlugin.js
+++ b/config/remotePlugin.js
@@ -469,6 +469,7 @@ module.exports = {
     '@openshift/dynamic-plugin-sdk-utils': { singleton: true, import: false },
     '@scalprum/react-core': { singleton: true, import: false },
     '@patternfly/quickstarts': { singleton: true, eager: true },
+    '@unleash/proxy-client-react': { singleton: true },
     '@openshift/dynamic-plugin-sdk': { singleton: true, import: false },
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@redhat-cloud-services/frontend-components": "^3.8.6",
         "@redhat-cloud-services/frontend-components-notifications": "^3.2.2",
         "@redhat-cloud-services/frontend-components-utilities": "^3.2.8",
+        "@unleash/proxy-client-react": "^3.4.1",
         "classnames": "^2.3.1",
         "dayjs": "^1.10.8",
         "file-saver": "1.3.x",
@@ -79,6 +80,7 @@
         "stylelint-scss": "3.19.0",
         "ts-jest": "^27.0.7",
         "typescript": "^4.4.4",
+        "unleash-proxy-client": "^2.3.0",
         "webpack-bundle-analyzer": "4.4.2"
       },
       "engines": {
@@ -3664,6 +3666,14 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@unleash/proxy-client-react": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@unleash/proxy-client-react/-/proxy-client-react-3.4.1.tgz",
+      "integrity": "sha512-X7OXsR3k2KpH9FZ/4QYy+SeUoL1g+w5IIiv//fVH4IyGp0M7CCLsF+8eYdfC7xHGk0w7/xbcIyVINmGsXfb04w==",
+      "peerDependencies": {
+        "unleash-proxy-client": "^2.3.0"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -16810,6 +16820,12 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
     },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "dev": true
+    },
     "node_modules/tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
@@ -17327,6 +17343,16 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/unleash-proxy-client": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/unleash-proxy-client/-/unleash-proxy-client-2.3.0.tgz",
+      "integrity": "sha512-UYDZjjsIF+n01LnijR8t/FXOM5XPnjZkE5K/E+SInFzBfL1SckYZHiuzii1/4QmiRo/x+vjx9LJjAzE8JRas4Q==",
+      "dev": true,
+      "dependencies": {
+        "tiny-emitter": "^2.1.0",
+        "uuid": "^8.3.2"
       }
     },
     "node_modules/unpipe": {
@@ -21365,6 +21391,11 @@
           "dev": true
         }
       }
+    },
+    "@unleash/proxy-client-react": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@unleash/proxy-client-react/-/proxy-client-react-3.4.1.tgz",
+      "integrity": "sha512-X7OXsR3k2KpH9FZ/4QYy+SeUoL1g+w5IIiv//fVH4IyGp0M7CCLsF+8eYdfC7xHGk0w7/xbcIyVINmGsXfb04w=="
     },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
@@ -31366,6 +31397,12 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
     },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "dev": true
+    },
     "tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
@@ -31732,6 +31769,16 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
+    },
+    "unleash-proxy-client": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/unleash-proxy-client/-/unleash-proxy-client-2.3.0.tgz",
+      "integrity": "sha512-UYDZjjsIF+n01LnijR8t/FXOM5XPnjZkE5K/E+SInFzBfL1SckYZHiuzii1/4QmiRo/x+vjx9LJjAzE8JRas4Q==",
+      "dev": true,
+      "requires": {
+        "tiny-emitter": "^2.1.0",
+        "uuid": "^8.3.2"
+      }
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@redhat-cloud-services/frontend-components": "^3.8.6",
     "@redhat-cloud-services/frontend-components-notifications": "^3.2.2",
     "@redhat-cloud-services/frontend-components-utilities": "^3.2.8",
+    "@unleash/proxy-client-react": "^3.4.1",
     "classnames": "^2.3.1",
     "dayjs": "^1.10.8",
     "file-saver": "1.3.x",
@@ -96,6 +97,7 @@
     "stylelint-scss": "3.19.0",
     "ts-jest": "^27.0.7",
     "typescript": "^4.4.4",
+    "unleash-proxy-client": "^2.3.0",
     "webpack-bundle-analyzer": "4.4.2"
   },
   "insights": {


### PR DESCRIPTION
## Fixes 

Unable to access unleash client values provided from chrome.


## Description

Application can't access values from unleash client to use feature flags. Hac-core will be sharing (**merge after!** https://github.com/openshift/hac-core/pull/116) unleash client values so we have to use the shared deps and use the values as well.


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
