### PR TITLE
Add cancelling status for pipelineruns

### DIFF
--- a/src/__data__/pipelinerun-data.ts
+++ b/src/__data__/pipelinerun-data.ts
@@ -175,11 +175,21 @@ const samplePipelineRun: PipelineRunKind = {
 export enum DataState {
   RUNNING = 'Running',
   SUCCEEDED = 'Succeeded',
-  FAILED1 = 'Failed',
+  FAILED = 'Failed',
   SKIPPED = 'Skipped',
   PIPELINE_RUN_PENDING = 'PipelineRunPending',
   PIPELINE_RUN_STOPPED = 'StoppedRunFinally',
   PIPELINE_RUN_CANCELLED = 'CancelledRunFinally',
+  TASK_RUN_CANCELLED = 'TaskRunCancelled',
+  PIPELINE_RUN_CANCELLING = 'PipelineRunCancelling',
+  PIPELINE_RUN_STOPPING = 'PipelineRunStopping',
+  TASK_RUN_STOPPING = 'TaskRunStopping',
+
+  /*Custom data state to test various scnearios*/
+  STATUS_WITHOUT_CONDITIONS = 'StatusWithoutCondition',
+  STATUS_WITH_EMPTY_CONDITIONS = 'StatusWithEmptyCondition',
+  STATUS_WITHOUT_CONDITION_TYPE = 'StatusWithoutConditionType',
+  STATUS_WITH_UNKNOWN_REASON = 'StatusWithUnknownReason',
 }
 
 type TestPipelineRuns = { [key in DataState]?: PipelineRunKind };
@@ -570,7 +580,7 @@ export const testPipelineRuns: TestPipelineRuns = {
         {
           lastTransitionTime: '2021-01-13T14:34:19Z',
           message: 'Tasks Completed: 1 (Failed: 0, Cancelled 0), Skipped: 1',
-          reason: 'Completed',
+          reason: 'ConditionCheckFailed',
           status: 'True',
           type: 'Succeeded',
         },
@@ -661,7 +671,7 @@ export const testPipelineRuns: TestPipelineRuns = {
         {
           lastTransitionTime: '2019-09-12T20:38:01Z',
           message: 'All Tasks have completed executing',
-          reason: 'Succeeded',
+          reason: 'ExceededResourceQuota',
           status: 'True',
           type: 'Succeeded',
         },
@@ -760,7 +770,7 @@ export const testPipelineRuns: TestPipelineRuns = {
   [DataState.PIPELINE_RUN_STOPPED]: {
     ...samplePipelineRun,
     spec: {
-      ...samplePipelineRun,
+      ...samplePipelineRun.spec,
       status: 'StoppedRunFinally',
     },
     status: {
@@ -843,6 +853,83 @@ export const testPipelineRuns: TestPipelineRuns = {
           },
         },
       },
+    },
+  },
+  [DataState.FAILED]: {
+    ...samplePipelineRun,
+    status: {
+      pipelineSpec: samplePipelineSpec,
+      conditions: [
+        { status: 'True', type: 'Failure' },
+        { status: 'False', type: 'Succeeded' },
+      ],
+    },
+  },
+  [DataState.PIPELINE_RUN_CANCELLING]: {
+    ...samplePipelineRun,
+    spec: {
+      ...samplePipelineRun,
+      status: 'CancelledRunFinally',
+    },
+    status: {
+      conditions: [{ status: 'True', type: 'Succeeded' }],
+      pipelineSpec: samplePipelineSpec,
+    },
+  },
+  [DataState.STATUS_WITHOUT_CONDITIONS]: {
+    ...samplePipelineRun,
+    status: {
+      pipelineSpec: samplePipelineSpec,
+    },
+  },
+  [DataState.STATUS_WITHOUT_CONDITIONS]: {
+    ...samplePipelineRun,
+    status: {
+      conditions: [],
+      pipelineSpec: samplePipelineSpec,
+    },
+  },
+  [DataState.TASK_RUN_CANCELLED]: {
+    ...samplePipelineRun,
+    status: {
+      conditions: [
+        {
+          lastTransitionTime: '2022-11-28T07:10:43Z',
+          message: 'TaskRun "test-casevcgrn" was cancelled',
+          reason: 'TaskRunCancelled',
+          status: 'False',
+          type: 'Succeeded',
+        },
+      ],
+      pipelineSpec: samplePipelineSpec,
+    },
+  },
+  [DataState.PIPELINE_RUN_STOPPING]: {
+    ...samplePipelineRun,
+    status: {
+      pipelineSpec: samplePipelineSpec,
+      conditions: [{ type: 'Succeeded', status: 'Unknown', reason: 'PipelineRunStopping' }],
+    },
+  },
+  [DataState.TASK_RUN_STOPPING]: {
+    ...samplePipelineRun,
+    status: {
+      pipelineSpec: samplePipelineSpec,
+      conditions: [{ type: 'Succeeded', status: 'Unknown', reason: 'TaskRunStopping' }],
+    },
+  },
+  [DataState.STATUS_WITHOUT_CONDITION_TYPE]: {
+    ...samplePipelineRun,
+    status: {
+      pipelineSpec: samplePipelineSpec,
+      conditions: [{ type: undefined, status: 'Unknown', reason: 'Unknown' }],
+    },
+  },
+  [DataState.STATUS_WITH_UNKNOWN_REASON]: {
+    ...samplePipelineRun,
+    status: {
+      pipelineSpec: samplePipelineSpec,
+      conditions: [{ type: 'Succeeded', status: 'False', reason: 'Unknown' }],
     },
   },
 };

--- a/src/shared/components/pipeline-run-logs/StatusIcon.tsx
+++ b/src/shared/components/pipeline-run-logs/StatusIcon.tsx
@@ -35,6 +35,7 @@ export const StatusIcon: React.FC<StatusIconProps> = ({ status, disableSpin, ...
     case runStatus.Pending:
       return <HourglassHalfIcon {...props} />;
 
+    case runStatus.Cancelling:
     case runStatus.Cancelled:
       return <BanIcon {...props} />;
 

--- a/src/shared/components/pipeline-run-logs/__tests__/utils.spec.ts
+++ b/src/shared/components/pipeline-run-logs/__tests__/utils.spec.ts
@@ -1,0 +1,150 @@
+import { DataState, testPipelineRuns } from '../../../../__data__/pipelinerun-data';
+import { ContainerStatus } from '../../types';
+import {
+  containerToLogSourceStatus,
+  getRunStatusColor,
+  LOG_SOURCE_RESTARTING,
+  LOG_SOURCE_RUNNING,
+  LOG_SOURCE_TERMINATED,
+  LOG_SOURCE_WAITING,
+  pipelineRunFilterReducer,
+  pipelineRunStatus,
+  pipelineRunStatusToGitOpsStatus,
+  runStatus,
+} from '../utils';
+
+describe('pipelineRunStatus', () => {
+  it('should return null if an invalid pipelineruns', () => {
+    expect(pipelineRunStatus(testPipelineRuns[DataState.STATUS_WITHOUT_CONDITIONS])).toBeNull();
+    expect(pipelineRunStatus(testPipelineRuns[DataState.STATUS_WITH_EMPTY_CONDITIONS])).toBeNull();
+    expect(pipelineRunStatus(testPipelineRuns[DataState.STATUS_WITHOUT_CONDITION_TYPE])).toBeNull();
+  });
+
+  it('should return Pending status for pipelinerun status  with type as "Succeeded" & Pending condition', () => {
+    expect(pipelineRunStatus(testPipelineRuns[DataState.PIPELINE_RUN_PENDING])).toBe('Pending');
+  });
+
+  it('should return Running status for pipelinerun status with type as "Succeeded" & status as "Unknown"', () => {
+    const reducerOutput = pipelineRunStatus(testPipelineRuns[DataState.RUNNING]);
+    expect(reducerOutput).toBe('Running');
+  });
+
+  it('should return Succeeded status for pipelinerun status with type as "Succeeded" & status as "True"', () => {
+    const reducerOutput = pipelineRunStatus(testPipelineRuns[DataState.SUCCEEDED]);
+    expect(reducerOutput).toBe('Succeeded');
+  });
+
+  it('should return failed status for all the failed pipelineruns"', () => {
+    expect(pipelineRunStatus(testPipelineRuns[DataState.FAILED])).toBe('Failed');
+    expect(pipelineRunStatus(testPipelineRuns[DataState.STATUS_WITH_UNKNOWN_REASON])).toBe(
+      'Failed',
+    );
+    expect(pipelineRunStatus(testPipelineRuns[DataState.PIPELINE_RUN_STOPPING])).toBe('Failed');
+    expect(pipelineRunStatus(testPipelineRuns[DataState.TASK_RUN_STOPPING])).toBe('Failed');
+  });
+
+  it('should return Cancelled status for pipelinerun status with reason as "StoppedRunFinally" and "CancelledRunFinally"', () => {
+    expect(pipelineRunStatus(testPipelineRuns[DataState.PIPELINE_RUN_STOPPED])).toBe('Cancelled');
+    expect(pipelineRunStatus(testPipelineRuns[DataState.PIPELINE_RUN_CANCELLED])).toBe('Cancelled');
+    expect(pipelineRunStatus(testPipelineRuns[DataState.TASK_RUN_CANCELLED])).toBe('Cancelled');
+  });
+
+  it('should return Cancelling status for pipelinerun which is cancelled but finishing the current execution', () => {
+    const reducerOutput = pipelineRunStatus(testPipelineRuns[DataState.PIPELINE_RUN_CANCELLING]);
+    expect(reducerOutput).toBe('Cancelling');
+  });
+
+  it('should return Skipped status for pipleinerun with reason as "ConditionCheckFailed"', () => {
+    expect(pipelineRunStatus(testPipelineRuns[DataState.SKIPPED])).toBe('Skipped');
+  });
+});
+
+describe('pipelineRunFilterReducer', () => {
+  it('should return a valid status', () => {
+    expect(pipelineRunFilterReducer(testPipelineRuns[DataState.RUNNING])).toBe('Running');
+  });
+
+  it('should return "-" for pipelinerun status with empty conditions', () => {
+    expect(pipelineRunFilterReducer(testPipelineRuns[DataState.STATUS_WITH_EMPTY_CONDITIONS])).toBe(
+      '-',
+    );
+  });
+});
+
+describe('containerToLogSourceStatus', () => {
+  it('should return waiting status', () => {
+    let status = containerToLogSourceStatus(null);
+    expect(status).toBe(LOG_SOURCE_WAITING);
+
+    status = containerToLogSourceStatus({
+      name: 'test',
+      state: { waiting: {} },
+    } as ContainerStatus);
+    expect(status).toBe(LOG_SOURCE_WAITING);
+  });
+
+  it('should return restarting status', () => {
+    const status = containerToLogSourceStatus({
+      name: 'test',
+      state: { waiting: {} },
+      lastState: { [LOG_SOURCE_WAITING]: {} },
+    } as ContainerStatus);
+    expect(status).toBe(LOG_SOURCE_RESTARTING);
+  });
+
+  it('should return running Status', () => {
+    const status = containerToLogSourceStatus({
+      name: 'test',
+      state: { running: {} },
+    } as ContainerStatus);
+    expect(status).toBe(LOG_SOURCE_RUNNING);
+  });
+
+  it('should return terminated Status', () => {
+    const status = containerToLogSourceStatus({
+      name: 'test',
+      state: { terminated: {} },
+    } as ContainerStatus);
+    expect(status).toBe(LOG_SOURCE_TERMINATED);
+  });
+});
+
+describe('getRunStatusColor', () => {
+  it('should return the default case', () => {
+    const { message, pftoken, labelColor } = getRunStatusColor(runStatus.PipelineNotStarted);
+    expect(message).toBeDefined();
+    expect(pftoken).toBeDefined();
+    expect(labelColor).toBeDefined();
+  });
+
+  it('should result the message, pftoken and label colour for all the handled statuses', () => {
+    const handledStatuses = Object.keys(runStatus)
+      .filter((status) => status !== runStatus.PipelineNotStarted)
+      .map((status) => runStatus[status]);
+
+    expect(handledStatuses).not.toHaveLength(0);
+
+    handledStatuses.forEach((statusValue) => {
+      const { message, pftoken, labelColor } = getRunStatusColor(statusValue);
+      expect(message).toBeDefined();
+      expect(pftoken).toBeDefined();
+      expect(labelColor).toBeDefined();
+    });
+  });
+});
+
+describe('pipelineRunStatusToGitOpsStatus', () => {
+  it('should return the default case', () => {
+    expect(pipelineRunStatusToGitOpsStatus('-')).toBe('Unknown');
+  });
+
+  it('should return the valid gitops statuses', () => {
+    expect(pipelineRunStatusToGitOpsStatus(runStatus.Succeeded)).toBe('Healthy');
+    expect(pipelineRunStatusToGitOpsStatus(runStatus.Failed)).toBe('Degraded');
+    expect(pipelineRunStatusToGitOpsStatus(runStatus.Running)).toBe('Progressing');
+    expect(pipelineRunStatusToGitOpsStatus(runStatus.Pending)).toBe('Progressing');
+    expect(pipelineRunStatusToGitOpsStatus(runStatus.Cancelled)).toBe('Suspended');
+    expect(pipelineRunStatusToGitOpsStatus(runStatus.Cancelling)).toBe('Suspended');
+    expect(pipelineRunStatusToGitOpsStatus(runStatus.Skipped)).toBe('Missing');
+  });
+});


### PR DESCRIPTION

## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-2644

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds `Cancelling` status to the pipeline runs that are already cancelled and still finishing up the current tasks (this could be finally tasks as well). Doing this will prevent the user from cancelling the pipelinerun again and again and provides the actual state of the pipelinerun.


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

**Before:**

https://user-images.githubusercontent.com/9964343/208898535-614c1bca-a0f2-405e-af6f-6ea146961ce4.mp4

 **After:** 

https://user-images.githubusercontent.com/9964343/208898548-15296b4a-1f57-403a-a945-129454b383c9.mp4




## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

 Stop/Cancel a running Pipeline, it should mark the pipelinerun status as cancelling and stop/cancel actions in the dropdown should be disabled.

<!-- **Test Configuration(s)**: -->

## Unit Tests

```
  pipelineRunStatus
    ✓ should return null if an invalid pipelineruns (2 ms)
    ✓ should return Pending status for pipelinerun status  with type as "Succeeded" & Pending condition (1 ms)
    ✓ should return Running status for pipelinerun status with type as "Succeeded" & status as "Unknown"
    ✓ should return Succeeded status for pipelinerun status with type as "Succeeded" & status as "True"
    ✓ should return failed status for all the failed pipelineruns" (1 ms)
    ✓ should return Cancelled status for pipelinerun status with reason as "StoppedRunFinally" and "CancelledRunFinally" (1 ms)
    ✓ should return Cancelling status for pipelinerun which is cancelled but finishing the current execution (1 ms)
    ✓ should return Skipped status for pipleinerun with reason as "ConditionCheckFailed" (1 ms)
  pipelineRunFilterReducer
    ✓ should return a valid status
    ✓ should return "-" for pipelinerun status with empty conditions (1 ms)
  containerToLogSourceStatus
    ✓ should return waiting status
    ✓ should return restarting status
    ✓ should return running Status (1 ms)
    ✓ should return terminated Status
  getRunStatusColor
    ✓ should return the default case (1 ms)
    ✓ should result the message, pftoken and label colour for all the handled statuses (2 ms)
  pipelineRunStatusToGitOpsStatus
    ✓ should return the default case
    ✓ should return the valid gitops statuses (3 ms)
 ```   

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

cc: @christianvogt 