### PR TITLE
Follow CR name requirements for application input field

### DIFF
--- a/integration-tests/support/pages/CreateApplicationPage.ts
+++ b/integration-tests/support/pages/CreateApplicationPage.ts
@@ -9,6 +9,7 @@ export class CreateApplicationPage extends AbstractWizardPage {
   }
 
   setApplicationName(name: string) {
+    cy.wait(500);
     this.clearApplicationName();
     cy.get(createApplicationPagePO.applicationName).type(name);
   }

--- a/src/components/ImportForm/ApplicationSection/ApplicationSection.tsx
+++ b/src/components/ImportForm/ApplicationSection/ApplicationSection.tsx
@@ -1,9 +1,26 @@
 import * as React from 'react';
 import { TextContent, Text, HelperText, FormSection } from '@patternfly/react-core';
+import { useField } from 'formik';
 import { InputField } from '../../../shared';
 import { HeadTitle } from '../../HeadTitle';
+import { useValidApplicationName } from '../utils/useValidApplicationName';
 
 const ApplicationSection: React.FunctionComponent = () => {
+  const [validName] = useValidApplicationName();
+  const [, { value, touched }, { setValue, setTouched }] = useField<string>('application');
+
+  React.useEffect(() => {
+    if (!value && !touched && validName) {
+      setValue(validName);
+    }
+  }, [setValue, touched, validName, value]);
+
+  React.useEffect(() => {
+    if (value && !touched) {
+      setTouched(true, false);
+    }
+  }, [setTouched, touched, value]);
+
   return (
     <>
       <HeadTitle>Import - Name application | CI/CD</HeadTitle>
@@ -12,12 +29,7 @@ const ApplicationSection: React.FunctionComponent = () => {
         <HelperText>Enter a name for your application.</HelperText>
       </TextContent>
       <FormSection>
-        <InputField
-          name="application"
-          label="Application name"
-          placeholder="My Application"
-          required
-        />
+        <InputField name="application" label="Name" placeholder="Enter name" required />
       </FormSection>
     </>
   );

--- a/src/components/ImportForm/ApplicationSection/__tests__/ApplicationSection.spec.tsx
+++ b/src/components/ImportForm/ApplicationSection/__tests__/ApplicationSection.spec.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { useField } from 'formik';
+import { useValidApplicationName } from '../../utils/useValidApplicationName';
+import ApplicationSection from '../ApplicationSection';
+
+jest.mock('../../utils/useValidApplicationName', () => ({
+  useValidApplicationName: jest.fn(),
+}));
+
+jest.mock('formik', () => ({
+  useField: jest.fn(),
+}));
+
+const useFieldMock = useField as jest.Mock;
+const useValidAppNameMock = useValidApplicationName as jest.Mock;
+
+describe('ApplicationSection', () => {
+  it('should set input field if it is not touched', () => {
+    const setValue = jest.fn();
+    const setTouched = jest.fn();
+    useFieldMock.mockReturnValue([{}, { value: '', touched: false }, { setValue, setTouched }]);
+    useValidAppNameMock.mockReturnValue(['my-first-app', true]);
+    render(<ApplicationSection />);
+    expect(setValue).toHaveBeenCalledWith('my-first-app');
+  });
+
+  it('should not set input field if it is touched', () => {
+    const setValue = jest.fn();
+    const setTouched = jest.fn();
+    useFieldMock.mockReturnValue([
+      {},
+      { value: 'my-app', touched: true },
+      { setValue, setTouched },
+    ]);
+    useValidAppNameMock.mockReturnValue(['my-first-app', true]);
+    render(<ApplicationSection />);
+    expect(setValue).not.toHaveBeenCalled();
+    expect(setTouched).not.toHaveBeenCalled();
+  });
+
+  it('should not set field if valid name is not fetched', () => {
+    const setValue = jest.fn();
+    const setTouched = jest.fn();
+    useFieldMock.mockReturnValue([{}, { value: '', touched: false }, { setValue, setTouched }]);
+    useValidAppNameMock.mockReturnValue([null, false]);
+    render(<ApplicationSection />);
+    expect(setValue).not.toHaveBeenCalled();
+    expect(setTouched).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ImportForm/utils/__tests__/useValidApplicationName.spec.ts
+++ b/src/components/ImportForm/utils/__tests__/useValidApplicationName.spec.ts
@@ -1,0 +1,24 @@
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { renderHook } from '@testing-library/react-hooks';
+import { useValidApplicationName } from '../useValidApplicationName';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  useK8sWatchResource: jest.fn(),
+  k8sCreateResource: jest.fn(),
+}));
+
+const watchResourceMock = useK8sWatchResource as jest.Mock;
+
+const testAppData = [
+  { metadata: { name: 'my-app' } },
+  { metadata: { name: 'my-app-1' } },
+  { metadata: { name: 'my-app-2' } },
+];
+
+describe('useValidApplicationName', () => {
+  it('returns next available incremented name', () => {
+    watchResourceMock.mockReturnValue([testAppData, true]);
+    const { result } = renderHook(() => useValidApplicationName());
+    expect(result.current[0]).toBe('my-app-3');
+  });
+});

--- a/src/components/ImportForm/utils/__tests__/validation-utils.spec.ts
+++ b/src/components/ImportForm/utils/__tests__/validation-utils.spec.ts
@@ -1,4 +1,8 @@
-import { containerImageRegex, reviewValidationSchema } from '../validation-utils';
+import {
+  containerImageRegex,
+  resourceNameRegex,
+  reviewValidationSchema,
+} from '../validation-utils';
 
 describe('Review form validation schema', () => {
   it('should fail when component name is missing', async () => {
@@ -98,5 +102,19 @@ describe('containerImageRegex', () => {
   it('should not validate a non-quay container image url', () => {
     expect('https://docker.io/example/repo').not.toMatch(containerImageRegex);
     expect('quay.com/example/repo').not.toMatch(containerImageRegex);
+  });
+});
+
+describe('resourceNameRegex', () => {
+  it('should not allow names starting with number', () => {
+    ['1test-name', '123resource'].forEach((str) => {
+      expect(str).not.toMatch(resourceNameRegex);
+    });
+  });
+
+  it('should not allow special characters', () => {
+    ['resource-@$*-name', 'test-namé'].forEach((str) => {
+      expect(str).not.toMatch(resourceNameRegex);
+    });
   });
 });

--- a/src/components/ImportForm/utils/useValidApplicationName.ts
+++ b/src/components/ImportForm/utils/useValidApplicationName.ts
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { ApplicationGroupVersionKind } from '../../../models';
+import { ApplicationKind } from '../../../types';
+import { useNamespace } from '../../../utils/namespace-context-utils';
+
+const BASE_NAME = 'my-app';
+
+export const useValidApplicationName = (): [string, boolean, unknown] => {
+  const namespace = useNamespace();
+
+  const [applications, loaded, loadErr] = useK8sWatchResource<ApplicationKind[]>({
+    groupVersionKind: ApplicationGroupVersionKind,
+    namespace,
+    isList: true,
+  });
+
+  const validName = React.useMemo(() => {
+    if (!loaded) {
+      return;
+    }
+    let name = BASE_NAME,
+      i = 1;
+    while (applications.some((app) => app.metadata.name === name)) {
+      name = `${BASE_NAME}-${i}`;
+      i++;
+    }
+    return name;
+  }, [applications, loaded]);
+
+  return [validName, loaded, loadErr];
+};

--- a/src/components/ImportForm/utils/validation-utils.ts
+++ b/src/components/ImportForm/utils/validation-utils.ts
@@ -6,7 +6,7 @@ export const gitUrlRegex =
 // generic regex to validate container image /^[^/]+\.[^/.]+\/([a-z0-9-_]+\/)?[^/.]+(:.+)?$/
 export const containerImageRegex = /^(https:\/\/)?quay.io\/([a-z0-9-_]+\/)?[^/.]+(:.+)?$/;
 
-export const componentNameRegex = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+export const resourceNameRegex = /^[a-z]([-a-z0-9]*[a-z0-9])?$/;
 
 const combineRegExps = (...regexps: RegExp[]) => {
   const regexStringsWithoutFlags = regexps.map((regex) => regex.source);
@@ -14,7 +14,10 @@ const combineRegExps = (...regexps: RegExp[]) => {
 };
 
 export const applicationValidationSchema = yup.object({
-  application: yup.string().required('Required'),
+  application: yup
+    .string()
+    .matches(resourceNameRegex, 'Name cannot contain spaces, uppercase or special characters.')
+    .required('Required'),
 });
 
 const createSourceValidationSchema = (containerImageSupport: boolean) =>
@@ -54,7 +57,7 @@ export const reviewValidationSchema = yup.object({
       componentStub: yup.object({
         componentName: yup
           .string()
-          .matches(componentNameRegex, 'Invalid component name')
+          .matches(resourceNameRegex, 'Invalid component name')
           .required('Required'),
         targetPort: yup
           .number()

--- a/src/utils/__tests__/create-utils.spec.ts
+++ b/src/utils/__tests__/create-utils.spec.ts
@@ -30,7 +30,7 @@ const mockApplicationRequestData = {
     namespace: 'test-ns',
   },
   spec: {
-    displayName: 'Test Application',
+    displayName: 'test-application',
   },
 };
 
@@ -142,7 +142,7 @@ const mockAccessTokenBinding: SPIAccessTokenBindingKind = {
 
 describe('Create Utils', () => {
   it('Should call k8s create util with correct model and data for application', async () => {
-    await createApplication('Test Application', 'test-ns');
+    await createApplication('test-application', 'test-ns');
 
     expect(k8sCreateResource).toHaveBeenCalledWith({
       model: ApplicationModel,

--- a/src/utils/create-utils.ts
+++ b/src/utils/create-utils.ts
@@ -35,12 +35,11 @@ export const createApplication = (
   namespace: string,
   dryRun?: boolean,
 ): Promise<ApplicationKind> => {
-  const name = sanitizeName(application);
   const requestData = {
     apiVersion: `${ApplicationModel.apiGroup}/${ApplicationModel.apiVersion}`,
     kind: ApplicationModel.kind,
     metadata: {
-      name,
+      name: application,
       namespace,
     },
     spec: {
@@ -51,7 +50,7 @@ export const createApplication = (
   return k8sCreateResource({
     model: ApplicationModel,
     queryOptions: {
-      name,
+      name: application,
       ns: namespace,
       ...(dryRun && { queryParams: { dryRun: 'All' } }),
     },


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-2353
https://issues.redhat.com/browse/HAC-3048
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
- Use CR name for field instead of displayName
- Change field label to "Name"
- Change placeholder to "my-first-app" and increment suffix if name is already used
- Show Inline errors for incorrect name format
- Use RFC compliant regex for resource name fields
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

https://user-images.githubusercontent.com/20013884/216340465-687b8791-050d-4a68-889a-e281a33c618c.mp4

<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
Create applications from import form.
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
