### PR TITLE
Fix skipped task icon in pipelinerun visualization

### DIFF
--- a/src/components/PipelineRunDetailsView/visualization/utils/__tests__/pipelinerun-graph-utils.spec.ts
+++ b/src/components/PipelineRunDetailsView/visualization/utils/__tests__/pipelinerun-graph-utils.spec.ts
@@ -128,6 +128,15 @@ describe('pipelinerun-graph-utils: ', () => {
       expect(taskList.filter((t) => t.status.reason === RunStatus.Skipped)).toHaveLength(2);
     });
 
+    it('should append Skipped status for the tasks without status/reason but marked as skipped in pipelinerun status', () => {
+      const plrwithoutSkippedStatus = testPipelineRuns[DataState.SKIPPED];
+      const taskList = appendStatus(
+        getPipelineFromPipelineRun(plrwithoutSkippedStatus),
+        plrwithoutSkippedStatus,
+      );
+      expect(taskList.filter((t) => t.status.reason === RunStatus.Skipped)).toHaveLength(1);
+    });
+
     it('should append Idle status if the taskruns are missing and overall pipelinerun status is PipelineRunPending', () => {
       const pendingPipelineRun: PipelineRunKind = {
         ...testPipelineRun,

--- a/src/components/PipelineRunDetailsView/visualization/utils/pipelinerun-graph-utils.ts
+++ b/src/components/PipelineRunDetailsView/visualization/utils/pipelinerun-graph-utils.ts
@@ -107,7 +107,12 @@ export const appendStatus = (
     }
     // append task status
     if (!mTask.status) {
-      mTask.status = { reason: RunStatus.Idle };
+      const isSkipped = !!pipelineRun.status.skippedTasks?.find((t) => t.name === task.name);
+      if (isSkipped) {
+        mTask.status = { reason: RunStatus.Skipped };
+      } else {
+        mTask.status = { reason: RunStatus.Idle };
+      }
     } else if (mTask.status && mTask.status.conditions) {
       mTask.status.reason = pipelineRunStatus(mTask) || RunStatus.Idle;
     } else if (mTask.status && !mTask.status.reason) {


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-2864

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

If When expression is not met, then the task will be skipped and collected in `pipelinerun.status.skippedTasks` but we were checking based on the task status (non-existent in this case) and marked those tasks as Idle.

**Solution:**

Finding skipped tasks in `pipelinerun.status.skippedTasks` and marking it as skipped to get the right icon.


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

**Before:** 

<img width="1458" alt="image" src="https://user-images.githubusercontent.com/9964343/212011222-21024da0-765f-4efd-b9e2-5d3c1992e2ae.png">

**After:**
<img width="1472" alt="image" src="https://user-images.githubusercontent.com/9964343/212011119-75899485-7af6-4cc7-a349-8a490fc55fc5.png">

## Unit tests

```
  appendStatus
      ✓ should append Skipped status for the tasks without status/reason but marked as skippedTasks in pipelinerun status
```

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

1. Cancel the running pipeline, which should mark all the remaining tasks as Skipped tasks.

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->


cc: @christianvogt 