### PR TITLE
Fix queries causing component tab loading forever

### DIFF
--- a/src/components/ComponentsListView/ComponentListView.tsx
+++ b/src/components/ComponentsListView/ComponentListView.tsx
@@ -109,13 +109,9 @@ const ComponentListView: React.FC<ComponentListViewProps> = ({
     isList: true,
     namespace,
     selector: {
-      matchExpressions: [
-        {
-          key: PipelineRunLabel.COMPONENT,
-          operator: 'In',
-          values: components?.map((c) => c.metadata.name),
-        },
-      ],
+      matchLabels: {
+        [PipelineRunLabel.APPLICATION]: applicationName,
+      },
     },
   });
 


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-2734


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


Component tab loads for ever for certain applications.

**RCA:** 

Creating an application with numbers+text (eg: `1234-app`) and when going through the samples flow the cdq returns the component name with application name prefix eg:  (`1234-app-devfile-sample-python-sqda`). The useK8sWatchResource (coming from dynamic-sdk-utils) does not encode the url properly and it is causing the issue. However it is not reproducible in the local environment but consistently I could reproduce in `console.dev.redhat`

Partially encoded URL : https://console.dev.redhat.com/api/k8s/apis/tekton.dev/v1beta1/namespaces/mreid1/pipelineruns?labelSelector=appstudio.openshift.io%2Fcomponent%20in%20(2023-app-devfile-sample-python-basic-3vph-sample)&limit=250

![image](https://user-images.githubusercontent.com/9964343/210966323-7de3a9b9-5076-4c43-bc4b-bc67974ec201.png)

**Solution:**

Instead of fetching the pipelineruns for all the components list, now we are fetching based on the application name label.



## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

![image](https://user-images.githubusercontent.com/9964343/210967138-792514d0-eae9-4838-859c-0dcd35916ccf.png)


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->



1. In `console.dev.redhat`, Create an application name starting with numbers eg: `1234-app`
2. choose samples flow and visit the components tab

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
