### PR TITLE
add learn more missing icon in component step

### DIFF
--- a/src/components/ImportForm/SourceSection/SourceSection.tsx
+++ b/src/components/ImportForm/SourceSection/SourceSection.tsx
@@ -12,6 +12,7 @@ import {
   TextContent,
   ValidatedOptions,
 } from '@patternfly/react-core';
+import { OpenDrawerRightIcon } from '@patternfly/react-icons/dist/esm/icons/open-drawer-right-icon';
 import { useField, useFormikContext } from 'formik';
 import { useOnMount } from '../../../hooks/useOnMount';
 import { getFieldId, InputField } from '../../../shared';
@@ -154,7 +155,10 @@ export const SourceSection: React.FC<SourceSectionProps> = ({
         <Text component="h2">Add components to your application</Text>
         <HelperText>
           <HelperTextItem>
-            {description} <HelpTopicLink topicId="add-component">Learn more</HelpTopicLink>
+            {description}{' '}
+            <HelpTopicLink topicId="add-component">
+              Learn more <OpenDrawerRightIcon />
+            </HelpTopicLink>
           </HelperTextItem>
         </HelperText>
       </TextContent>


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/HAC-2377

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds missing icons near the Learn more quickstart link  in Add component step.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

![Screenshot 2023-01-03 at 7 09 22 PM](https://user-images.githubusercontent.com/9964343/210368304-1b0dc25b-3e91-4d0b-bfb9-f00ca661458d.png)


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
