### PR TITLE
fix merge build pr status in component list view

### DIFF
--- a/src/components/Components/BuildStatusColumn.tsx
+++ b/src/components/Components/BuildStatusColumn.tsx
@@ -52,7 +52,7 @@ const BuildStatusColumn: React.FC<BuildStatusComponentProps> = ({ component, all
   });
 
   const merged = pipelineRunsLoaded && pipelineBuildRuns.length;
-  const hasPAC = hasPACAnnotation(component);
+  const hasPAC = pipelineRunsLoaded && hasPACAnnotation(component);
   const openPRsURL = getURLForComponentPRs(allComponents);
 
   return merged || !hasPAC ? (

--- a/src/components/Components/__tests__/BuildStatusColumn.spec.tsx
+++ b/src/components/Components/__tests__/BuildStatusColumn.spec.tsx
@@ -36,6 +36,17 @@ describe('BuildStatusColumn', () => {
     await waitFor(() => screen.getByText('Build Failed'));
     await waitFor(() => screen.getByText('View logs'));
   });
+
+  it('should not render merge status if the pipelineruns is still loading', async () => {
+    useK8sWatchResourceMock.mockReturnValue([[], false]);
+    render(
+      <BrowserRouter>
+        <BuildStatusColumn component={componentCRMocks[1]} allComponents={componentCRMocks} />
+      </BrowserRouter>,
+    );
+    expect(screen.queryByText('Merge build PR')).not.toBeInTheDocument();
+  });
+
   it('should render needs merge status', async () => {
     useK8sWatchResourceMock.mockReturnValue([[], true]);
     render(
@@ -45,8 +56,19 @@ describe('BuildStatusColumn', () => {
     );
     await waitFor(() => screen.getByText('Merge build PR'));
   });
-  it('should render View Build logs action item for components without PAC annotation', async () => {
+
+  it('should not render View Build logs action item for components without build pipelinerun', async () => {
     useK8sWatchResourceMock.mockReturnValue([[], true]);
+    render(
+      <BrowserRouter>
+        <BuildStatusColumn component={componentCRMocks[0]} allComponents={componentCRMocks} />
+      </BrowserRouter>,
+    );
+    expect(screen.queryByText('View logs')).not.toBeInTheDocument();
+  });
+
+  it('should render View Build logs action item for components without PAC annotation', async () => {
+    useK8sWatchResourceMock.mockReturnValue([[mockPipelineRuns], true]);
     render(
       <BrowserRouter>
         <BuildStatusColumn component={componentCRMocks[0]} allComponents={componentCRMocks} />

--- a/src/components/ComponentsListView/BuildStatusColumn.tsx
+++ b/src/components/ComponentsListView/BuildStatusColumn.tsx
@@ -24,7 +24,7 @@ const BuildStatusColumn: React.FC<BuildStatusColumnProps> = ({ component }) => {
             {getBuildStatusIcon(status)} Build {status}
           </FlexItem>
         )}
-        {!isContainerImage && (
+        {pipelineRun && !isContainerImage && (
           <FlexItem align={{ default: 'alignRight' }}>
             <Button
               onClick={buildLogsModal}


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-2845

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

In components list view, `Merge build PR`  and followed by `view logs` status is shown before the actual component status.

**Solution:**

 Wait for pipeline runs call to resolve before showing any status.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


https://user-images.githubusercontent.com/9964343/211794262-daf6cbcd-cd43-46e7-a698-848d977f9182.mov


## Unit test

```
  BuildStatusColumn
    ✓ should not render merge status if the pipelineruns is still loading (5 ms)
    ✓ should not render View Build logs action item for components without build pipelinerun (4 ms)

```

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
