### PR TITLE
Fix the error fields to show actual pipeline failure messages

### DIFF
--- a/src/components/PipelineRunDetailsView/__tests__/PipelineRunDetailsView.spec.tsx
+++ b/src/components/PipelineRunDetailsView/__tests__/PipelineRunDetailsView.spec.tsx
@@ -122,9 +122,7 @@ describe('PipelineRunDetailsView', () => {
     render(<PipelineRunDetailsView pipelineRunName={pipelineRunName} />);
     expect(screen.queryByText('Pipeline run details')).toBeInTheDocument();
     expect(screen.queryByText('Status')).toBeInTheDocument();
-    expect(screen.queryByText('Message')).toBeInTheDocument();
     expect(screen.queryByText('Namespace')).toBeInTheDocument();
-    expect(screen.queryByText('Message')).toBeInTheDocument();
   });
 
   it('should render Stop and Cancel button under the Actions dropdown', () => {

--- a/src/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
@@ -15,6 +15,8 @@ import {
 import { PipelineRunLabel } from '../../../consts/pipelinerun';
 import { pipelineRunFilterReducer } from '../../../shared';
 import ExternalLink from '../../../shared/components/links/ExternalLink';
+import { ErrorDetailsWithStaticLog } from '../../../shared/components/pipeline-run-logs/logs/log-snippet-types';
+import { getPLRLogSnippet } from '../../../shared/components/pipeline-run-logs/logs/pipelineRunLogSnippet';
 import { StatusIconWithText } from '../../../shared/components/pipeline-run-logs/StatusIcon';
 import { Timestamp } from '../../../shared/components/timestamp/Timestamp';
 import { PipelineRunKind } from '../../../types';
@@ -28,6 +30,7 @@ type PipelineRunDetailsTabProps = {
   error: unknown;
 };
 const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({ pipelineRun, error }) => {
+  const pipelineRunFailed = (getPLRLogSnippet(pipelineRun) || {}) as ErrorDetailsWithStaticLog;
   const duration = calculateDuration(
     typeof pipelineRun.status?.startTime === 'string' ? pipelineRun.status?.startTime : '',
     typeof pipelineRun.status?.completionTime === 'string'
@@ -103,35 +106,38 @@ const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({ pipelineR
                     <StatusIconWithText status={pipelineRunFilterReducer(pipelineRun)} />
                   </DescriptionListDescription>
                 </DescriptionListGroup>
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Message</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    {pipelineRun.status?.conditions[0]?.message ?? '-'}
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Log snippet</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    <CodeBlock>
-                      <CodeBlockCode id="code-content">
-                        {pipelineRun.status?.taskRuns[`${pipelineRun.metadata?.name}-show-summary`]
-                          ?.status?.taskSpec?.steps[0].script ?? '-'}
-                      </CodeBlockCode>
-                    </CodeBlock>
-                    <Button
-                      variant="link"
-                      isInline
-                      component={(props) => (
-                        <Link
-                          {...props}
-                          to={`/stonesoup/pipelineruns/${pipelineRun.metadata?.name}?activeTab=logs`}
-                        />
-                      )}
-                    >
-                      See logs
-                    </Button>
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
+                {Object.keys(pipelineRunFailed).length > 0 && (
+                  <>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Message</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {pipelineRunFailed.title ?? '-'}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Log snippet</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        <CodeBlock>
+                          <CodeBlockCode id="code-content">
+                            {pipelineRunFailed.staticMessage ?? '-'}
+                          </CodeBlockCode>
+                        </CodeBlock>
+                        <Button
+                          variant="link"
+                          isInline
+                          component={(props) => (
+                            <Link
+                              {...props}
+                              to={`/stonesoup/pipelineruns/${pipelineRun.metadata?.name}?activeTab=logs`}
+                            />
+                          )}
+                        >
+                          See logs
+                        </Button>
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  </>
+                )}
                 <DescriptionListGroup>
                   <DescriptionListTerm>Pipeline</DescriptionListTerm>
                   <DescriptionListDescription>

--- a/src/components/PipelineRunDetailsView/tabs/__tests__/PipelineRunDetailsTab.spec.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/__tests__/PipelineRunDetailsTab.spec.tsx
@@ -61,6 +61,40 @@ describe('PipelineRunDetailsTab', () => {
     screen.getByTestId('pipelinerun-graph');
   });
 
+  it('should not render the error fields for the succeeded pipelinerun', () => {
+    watchResourceMock.mockReturnValue([[], true]);
+
+    render(<PipelineRunDetailsTab pipelineRun={testPipelineRun} error={null} />, {
+      wrapper: BrowserRouter,
+    });
+    expect(screen.queryByText('Message')).not.toBeInTheDocument();
+    expect(screen.queryByText('Log snippet')).not.toBeInTheDocument();
+  });
+
+  it('should render the error fields for the failed pipelinerun', () => {
+    watchResourceMock.mockReturnValue([[], true]);
+    const failedPipelineRun = {
+      ...testPipelineRun,
+      status: {
+        ...testPipelineRun.status,
+        conditions: [
+          {
+            lastTransitionTime: '2022-12-20T11:58:45Z',
+            message: 'PipelineRun "node-on-pull-request-g5twk" failed to finish within "1m0s"',
+            reason: 'PipelineRunTimeout',
+            status: 'False',
+            type: 'Succeeded',
+          },
+        ],
+      },
+    };
+    render(<PipelineRunDetailsTab pipelineRun={failedPipelineRun} error={null} />, {
+      wrapper: BrowserRouter,
+    });
+    screen.getByText('Message');
+    screen.getByText('Log snippet');
+  });
+
   it('should render the graph error state', () => {
     watchResourceMock.mockReturnValue([[], true]);
     render(


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-2643

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

 Log snippet and Message fields are shown only when the pipeline is failed. Removed the hard coded summary task log and replaced it with the actual failure message.



## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

**Before:**  (shows the logs from show-summary task instead of failed task)

<img width="1898" alt="Log snippet issue" src="https://user-images.githubusercontent.com/9964343/208678672-bed31429-d656-4aa7-b12b-fc7decf0efe7.png">

**After:**

Shows the failure message: 
<img width="1790" alt="Error_message" src="https://user-images.githubusercontent.com/9964343/208679002-69a9a8e9-344c-44d7-a02c-1f69bacca633.png">

Error fields are not shown when the pipeline is succeeded.

<img width="1790" alt="Succeeded_pipeline" src="https://user-images.githubusercontent.com/9964343/208679017-0cbed353-abc5-4810-bb8c-9fb3042925b8.png">

## Unit tests

```
  PipelineRunDetailsTab
  
    ✓ should not render the error fields for the succeeded pipelinerun (25 ms)
    ✓ should render the error fields for the failed pipelinerun (28 ms)

```
## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
