### PR TITLE
Use path params instead of query params in details page tabs

### DIFF
--- a/config/remotePlugin.js
+++ b/config/remotePlugin.js
@@ -75,6 +75,32 @@ module.exports = {
     {
       type: 'console.page/route',
       properties: {
+        path: '/stonesoup/pipelineruns/:plrName/:activeTab',
+        exact: true,
+        component: {
+          $codeRef: 'PipelineRuns',
+        },
+      },
+      flags: {
+        required: ['SIGNUP'],
+      },
+    },
+    {
+      type: 'core.page/route',
+      properties: {
+        path: '/stonesoup/pipelineruns/:plrName/:activeTab',
+        exact: true,
+        component: {
+          $codeRef: 'PipelineRuns',
+        },
+      },
+      flags: {
+        required: ['SIGNUP'],
+      },
+    },
+    {
+      type: 'console.page/route',
+      properties: {
         path: '/stonesoup/applications/:appName/integration-test',
         exact: true,
         component: {
@@ -154,7 +180,7 @@ module.exports = {
     {
       type: 'console.page/route',
       properties: {
-        path: '/stonesoup/:appName/test/:testName',
+        path: '/stonesoup/:appName/integrationtests/:testName',
         exact: true,
         component: {
           $codeRef: 'IntegrationTestDetails',
@@ -167,7 +193,33 @@ module.exports = {
     {
       type: 'core.page/route',
       properties: {
-        path: '/stonesoup/:appName/test/:testName',
+        path: '/stonesoup/:appName/integrationtests/:testName',
+        exact: true,
+        component: {
+          $codeRef: 'IntegrationTestDetails',
+        },
+      },
+      flags: {
+        required: ['HACBS', 'SIGNUP'],
+      },
+    },
+    {
+      type: 'console.page/route',
+      properties: {
+        path: '/stonesoup/:appName/integrationtests/:testName/:activeTab',
+        exact: true,
+        component: {
+          $codeRef: 'IntegrationTestDetails',
+        },
+      },
+      flags: {
+        required: ['HACBS', 'SIGNUP'],
+      },
+    },
+    {
+      type: 'core.page/route',
+      properties: {
+        path: '/stonesoup/:appName/integrationtests/:testName/:activeTab',
         exact: true,
         component: {
           $codeRef: 'IntegrationTestDetails',
@@ -220,6 +272,32 @@ module.exports = {
       type: 'core.page/route',
       properties: {
         path: '/stonesoup/applications/:appName',
+        exact: true,
+        component: {
+          $codeRef: 'ApplicationDetails',
+        },
+      },
+      flags: {
+        required: ['SIGNUP'],
+      },
+    },
+    {
+      type: 'console.page/route',
+      properties: {
+        path: '/stonesoup/applications/:appName/:activeTab',
+        exact: true,
+        component: {
+          $codeRef: 'ApplicationDetails',
+        },
+      },
+      flags: {
+        required: ['SIGNUP'],
+      },
+    },
+    {
+      type: 'core.page/route',
+      properties: {
+        path: '/stonesoup/applications/:appName/:activeTab',
         exact: true,
         component: {
           $codeRef: 'ApplicationDetails',

--- a/src/components/ApplicationDetails/ApplicationDetails.tsx
+++ b/src/components/ApplicationDetails/ApplicationDetails.tsx
@@ -181,6 +181,7 @@ const ApplicationDetails: React.FC<HacbsApplicationDetailsProps> = ({ applicatio
               }),
           },
         ]}
+        baseURL={`/stonesoup/applications/${applicationName}`}
         tabs={[
           {
             key: 'overview',

--- a/src/components/ApplicationDetails/DetailsPage.tsx
+++ b/src/components/ApplicationDetails/DetailsPage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import {
   Dropdown,
   DropdownItem,
@@ -31,7 +31,6 @@ type DetailsPageTabProps = {
   key: string;
   label: string;
   component: React.ReactNode;
-  href?: string;
   isDisabled?: true;
   className?: string;
   isFilled?: boolean;
@@ -46,6 +45,7 @@ type DetailsPageProps = {
   breadcrumbItems?: React.ReactNode;
   actions?: Action[];
   tabs: DetailsPageTabProps[];
+  baseURL: string;
   onTabSelect?: (selectedTabKey: string) => void;
 };
 
@@ -57,33 +57,23 @@ const DetailsPage: React.FC<DetailsPageProps> = ({
   breadcrumbItems,
   actions = [],
   tabs = [],
+  baseURL,
   onTabSelect,
 }) => {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const activeTab = searchParams.get('activeTab');
-  const tabMatched = tabs?.find((t) => t.key === activeTab)?.key || tabs?.[0]?.key;
   const [isOpen, setIsOpen] = React.useState(false);
+  const params = useParams();
+  const { activeTab: tab } = params;
 
+  const activeTab = React.useMemo(() => tab || tabs?.[0]?.key, [tab, tabs]);
+  const navigate = useNavigate();
   const setActiveTab = React.useCallback(
-    (tab: string, replace = false) => {
-      if (activeTab !== tab) {
-        const params = new URLSearchParams();
-        params.set('activeTab', tab);
-        setSearchParams(params, { replace });
+    (newTab: string) => {
+      if (activeTab !== newTab) {
+        navigate(`${baseURL}/${newTab}`);
       }
     },
-    [setSearchParams, activeTab],
+    [activeTab, baseURL, navigate],
   );
-
-  React.useEffect(() => {
-    if (!tabMatched) {
-      setSearchParams(new URLSearchParams(), { replace: true });
-    } else {
-      setActiveTab(tabMatched, true);
-    }
-    // Only run once
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const dropdownItems = React.useMemo(
     () =>

--- a/src/components/ApplicationDetails/__tests__/ApplicationDetails.spec.tsx
+++ b/src/components/ApplicationDetails/__tests__/ApplicationDetails.spec.tsx
@@ -2,22 +2,27 @@ import * as React from 'react';
 import '@testing-library/jest-dom';
 import { useFeatureFlag } from '@openshift/dynamic-plugin-sdk';
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
-import { render, screen, configure, fireEvent, act, waitFor } from '@testing-library/react';
+import { screen, configure, fireEvent, act, waitFor } from '@testing-library/react';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { useGitOpsDeploymentCR } from '../../../hooks/useGitOpsDeploymentCR';
+import { routerRenderer } from '../../../utils/test-utils';
 import { mockApplication } from '../../ApplicationDetailsView/__data__/mock-data';
 import ApplicationDetails from '../ApplicationDetails';
 import { HACBS_APPLICATION_MODAL_HIDE_KEY } from '../ApplicationModal';
 
-jest.mock('react-router-dom', () => ({
-  Link: (props) => (
-    <a href={props.to} data-test={props.to}>
-      {props.children}
-    </a>
-  ),
-  useNavigate: () => jest.fn(),
-  useSearchParams: () => React.useState(() => new URLSearchParams()),
-}));
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    Link: (props) => (
+      <a href={props.to} data-test={props.to}>
+        {props.children}
+      </a>
+    ),
+    useNavigate: () => jest.fn(),
+    useSearchParams: () => React.useState(() => new URLSearchParams()),
+  };
+});
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   useK8sWatchResource: jest.fn(),
@@ -55,7 +60,7 @@ describe('ApplicationDetails', () => {
     useChromeMock.mockReturnValue({
       quickStarts: { set, toggle },
     });
-    render(<ApplicationDetails applicationName="test" />);
+    routerRenderer(<ApplicationDetails applicationName="test" />);
     expect(screen.queryByTestId('spinner')).toBeInTheDocument();
   });
 
@@ -66,14 +71,14 @@ describe('ApplicationDetails', () => {
     useChromeMock.mockReturnValue({
       quickStarts: { set, toggle },
     });
-    render(<ApplicationDetails applicationName="test" />);
+    routerRenderer(<ApplicationDetails applicationName="test" />);
     expect(screen.queryByTestId('details__title')).toBeInTheDocument();
     expect(screen.queryByTestId('details__title').innerHTML).toBe('Test Application');
   });
 
   it('should display overview modal on first run', async () => {
     watchResourceMock.mockReturnValueOnce([mockApplication, true]);
-    render(<ApplicationDetails applicationName="test" />);
+    routerRenderer(<ApplicationDetails applicationName="test" />);
     expect(screen.getByTestId('application-modal-content')).toBeVisible();
 
     act(() => {
@@ -90,7 +95,7 @@ describe('ApplicationDetails', () => {
   it('should not display integration test tab if the mvp flag is set to true', async () => {
     useFeatureFlagMock.mockReturnValue([true]);
     watchResourceMock.mockReturnValueOnce([mockApplication, true]);
-    render(<ApplicationDetails applicationName="test" />);
+    routerRenderer(<ApplicationDetails applicationName="test" />);
     expect(screen.queryByTestId('details__tabItem integrationtests')).not.toBeInTheDocument();
   });
 });

--- a/src/components/ApplicationDetails/__tests__/DetailsPage.spec.tsx
+++ b/src/components/ApplicationDetails/__tests__/DetailsPage.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import '@testing-library/jest-dom';
-import { act, configure, fireEvent, render, screen } from '@testing-library/react';
+import { act, configure, fireEvent, screen } from '@testing-library/react';
+import { routerRenderer } from '../../../utils/test-utils';
 import DetailsPage from '../DetailsPage';
 
 jest.mock('react-router-dom', () => {
@@ -15,24 +16,25 @@ configure({ testIdAttribute: 'data-test' });
 
 describe('DetailsPage', () => {
   it('should render the DetailsPage', () => {
-    const { getByTestId } = render(<DetailsPage title="Details" tabs={[]} />);
+    const { getByTestId } = routerRenderer(<DetailsPage title="Details" baseURL="/" tabs={[]} />);
     expect(getByTestId('details')).toBeInTheDocument();
   });
 
   it('should render the DetailsPage', () => {
-    const { getByTestId } = render(<DetailsPage title="Details" tabs={[]} />);
+    const { getByTestId } = routerRenderer(<DetailsPage title="Details" baseURL="/" tabs={[]} />);
     expect(getByTestId('details')).toBeInTheDocument();
   });
 
   it('should not render the tabs if invalid values are passed', () => {
-    render(<DetailsPage title="Details" tabs={null} />);
+    routerRenderer(<DetailsPage title="Details" baseURL="/" tabs={null} />);
     expect(screen.queryByTestId('app-details__tabs')).not.toBeInTheDocument();
   });
 
   it('should render the tabs', () => {
-    const { getByTestId } = render(
+    const { getByTestId } = routerRenderer(
       <DetailsPage
         title="Details"
+        baseURL="/"
         tabs={[{ key: 'tab1', label: 'Tab 1', component: <div>Tab1 content</div> }]}
       />,
     );
@@ -41,10 +43,11 @@ describe('DetailsPage', () => {
 
   it('should render the tabs', async () => {
     const onTabSelect = jest.fn();
-    render(
+    routerRenderer(
       <DetailsPage
         onTabSelect={onTabSelect}
         title="Details"
+        baseURL="/"
         tabs={[
           { key: 'tab1', label: 'Tab 1', component: <div>Tab1 content</div> },
           { key: 'tab2', label: 'Tab 1', component: <div>Tab1 content</div> },
@@ -61,12 +64,12 @@ describe('DetailsPage', () => {
   });
 
   it('should not render the actions if it is not passed', () => {
-    render(<DetailsPage title="Details" tabs={[]} />);
+    routerRenderer(<DetailsPage title="Details" baseURL="/" tabs={[]} />);
     expect(screen.queryByTestId('details__actions')).not.toBeInTheDocument();
   });
 
   it('should not render actions invalid values are passed to actions', () => {
-    render(<DetailsPage title="Details" tabs={[]} actions={null} />);
+    routerRenderer(<DetailsPage title="Details" baseURL="/" tabs={[]} actions={null} />);
     expect(screen.queryByTestId('details__actions')).not.toBeInTheDocument();
   });
 });

--- a/src/components/ApplicationDetails/tabs/CommitsTab.tsx
+++ b/src/components/ApplicationDetails/tabs/CommitsTab.tsx
@@ -63,10 +63,7 @@ const CommitsTab: React.FC<CommitTabProps> = ({ applicationName }) => {
       <EmptyStateSecondaryActions>
         <Button
           component={(props) => (
-            <Link
-              {...props}
-              to={`/stonesoup/applications/${applicationName}?activeTab=components`}
-            />
+            <Link {...props} to={`/stonesoup/applications/${applicationName}/components`} />
           )}
           variant="secondary"
         >

--- a/src/components/ApplicationDetails/tabs/overview/visualization/hooks/useAppApplicationTestNodes.ts
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/hooks/useAppApplicationTestNodes.ts
@@ -54,6 +54,7 @@ export const useAppApplicationTestNodes = (
           );
           return resourceToPipelineNode(
             test,
+            applicationName,
             WorkflowNodeType.APPLICATION_TEST,
             previousTasks,
             testPipeline ? pipelineRunStatus(testPipeline) : 'Pending',
@@ -62,6 +63,7 @@ export const useAppApplicationTestNodes = (
       : [
           emptyPipelineNode(
             'no-application-tests',
+            applicationName,
             'No application tests set',
             WorkflowNodeType.APPLICATION_TEST,
             previousTasks,
@@ -69,7 +71,14 @@ export const useAppApplicationTestNodes = (
         ];
     updateParallelNodeWidths(nodes);
     return nodes;
-  }, [allLoaded, applicationIntegrationTests, previousTasks, testPipelines, allErrors]);
+  }, [
+    allLoaded,
+    allErrors.length,
+    applicationIntegrationTests,
+    applicationName,
+    previousTasks,
+    testPipelines,
+  ]);
 
   const applicationIntegrationTestTasks = React.useMemo(
     () => (expanded ? applicationTestNodes.map((c) => c.id) : []),

--- a/src/components/ApplicationDetails/tabs/overview/visualization/hooks/useAppBuildNodes.ts
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/hooks/useAppBuildNodes.ts
@@ -55,17 +55,28 @@ export const useAppBuildNodes = (
   const buildNodes: WorkflowNodeModel<WorkflowNodeModelData>[] = React.useMemo(() => {
     const nodes =
       components.length && latestBuilds.length
-        ? components.map((component) => getBuildNodeForComponent(component, latestBuilds))
-        : [emptyPipelineNode('no-builds', 'No builds yet', WorkflowNodeType.BUILD, previousTasks)];
+        ? components.map((component) =>
+            getBuildNodeForComponent(component, applicationName, latestBuilds),
+          )
+        : [
+            emptyPipelineNode(
+              'no-builds',
+              applicationName,
+              'No builds yet',
+              WorkflowNodeType.BUILD,
+              previousTasks,
+            ),
+          ];
     updateParallelNodeWidths(nodes);
     return nodes;
-  }, [previousTasks, components, latestBuilds]);
+  }, [components, latestBuilds, applicationName, previousTasks]);
 
   const buildGroup = React.useMemo(
     () =>
       allResourcesLoaded
         ? groupToPipelineNode(
             'builds',
+            applicationName,
             latestBuilds?.length ? 'Builds' : 'No builds yet',
             WorkflowNodeType.BUILD,
             previousTasks,
@@ -78,7 +89,15 @@ export const useAppBuildNodes = (
               : worstWorkflowStatus(buildNodes),
           )
         : undefined,
-    [allResourcesLoaded, previousTasks, expanded, buildNodes, latestBuilds, components.length],
+    [
+      allResourcesLoaded,
+      applicationName,
+      latestBuilds,
+      previousTasks,
+      expanded,
+      buildNodes,
+      components.length,
+    ],
   );
 
   const buildTasks = React.useMemo(

--- a/src/components/ApplicationDetails/tabs/overview/visualization/hooks/useAppComponentsNodes.ts
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/hooks/useAppComponentsNodes.ts
@@ -36,6 +36,7 @@ export const useAppComponentsNodes = (
       ? components.map((component) =>
           resourceToPipelineNode(
             component,
+            applicationName,
             WorkflowNodeType.COMPONENT,
             previousTasks,
             getRunStatusComponent(component, buildPipelines),
@@ -44,6 +45,7 @@ export const useAppComponentsNodes = (
       : [
           emptyPipelineNode(
             'no-components',
+            applicationName,
             'No components set',
             WorkflowNodeType.COMPONENT,
             previousTasks,
@@ -51,13 +53,14 @@ export const useAppComponentsNodes = (
         ];
     updateParallelNodeWidths(nodes);
     return nodes;
-  }, [buildPipelines, components, previousTasks]);
+  }, [applicationName, buildPipelines, components, previousTasks]);
 
   const componentGroup: WorkflowNodeModel<WorkflowNodeModelData> = React.useMemo(
     () =>
       allResourcesLoaded && allErrors.length === 0
         ? groupToPipelineNode(
             'components',
+            applicationName,
             components?.length ? 'Components' : 'No components set',
             WorkflowNodeType.COMPONENT,
             previousTasks,
@@ -68,7 +71,15 @@ export const useAppComponentsNodes = (
             worstWorkflowStatus(componentNodes),
           )
         : undefined,
-    [allResourcesLoaded, componentNodes, components, expanded, previousTasks, allErrors],
+    [
+      allResourcesLoaded,
+      allErrors.length,
+      applicationName,
+      components,
+      previousTasks,
+      expanded,
+      componentNodes,
+    ],
   );
 
   const componentTasks = React.useMemo(

--- a/src/components/ApplicationDetails/tabs/overview/visualization/hooks/useAppIntegrationTestNodes.ts
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/hooks/useAppIntegrationTestNodes.ts
@@ -64,6 +64,7 @@ export const useAppIntegrationTestNodes = (
           );
           return resourceToPipelineNode(
             test,
+            applicationName,
             WorkflowNodeType.COMPONENT_TEST,
             previousTasks,
             testPipeline ? pipelineRunStatus(testPipeline) : 'Pending',
@@ -72,6 +73,7 @@ export const useAppIntegrationTestNodes = (
       : [
           emptyPipelineNode(
             'no-component-tests',
+            applicationName,
             'No component tests set',
             WorkflowNodeType.COMPONENT_TEST,
             previousTasks,
@@ -79,7 +81,7 @@ export const useAppIntegrationTestNodes = (
         ];
     updateParallelNodeWidths(nodes);
     return nodes;
-  }, [allLoaded, componentIntegrationTests, previousTasks, testPipelines]);
+  }, [allLoaded, applicationName, componentIntegrationTests, previousTasks, testPipelines]);
 
   const componentIntegrationTestTasks = React.useMemo(
     () => (expanded ? componentTestNodes.map((c) => c.id) : []),

--- a/src/components/ApplicationDetails/tabs/overview/visualization/hooks/useAppReleasePlanNodes.ts
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/hooks/useAppReleasePlanNodes.ts
@@ -42,6 +42,7 @@ export const useAppReleasePlanNodes = (
               : 'no-releases';
             return resourceToPipelineNode(
               releasePlan,
+              applicationName,
               WorkflowNodeType.MANAGED_ENVIRONMENT,
               latestRelease ? [latestRelease.metadata.uid] : [notFoundPrevTask],
               latestRelease ? pipelineRunStatus(latestRelease) : 'Pending',
@@ -50,6 +51,7 @@ export const useAppReleasePlanNodes = (
         : [
             emptyPipelineNode(
               'no-managed-environments',
+              applicationName,
               'No managed environments set',
               WorkflowNodeType.MANAGED_ENVIRONMENT,
               previousTasks,
@@ -57,13 +59,14 @@ export const useAppReleasePlanNodes = (
           ];
     updateParallelNodeWidths(nodes);
     return nodes;
-  }, [allLoaded, releasePlans, previousTasks, releases, allErrors]);
+  }, [allLoaded, releasePlans, allErrors.length, applicationName, previousTasks, releases]);
 
   const releasePlanGroup = React.useMemo(
     () =>
       allLoaded && allErrors.length === 0
         ? groupToPipelineNode(
             'managed-environments',
+            applicationName,
             releasePlans?.length ? 'Managed environments' : 'No managed environments yet',
             WorkflowNodeType.MANAGED_ENVIRONMENT,
             previousTasks,
@@ -74,7 +77,15 @@ export const useAppReleasePlanNodes = (
             worstWorkflowStatus(releasePlanNodes),
           )
         : undefined,
-    [allLoaded, expanded, releasePlanNodes, releasePlans, previousTasks, allErrors],
+    [
+      allLoaded,
+      allErrors.length,
+      applicationName,
+      releasePlans,
+      previousTasks,
+      expanded,
+      releasePlanNodes,
+    ],
   );
 
   return [releasePlanNodes, releasePlanGroup, allLoaded, allErrors];

--- a/src/components/ApplicationDetails/tabs/overview/visualization/hooks/useAppStaticEnvironmentNodes.ts
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/hooks/useAppStaticEnvironmentNodes.ts
@@ -69,6 +69,7 @@ export const useAppStaticEnvironmentNodes = (
 
           return resourceToPipelineNode(
             staticEnvironment,
+            applicationName,
             WorkflowNodeType.STATIC_ENVIRONMENT,
             prevEnv ? [prevEnv.metadata.uid] : previousTasks,
             testPipeline ? pipelineRunStatus(testPipeline) : 'Pending',
@@ -77,6 +78,7 @@ export const useAppStaticEnvironmentNodes = (
       : [
           emptyPipelineNode(
             'no-static-environments',
+            applicationName,
             'No static environments set',
             WorkflowNodeType.STATIC_ENVIRONMENT,
             previousTasks,
@@ -86,6 +88,7 @@ export const useAppStaticEnvironmentNodes = (
     return nodes;
   }, [
     allLoaded,
+    applicationName,
     staticEnvironments,
     previousTasks,
     snapshotsEnvironmentBindings,
@@ -98,6 +101,7 @@ export const useAppStaticEnvironmentNodes = (
       allLoaded && previousTasks?.length && allErrors.length === 0
         ? groupToPipelineNode(
             'static-environments',
+            applicationName,
             staticEnvironments?.length ? 'Static environments' : 'No static environments set',
             WorkflowNodeType.STATIC_ENVIRONMENT,
             previousTasks,
@@ -108,7 +112,15 @@ export const useAppStaticEnvironmentNodes = (
             worstWorkflowStatus(staticEnvironmentNodes),
           )
         : undefined,
-    [allLoaded, previousTasks, expanded, staticEnvironmentNodes, staticEnvironments, allErrors],
+    [
+      allLoaded,
+      previousTasks,
+      allErrors.length,
+      applicationName,
+      staticEnvironments,
+      expanded,
+      staticEnvironmentNodes,
+    ],
   );
 
   const lastStaticEnv = React.useMemo(

--- a/src/components/ApplicationDetails/tabs/overview/visualization/hooks/useAppWorkflowData.ts
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/hooks/useAppWorkflowData.ts
@@ -58,6 +58,7 @@ export const useAppWorkflowData = (
       integrationTestsLoaded && applicationTestsLoaded
         ? groupToPipelineNode(
             'tests',
+            applicationName,
             !applicationIntegrationTests?.length && !applicationIntegrationTests.length
               ? 'No tests set'
               : 'Tests',
@@ -78,14 +79,15 @@ export const useAppWorkflowData = (
     [
       integrationTestsLoaded,
       applicationTestsLoaded,
-      applicationIntegrationTestTasks,
+      applicationName,
       applicationIntegrationTests,
-      applicationIntegrationTestNodes,
       buildTasks,
-      componentIntegrationTestTasks,
-      componentIntegrationTests,
-      componentIntegrationTestNodes,
       expanded,
+      componentIntegrationTestTasks,
+      applicationIntegrationTestTasks,
+      componentIntegrationTestNodes,
+      applicationIntegrationTestNodes,
+      componentIntegrationTests,
     ],
   );
 

--- a/src/components/ApplicationDetails/tabs/overview/visualization/nodes/WorkflowNode.tsx
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/nodes/WorkflowNode.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { Popover } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import { Node, NodeModel, observer, TaskNode, useHover } from '@patternfly/react-topology';
 import { WorkflowNodeModelData } from '../types';
 import { getWorkflowNodeIcon } from '../utils/node-icon-utils';
-import { getLinkForElement, statusToRunStatus } from '../utils/node-utils';
+import { statusToRunStatus, getLinksForElement } from '../utils/node-utils';
 import WorkflowNodeTipContent from './WorkflowNodeTipContent';
 
 import './WorkflowNode.scss';
@@ -15,24 +15,17 @@ type WorkflowNodeProps = {
 };
 
 const WorkflowNode: React.FC<WorkflowNodeProps> = ({ element }) => {
+  const navigate = useNavigate();
   const [tipHover, setTipHover] = React.useState<boolean>(false);
   const [tipVisible, setTipVisible] = React.useState<boolean>(false);
   const [hover, hoverRef] = useHover();
-  const setSearchParams = useSearchParams()[1];
-  const setActiveTab = React.useCallback(
-    (tabData: { tab: string; filter?: { name: string; value: string } }, replace = false) => {
-      const params = new URLSearchParams();
-      params.set('activeTab', tabData.tab);
-      if (tabData.filter) {
-        params.set(tabData.filter.name, tabData.filter.value);
-      }
-      setSearchParams(params, { replace });
-    },
-    [setSearchParams],
-  );
   const { isDisabled, workflowType, status, children, hidden } = element.getData();
-
   const childNodes = children?.filter((n) => !n.data.isDisabled) || [];
+
+  const setActiveTab = React.useCallback(() => {
+    navigate(getLinksForElement(element).elementRef);
+  }, [element, navigate]);
+
   React.useEffect(() => {
     let canceled = false;
     if (tipHover || hover) {
@@ -77,7 +70,7 @@ const WorkflowNode: React.FC<WorkflowNodeProps> = ({ element }) => {
           className={css('workload-node', { 'm-disabled': isDisabled })}
           taskIcon={getWorkflowNodeIcon(workflowType)}
           paddingY={6}
-          onSelect={() => setActiveTab(getLinkForElement(element))}
+          onSelect={setActiveTab}
         />
       </g>
     </Popover>

--- a/src/components/ApplicationDetails/tabs/overview/visualization/nodes/WorkflowNodeTipContent.tsx
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/nodes/WorkflowNodeTipContent.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { css } from '@patternfly/react-styles';
 import pipelineStyles from '@patternfly/react-styles/css/components/Topology/topology-pipelines';
 import {
@@ -11,7 +11,7 @@ import {
   PipelineNodeModel,
 } from '@patternfly/react-topology';
 import { WorkflowNodeModelData, WorkflowNodeType } from '../types';
-import { getLinkForElement, statusToRunStatus, TYPE_DESCRIPTIONS } from '../utils/node-utils';
+import { getLinksForElement, statusToRunStatus, TYPE_DESCRIPTIONS } from '../utils/node-utils';
 
 import './WorkflowNodeTipContent.scss';
 
@@ -21,18 +21,7 @@ type WorkflowNodeTipContentProps = {
 
 const WorkflowNodeTipContent: React.FC<WorkflowNodeTipContentProps> = ({ element }) => {
   const { label, workflowType, children } = element.getData();
-  const { pathname } = useLocation();
-
-  const { elementRef, pipelinesRef } = React.useMemo(() => {
-    const linkData = getLinkForElement(element);
-    const queryParams = `?activeTab=${linkData.tab}${
-      linkData.filter ? `&${linkData.filter.name}=${linkData.filter.value}` : ''
-    }`;
-    return {
-      elementRef: `${pathname}${queryParams}`,
-      pipelinesRef: `${pathname}?activeTab=pipelineruns`,
-    };
-  }, [element, pathname]);
+  const { elementRef, pipelinesRef } = getLinksForElement(element);
 
   const links = React.useMemo(() => {
     switch (workflowType) {
@@ -56,7 +45,7 @@ const WorkflowNodeTipContent: React.FC<WorkflowNodeTipContentProps> = ({ element
       case WorkflowNodeType.APPLICATION_TEST:
         return [
           <Link key="element-link" data-testid="element-link" to={elementRef}>
-            View in tab
+            View details
           </Link>,
           <Link key="pipeline-runs-link" data-testid="pipeline-runs-link" to={pipelinesRef}>
             View pipeline runs

--- a/src/components/ApplicationDetails/tabs/overview/visualization/nodes/__tests__/WorkflowNodeTipContent.spec.tsx
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/nodes/__tests__/WorkflowNodeTipContent.spec.tsx
@@ -28,7 +28,7 @@ import {
 import { componentFactory } from '../../factories';
 import { useAppWorkflowData } from '../../hooks/useAppWorkflowData';
 import { WorkflowNodeModelData } from '../../types';
-import { getLinkForElement, TYPE_DESCRIPTIONS } from '../../utils/node-utils';
+import { getLinkDataForElement, TYPE_DESCRIPTIONS } from '../../utils/node-utils';
 import WorkflowNodeTipContent from '../WorkflowNodeTipContent';
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
@@ -134,7 +134,7 @@ describe('WorkflowNode', () => {
     expect(
       screen.getByText(TYPE_DESCRIPTIONS[mockElement.getData().workflowType]),
     ).toBeInTheDocument();
-    let linkData = getLinkForElement(mockElement);
+    let linkData = getLinkDataForElement(mockElement);
     expect(linkData.tab).toBe('components');
     expect(linkData.filter).toBeUndefined();
     expect(screen.getAllByTestId('child-row')).toHaveLength(mockComponentsData.length);
@@ -158,7 +158,7 @@ describe('WorkflowNode', () => {
     ).toBeInTheDocument();
 
     expect(screen.getByTestId('element-link')).toBeVisible();
-    linkData = getLinkForElement(mockElement);
+    linkData = getLinkDataForElement(mockElement);
     expect(linkData.tab).toBe('integrationtests');
     expect(linkData.filter).toBeUndefined();
 
@@ -179,7 +179,7 @@ describe('WorkflowNode', () => {
     ).toBeInTheDocument();
     const link = screen.getByTestId('element-link');
     expect(link).toBeVisible();
-    const linkData = getLinkForElement(mockElement);
+    const linkData = getLinkDataForElement(mockElement);
     expect(linkData.tab).toBe('components');
     expect(linkData.filter.name).toBe('name');
     expect(linkData.filter.value).toBe(mockElement.getLabel());

--- a/src/components/ApplicationDetails/tabs/overview/visualization/types.ts
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/types.ts
@@ -74,6 +74,7 @@ export type Workflow = {
 };
 
 export type WorkflowNodeModelData = {
+  application?: string;
   label: string;
   workflowType: WorkflowNodeType;
   isDisabled?: boolean;

--- a/src/components/Commits/AppRecentCommits.tsx
+++ b/src/components/Commits/AppRecentCommits.tsx
@@ -76,10 +76,7 @@ const AppRecentCommits = ({ applicationName }) => {
         <EmptyStateSecondaryActions>
           <Button
             component={(props) => (
-              <Link
-                {...props}
-                to={`/stonesoup/applications/${applicationName}?activeTab=components&hacbs=true`}
-              />
+              <Link {...props} to={`/stonesoup/applications/${applicationName}/components`} />
             )}
             variant="secondary"
             data-test="go-to-components-tab"

--- a/src/components/Commits/CommitDetailsView.tsx
+++ b/src/components/Commits/CommitDetailsView.tsx
@@ -192,11 +192,11 @@ const CommitDetailsView: React.FC<CommitDetailsViewProps> = ({ commitName, appli
                   name: applicationName,
                 },
                 {
-                  path: `/stonesoup/applications/${applicationName}?activeTab=commits`,
+                  path: `/stonesoup/applications/${applicationName}/commits`,
                   name: 'commits',
                 },
                 {
-                  path: `/stonesoup/applications/${applicationName}/commit/${commitName}`,
+                  path: `/stonesoup/${applicationName}/commit/${commitName}`,
                   name: commitDisplayName,
                 },
               ]}
@@ -278,6 +278,7 @@ const CommitDetailsView: React.FC<CommitDetailsViewProps> = ({ commitName, appli
                   onClick: () => window.open(commit.shaURL),
                 },
               ]}
+              baseURL={`/stonesoup/${applicationName}/commit/${commitName}`}
               tabs={[
                 {
                   key: 'overview',

--- a/src/components/Commits/CommitsListView.tsx
+++ b/src/components/Commits/CommitsListView.tsx
@@ -118,7 +118,7 @@ const CommitsListView: React.FC<CommitsListViewProps> = ({
         <Button
           className="pf-u-mt-md"
           variant="secondary"
-          onClick={() => navigate(`/stonesoup/applications/${applicationName}?activeTab=commits`)}
+          onClick={() => navigate(`/stonesoup/applications/${applicationName}/commits`)}
         >
           View More
         </Button>

--- a/src/components/Commits/__tests__/CommitDetailsView.spec.tsx
+++ b/src/components/Commits/__tests__/CommitDetailsView.spec.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import '@testing-library/jest-dom';
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { getCommitShortName } from '../../../utils/commits-utils';
+import { routerRenderer } from '../../../utils/test-utils';
 import { pipelineWithCommits } from '../__data__/pipeline-with-commits';
 import CommitDetailsView, { COMMITS_GS_LOCAL_STORAGE_KEY } from '../CommitDetailsView';
 
@@ -14,11 +15,15 @@ jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   useK8sWatchResource: jest.fn(),
 }));
 
-jest.mock('react-router-dom', () => ({
-  Link: (props) => <a href={props.to}>{props.children}</a>,
-  useNavigate: () => {},
-  useSearchParams: () => React.useState(() => new URLSearchParams()),
-}));
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    Link: (props) => <a href={props.to}>{props.children}</a>,
+    useNavigate: () => {},
+    useSearchParams: () => React.useState(() => new URLSearchParams()),
+  };
+});
 
 jest.mock('../../../hooks', () => ({
   useLocalStorage: jest.fn(),
@@ -36,42 +41,42 @@ describe('CommitDetailsView', () => {
 
   it('should render spinner while pipeline data is not loaded', () => {
     watchResourceMock.mockReturnValueOnce([[], false]);
-    render(<CommitDetailsView applicationName="test" commitName="commit123" />);
+    routerRenderer(<CommitDetailsView applicationName="test" commitName="commit123" />);
     screen.getByRole('progressbar');
   });
 
   it('should show plr fetching error if unable to load plrs', () => {
     watchResourceMock.mockReturnValueOnce([[], true, true]);
-    render(<CommitDetailsView applicationName="test" commitName="commit123" />);
+    routerRenderer(<CommitDetailsView applicationName="test" commitName="commit123" />);
     screen.getByText('Could not load PipelineRun');
     screen.getByText('Not found');
   });
 
   it('should show commit not found error if no matching pipelineruns are found ', () => {
     watchResourceMock.mockReturnValueOnce([[], true]);
-    render(<CommitDetailsView applicationName="test" commitName="commit123" />);
+    routerRenderer(<CommitDetailsView applicationName="test" commitName="commit123" />);
     screen.getByText('Commit not found');
     screen.getByText('No such commit');
   });
 
   it('should render proper commit details', () => {
-    render(<CommitDetailsView applicationName="test-application" commitName="commit123" />);
+    routerRenderer(<CommitDetailsView applicationName="test-application" commitName="commit123" />);
     screen.getAllByText(getCommitShortName('commit123'));
   });
 
   it('should show the getting started modal when not dismissed', () => {
-    render(<CommitDetailsView applicationName="test-application" commitName="commit123" />);
+    routerRenderer(<CommitDetailsView applicationName="test-application" commitName="commit123" />);
     expect(screen.getByTestId('getting-started-modal')).toBeVisible();
   });
 
   it('should hide the getting started modal when dismissed', () => {
     localStorage[COMMITS_GS_LOCAL_STORAGE_KEY] = 'true';
-    render(<CommitDetailsView applicationName="test-application" commitName="commit123" />);
+    routerRenderer(<CommitDetailsView applicationName="test-application" commitName="commit123" />);
     expect(screen.queryByTestId('getting-started-modal')).toBeNull();
   });
 
   it('should update local storage when getting started is dismissed', () => {
-    render(<CommitDetailsView applicationName="test-application" commitName="commit123" />);
+    routerRenderer(<CommitDetailsView applicationName="test-application" commitName="commit123" />);
     expect(localStorage[COMMITS_GS_LOCAL_STORAGE_KEY]).toBe(undefined);
     const dismissButton = screen.getByTestId('getting-started-modal-dismiss');
     fireEvent.click(dismissButton);
@@ -81,7 +86,9 @@ describe('CommitDetailsView', () => {
   it('should show the getting started modal when learn more is clicked', async () => {
     localStorage.setItem(COMMITS_GS_LOCAL_STORAGE_KEY, 'true');
     await act(() => {
-      render(<CommitDetailsView applicationName="test-application" commitName="commit123" />);
+      routerRenderer(
+        <CommitDetailsView applicationName="test-application" commitName="commit123" />,
+      );
     });
     expect(screen.queryByTestId('getting-started-modal')).toBeNull();
     const learnMoreButton = screen.getByTestId('commit-overview-learn-more');

--- a/src/components/Commits/tabs/__tests__/CommitsPipelineRunTab.spec.tsx
+++ b/src/components/Commits/tabs/__tests__/CommitsPipelineRunTab.spec.tsx
@@ -31,9 +31,7 @@ describe('Commit Pipelinerun List', () => {
     );
     const button = screen.getByText('Go to components tab');
     expect(button).toBeInTheDocument();
-    expect(button.closest('a').href).toContain(
-      `/stonesoup/applications/${appName}?activeTab=components`,
-    );
+    expect(button.closest('a').href).toContain(`/stonesoup/applications/${appName}/components`);
   });
 
   it('should render pipelineRuns list when pipelineRuns are present', () => {

--- a/src/components/IntegrationTest/IntegrationTestDetailsView.tsx
+++ b/src/components/IntegrationTest/IntegrationTestDetailsView.tsx
@@ -71,11 +71,11 @@ const IntegrationTestDetailsView: React.FC<IntegrationTestDetailsViewProps> = ({
             name: applicationName,
           },
           {
-            path: `/stonesoup/applications/${applicationName}?activeTab=integrationtests`,
+            path: `/stonesoup/applications/${applicationName}/integrationtests`,
             name: 'Integration tests',
           },
           {
-            path: `/stonesoup/applications/${applicationName}/test/${testName}`,
+            path: `/stonesoup/${applicationName}/integrationtests/${testName}`,
             name: integrationTest.metadata.name,
           },
         ]}
@@ -96,12 +96,13 @@ const IntegrationTestDetailsView: React.FC<IntegrationTestDetailsViewProps> = ({
                 integrationTestDeleteModalAndNavigate(integrationTest),
               ).closed.then(({ submitClicked }) => {
                 if (submitClicked)
-                  navigate(`/stonesoup/applications/${applicationName}?activeTab=integrationtests`);
+                  navigate(`/stonesoup/applications/${applicationName}/integrationtests`);
               }),
             key: `delete-${integrationTest.metadata.name.toLowerCase()}`,
             label: 'Delete',
           },
         ]}
+        baseURL={`/stonesoup/${applicationName}/integrationtests/${testName}`}
         tabs={[
           {
             key: 'overview',

--- a/src/components/IntegrationTest/IntegrationTestForm/IntegrationTestForm.tsx
+++ b/src/components/IntegrationTest/IntegrationTestForm/IntegrationTestForm.tsx
@@ -37,7 +37,7 @@ const IntegrationTestForm: React.FunctionComponent<IntegrationTestFormProps> = (
         { path: '/stonesoup/applications', name: 'Applications' },
         { path: `/stonesoup/applications/${applicationName}`, name: applicationName },
         {
-          path: `/stonesoup/applications/${applicationName}?activeTab=integrationtests`,
+          path: `/stonesoup/applications/${applicationName}/integrationtests`,
           name: 'Integration tests',
         },
         { path: '#', name: title },

--- a/src/components/IntegrationTest/IntegrationTestForm/IntegrationTestView.tsx
+++ b/src/components/IntegrationTest/IntegrationTestForm/IntegrationTestView.tsx
@@ -46,7 +46,7 @@ const IntegrationTestView: React.FunctionComponent<IntegrationTestViewProps> = (
             navigate(`/stonesoup/${applicationName}/test/${integrationTest.metadata.name}`);
           }
         } else {
-          navigate(`/stonesoup/applications/${applicationName}?activeTab=integrationtests`);
+          navigate(`/stonesoup/applications/${applicationName}/integrationtests`);
         }
       })
       .catch((error) => {

--- a/src/components/IntegrationTest/IntegrationTestForm/__tests__/IntegrationTestView.spec.tsx
+++ b/src/components/IntegrationTest/IntegrationTestForm/__tests__/IntegrationTestView.spec.tsx
@@ -91,7 +91,7 @@ describe('IntegrationTestView', () => {
     await waitFor(() => expect(createIntegrationTestMock).toHaveBeenCalledTimes(1));
     await waitFor(() =>
       expect(navigateMock).toHaveBeenCalledWith(
-        '/stonesoup/applications/test-app?activeTab=integrationtests',
+        '/stonesoup/applications/test-app/integrationtests',
       ),
     );
   });

--- a/src/components/IntegrationTest/IntegrationTestsListView/IntegrationTestListRow.tsx
+++ b/src/components/IntegrationTest/IntegrationTestsListView/IntegrationTestListRow.tsx
@@ -19,7 +19,7 @@ const IntegrationTestListRow: React.FC<RowFunctionArgs<IntegrationTestScenarioKi
         className={integrationListTableColumnClasses.name}
         data-test="integration-tests__row-name"
       >
-        <Link to={`/stonesoup/${obj.spec.application}/test/${obj.metadata.name}`}>
+        <Link to={`/stonesoup/${obj.spec.application}/integrationtests/${obj.metadata.name}`}>
           {obj.metadata.name}
         </Link>
       </TableData>

--- a/src/components/PipelineRunDetailsView/PipelineRunDetailsView.tsx
+++ b/src/components/PipelineRunDetailsView/PipelineRunDetailsView.tsx
@@ -55,11 +55,11 @@ export const PipelineRunDetailsView: React.FC<PipelineRunDetailsViewProps> = ({
               name: applicationName,
             },
             {
-              path: `/stonesoup/applications/${applicationName}?activeTab=pipelineruns`,
+              path: `/stonesoup/applications/${applicationName}/pipelineruns`,
               name: 'Pipeline runs',
             },
             {
-              path: `/stonesoup/applications/${pipelineRunName}`,
+              path: `/stonesoup/pipelineruns/${pipelineRunName}`,
               name: pipelineRunName,
             },
           ]}
@@ -93,6 +93,7 @@ export const PipelineRunDetailsView: React.FC<PipelineRunDetailsViewProps> = ({
               onClick: () => pipelineRunCancel(pipelineRun),
             },
           ]}
+          baseURL={`/stonesoup/pipelineruns/${pipelineRunName}`}
           tabs={[
             {
               key: 'detail',

--- a/src/components/PipelineRunDetailsView/PipelineRunEmptyState.tsx
+++ b/src/components/PipelineRunDetailsView/PipelineRunEmptyState.tsx
@@ -29,10 +29,7 @@ const PipelineRunEmptyState: React.FC<PipelineRunEmptyStateProps> = ({ applicati
       <EmptyStateSecondaryActions>
         <Button
           component={(props) => (
-            <Link
-              {...props}
-              to={`/stonesoup/applications/${applicationName}?activeTab=components`}
-            />
+            <Link {...props} to={`/stonesoup/applications/${applicationName}/components`} />
           )}
           variant="secondary"
         >

--- a/src/components/PipelineRunDetailsView/__tests__/PipelineRunDetailsView.spec.tsx
+++ b/src/components/PipelineRunDetailsView/__tests__/PipelineRunDetailsView.spec.tsx
@@ -2,8 +2,9 @@ import * as React from 'react';
 import '@testing-library/jest-dom';
 import { useNavigate } from 'react-router-dom';
 import { useK8sWatchResource, k8sCreateResource } from '@openshift/dynamic-plugin-sdk-utils';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { DataState, testPipelineRuns } from '../../../__data__/pipelinerun-data';
+import { routerRenderer } from '../../../utils/test-utils';
 import { PipelineRunDetailsView } from '../PipelineRunDetailsView';
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
@@ -13,11 +14,15 @@ jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
 
 jest.mock('../../PipelineRunDetailsView/PipelineRunVisualization', () => () => <div />);
 
-jest.mock('react-router-dom', () => ({
-  Link: (props) => <a href={props.to}>{props.children}</a>,
-  useNavigate: jest.fn(),
-  useSearchParams: () => React.useState(() => new URLSearchParams()),
-}));
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    Link: (props) => <a href={props.to}>{props.children}</a>,
+    useNavigate: jest.fn(),
+    useSearchParams: () => React.useState(() => new URLSearchParams()),
+  };
+});
 
 const watchResourceMock = useK8sWatchResource as jest.Mock;
 const useNavigateMock = useNavigate as jest.Mock;
@@ -111,19 +116,19 @@ const mockApplication = {
 describe('PipelineRunDetailsView', () => {
   it('should render spinner if pipelinerun data is not loaded', () => {
     watchResourceMock.mockReturnValue([[], false]);
-    render(<PipelineRunDetailsView pipelineRunName={pipelineRunName} />);
+    routerRenderer(<PipelineRunDetailsView pipelineRunName={pipelineRunName} />);
     screen.getByRole('progressbar');
   });
 
   it('should render application display name if application data is loaded', () => {
     watchResourceMock.mockReturnValueOnce([mockApplication, true]).mockReturnValue([[], true]);
-    render(<PipelineRunDetailsView pipelineRunName={pipelineRunName} />);
+    routerRenderer(<PipelineRunDetailsView pipelineRunName={pipelineRunName} />);
     screen.getAllByText(pipelineRunName);
   });
 
   it('should render application if components data is loaded', () => {
     watchResourceMock.mockReturnValueOnce([mockApplication, true]).mockReturnValue([[], true]);
-    render(<PipelineRunDetailsView pipelineRunName={pipelineRunName} />);
+    routerRenderer(<PipelineRunDetailsView pipelineRunName={pipelineRunName} />);
     expect(screen.queryByText('Pipeline run details')).toBeInTheDocument();
     expect(screen.queryByText('Status')).toBeInTheDocument();
     expect(screen.queryByText('Namespace')).toBeInTheDocument();
@@ -134,7 +139,7 @@ describe('PipelineRunDetailsView', () => {
       .mockReturnValueOnce([testPipelineRuns[DataState.SUCCEEDED], true])
       .mockReturnValue([[], true]);
 
-    render(<PipelineRunDetailsView pipelineRunName={pipelineRunName} />);
+    routerRenderer(<PipelineRunDetailsView pipelineRunName={pipelineRunName} />);
 
     const actionsDropdown = screen.queryByRole('button', { name: 'Actions' });
     expect(actionsDropdown).toBeInTheDocument();
@@ -149,7 +154,7 @@ describe('PipelineRunDetailsView', () => {
     watchResourceMock
       .mockReturnValueOnce([testPipelineRuns[DataState.RUNNING], true])
       .mockReturnValue([[], true]);
-    render(<PipelineRunDetailsView pipelineRunName={pipelineRunName} />);
+    routerRenderer(<PipelineRunDetailsView pipelineRunName={pipelineRunName} />);
 
     fireEvent.click(screen.queryByRole('button', { name: 'Actions' }));
 
@@ -162,7 +167,7 @@ describe('PipelineRunDetailsView', () => {
       .mockReturnValueOnce([testPipelineRuns[DataState.SUCCEEDED], true])
       .mockReturnValue([[], true]);
 
-    render(<PipelineRunDetailsView pipelineRunName={pipelineRunName} />);
+    routerRenderer(<PipelineRunDetailsView pipelineRunName={pipelineRunName} />);
     fireEvent.click(screen.queryByRole('button', { name: 'Actions' }));
 
     expect(screen.queryByText('Stop')).toHaveAttribute('aria-disabled', 'true');
@@ -174,7 +179,7 @@ describe('PipelineRunDetailsView', () => {
       .mockReturnValueOnce([testPipelineRuns[DataState.PIPELINE_RUN_CANCELLED], true])
       .mockReturnValue([[], true]);
 
-    render(<PipelineRunDetailsView pipelineRunName={pipelineRunName} />);
+    routerRenderer(<PipelineRunDetailsView pipelineRunName={pipelineRunName} />);
     fireEvent.click(screen.queryByRole('button', { name: 'Actions' }));
 
     expect(screen.queryByText('Stop')).toHaveAttribute('aria-disabled', 'true');
@@ -186,7 +191,7 @@ describe('PipelineRunDetailsView', () => {
       .mockReturnValueOnce([testPipelineRuns[DataState.PIPELINE_RUN_STOPPED], true])
       .mockReturnValue([[], true]);
 
-    render(<PipelineRunDetailsView pipelineRunName={pipelineRunName} />);
+    routerRenderer(<PipelineRunDetailsView pipelineRunName={pipelineRunName} />);
     fireEvent.click(screen.queryByRole('button', { name: 'Actions' }));
 
     expect(screen.queryByText('Stop')).toHaveAttribute('aria-disabled', 'true');
@@ -205,7 +210,7 @@ describe('PipelineRunDetailsView', () => {
       .mockReturnValueOnce([testPipelineRuns[DataState.RUNNING], true])
       .mockReturnValue([[], true]);
 
-    render(<PipelineRunDetailsView pipelineRunName={pipelineRunName} />);
+    routerRenderer(<PipelineRunDetailsView pipelineRunName={pipelineRunName} />);
     fireEvent.click(screen.queryByRole('button', { name: 'Actions' }));
 
     expect(screen.queryByText('Rerun')).toHaveAttribute('aria-disabled', 'false');

--- a/src/components/PipelineRunDetailsView/__tests__/PipelineRunEmptyState.spec.tsx
+++ b/src/components/PipelineRunDetailsView/__tests__/PipelineRunEmptyState.spec.tsx
@@ -10,7 +10,7 @@ describe('PipelineRunEmptyState', () => {
   it('should render correct Link to Application Name', () => {
     render(<PipelineRunEmptyState applicationName="test" />);
     expect(screen.getByRole('link').getAttribute('href')).toBe(
-      '/stonesoup/applications/test?activeTab=components',
+      '/stonesoup/applications/test/components',
     );
     screen.getByText('Go to components tab');
   });

--- a/src/components/PipelineRunListView/__tests__/PipelineRunListView.spec.tsx
+++ b/src/components/PipelineRunListView/__tests__/PipelineRunListView.spec.tsx
@@ -109,9 +109,7 @@ describe('Pipeline run List', () => {
     );
     const button = screen.getByText('Go to components tab');
     expect(button).toBeInTheDocument();
-    expect(button.closest('a').href).toContain(
-      `/stonesoup/applications/${appName}?activeTab=components`,
-    );
+    expect(button.closest('a').href).toContain(`/stonesoup/applications/${appName}/components`);
   });
 
   it('should render pipelineRuns list when pipelineRuns are present', () => {


### PR DESCRIPTION
## Fixes 
[HAC-2571](https://issues.redhat.com/browse/HAC-2571)

## Description
Use URL path params rather that search params for tabs in details pages.

## Type of change
- [x] Feature

