### PR TITLE
remove flags from redirect

### DIFF
--- a/config/remotePlugin.js
+++ b/config/remotePlugin.js
@@ -206,9 +206,6 @@ module.exports = {
           $codeRef: 'Redirect',
         },
       },
-      flags: {
-        required: ['SIGNUP'],
-      },
     },
     {
       type: 'core.page/route',
@@ -217,9 +214,6 @@ module.exports = {
         component: {
           $codeRef: 'Redirect',
         },
-      },
-      flags: {
-        required: ['SIGNUP'],
       },
     },
 


### PR DESCRIPTION
## Fixes 
Redirect from `/app-studio` to `/stonesoup` isn't working when the user has yet to signup.

## Description
https://github.com/openshift/hac-dev/pull/277 changed the url to `/stonesoup` and at the same time added a redirect from `/app-studio`. However the redirect route still had the `SIGNUP` flag as a requirement. Simply removed the flag so that the redirect would work as expected.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Create a new RHD account that has yet to sign up.
Go to `/hac/app-studio`.
Observe the page fails to load.
With this change, a redirect to `/stonesoup` would happen and then the signup page will load.


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
