### PR TITLE
feature flag and remove settings page for mvp

### DIFF
--- a/config/remotePlugin.js
+++ b/config/remotePlugin.js
@@ -318,6 +318,7 @@ module.exports = {
       },
       flags: {
         required: ['SIGNUP'],
+        disallowed: ['MVP'],
       },
     },
     {
@@ -331,6 +332,7 @@ module.exports = {
       },
       flags: {
         required: ['SIGNUP'],
+        disallowed: ['MVP'],
       },
     },
     {
@@ -353,26 +355,28 @@ module.exports = {
         required: ['SIGNUP'],
       },
     },
-    {
-      type: 'console.navigation/href',
-      properties: {
-        href: '/stonesoup/workspace-settings',
-        name: 'Settings',
-      },
-      flags: {
-        required: ['SIGNUP'],
-      },
-    },
-    {
-      type: 'core.navigation/href',
-      properties: {
-        href: '/stonesoup/workspace-settings',
-        name: 'Settings',
-      },
-      flags: {
-        required: ['SIGNUP'],
-      },
-    },
+    // {
+    //   type: 'console.navigation/href',
+    //   properties: {
+    //     href: '/stonesoup/workspace-settings',
+    //     name: 'Settings',
+    //   },
+    //   flags: {
+    //     required: ['SIGNUP'],
+    //     disallowed: ['MVP'],
+    //   },
+    // },
+    // {
+    //   type: 'core.navigation/href',
+    //   properties: {
+    //     href: '/stonesoup/workspace-settings',
+    //     name: 'Settings',
+    //   },
+    //   flags: {
+    //     required: ['SIGNUP'],
+    //     disallowed: ['MVP'],
+    //   },
+    // },
     {
       type: 'core.flag',
       properties: {
@@ -386,6 +390,15 @@ module.exports = {
       properties: {
         handler: {
           $codeRef: 'FlagUtils.setSignupFeatureFlags',
+        },
+      },
+    },
+
+    {
+      type: 'core.flag',
+      properties: {
+        handler: {
+          $codeRef: 'FlagUtils.setMvpFeatureFlag',
         },
       },
     },

--- a/src/utils/flag-utils.ts
+++ b/src/utils/flag-utils.ts
@@ -25,3 +25,16 @@ export const setSignupFeatureFlags = async (setFlag: SetFeatureFlag) => {
     if (error.code === 404) setFlag(SIGNUP_FLAG, false);
   }
 };
+
+export const MVP_FLAG = 'MVP';
+
+export const setMvpFeatureFlag = (setFlag: SetFeatureFlag): void => {
+  let enabled = true;
+  const param = new URLSearchParams(window.location.search).get(MVP_FLAG.toLowerCase());
+  if (['true', 'false'].includes(param)) {
+    enabled = param !== `${!enabled}`;
+  } else {
+    enabled = localStorage.getItem(MVP_FLAG.toLowerCase()) !== `${!enabled}`;
+  }
+  setFlag(MVP_FLAG, enabled);
+};


### PR DESCRIPTION
## Fixes 
[<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
](https://issues.redhat.com/browse/HAC-2688)

## Description
Adds a feature flag for mvp using the flags extension point.

Feature flagged the settings page route as well as the navigation link. Unfortunately there seems to be a bug with the navigation links not obeying feature flags. Therefore these links were simply commented out.

The mvp feature flag can be controlled by the developer using the query string param `?mvp=true|false` as well as through the local storage by setting `mvp=true|false`. By default the flag is enabled.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
![image](https://user-images.githubusercontent.com/14068621/209198535-c2cd3362-ac0d-465d-8fc7-d780f2e82685.png)

## How to test or reproduce?
The flag can be tested by going directly to the url `/hac/stonesoup/workspace-settings` with the mvp feature flag set to `true` or `false` using the query param or local storage.

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
