### PR TITLE
Use PF pipelines statusIcon component for icon consistency in plr logs and graph

### DIFF
--- a/src/components/PipelineRunDetailsView/visualization/utils/pipelinerun-graph-utils.ts
+++ b/src/components/PipelineRunDetailsView/visualization/utils/pipelinerun-graph-utils.ts
@@ -109,9 +109,9 @@ export const appendStatus = (
     if (!mTask.status) {
       mTask.status = { reason: RunStatus.Idle };
     } else if (mTask.status && mTask.status.conditions) {
-      mTask.status.reason = pipelineRunStatus(mTask) || RunStatus.Idle;
+      mTask.status.reason = pipelineRunStatus(mTask) || RunStatus.Pending;
     } else if (mTask.status && !mTask.status.reason) {
-      mTask.status.reason = RunStatus.Idle;
+      mTask.status.reason = RunStatus.Pending;
     }
     return mTask;
   });

--- a/src/shared/components/pipeline-run-logs/StatusIcon.scss
+++ b/src/shared/components/pipeline-run-logs/StatusIcon.scss
@@ -1,0 +1,7 @@
+.status-icon.pf-m-spin svg {
+    filter: blur(0);
+    -webkit-filter: blur(0);
+    transform-box: fill-box;
+    transform-origin: center;
+    animation: status-spin 2s infinite linear;
+}

--- a/src/shared/components/pipeline-run-logs/StatusIcon.tsx
+++ b/src/shared/components/pipeline-run-logs/StatusIcon.tsx
@@ -8,7 +8,7 @@ import {
   RunStatus,
   StatusIcon as PfStatusIcon,
 } from '@patternfly/react-topology';
-import { runStatus } from './utils';
+import { getLabelColorFromStatus, runStatus } from './utils';
 
 import './StatusIcon.scss';
 
@@ -55,7 +55,7 @@ export const StatusIconWithText: React.FC<
   StatusIconProps & { text?: string; dataTestAttribute?: string }
 > = ({ status, text, dataTestAttribute, ...others }) => {
   return (
-    <Label>
+    <Label color={getLabelColorFromStatus(status)}>
       <span
         className={css(
           'pf-u-mr-xs',

--- a/src/shared/components/pipeline-run-logs/StatusIcon.tsx
+++ b/src/shared/components/pipeline-run-logs/StatusIcon.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react';
 import { Label } from '@patternfly/react-core';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/js/icons';
+import { css } from '@patternfly/react-styles';
+import pipelineStyles from '@patternfly/react-styles/css/components/Topology/topology-pipelines';
 import {
-  AngleDoubleRightIcon,
-  BanIcon,
-  CheckCircleIcon,
-  CircleIcon,
-  ExclamationCircleIcon,
-  HourglassHalfIcon,
-  SyncAltIcon,
-} from '@patternfly/react-icons/dist/js/icons';
-import cx from 'classnames';
-import { getRunStatusColor, runStatus } from './utils';
+  getRunStatusModifier,
+  RunStatus,
+  StatusIcon as PfStatusIcon,
+} from '@patternfly/react-topology';
+import { runStatus } from './utils';
+
+import './StatusIcon.scss';
 
 type StatusIconProps = {
   status: string;
@@ -19,42 +19,32 @@ type StatusIconProps = {
   disableSpin?: boolean;
 };
 
-export const StatusIcon: React.FC<StatusIconProps> = ({ status, disableSpin, ...props }) => {
-  switch (status) {
-    case runStatus['In Progress']:
-    case runStatus.Running:
-      return <SyncAltIcon {...props} className={cx({ 'fa-spin': !disableSpin })} />;
-
-    case runStatus.Succeeded:
-      return <CheckCircleIcon {...props} />;
-
-    case runStatus.Failed:
-      return <ExclamationCircleIcon {...props} />;
-
-    case runStatus.Idle:
-    case runStatus.Pending:
-      return <HourglassHalfIcon {...props} />;
-
-    case runStatus.Cancelling:
-    case runStatus.Cancelled:
-      return <BanIcon {...props} />;
-
-    case runStatus.Skipped:
-      return <AngleDoubleRightIcon {...props} />;
-
-    default:
-      return <CircleIcon {...props} />;
+export const StatusIcon: React.FC<StatusIconProps> = ({ status, ...props }) => {
+  if (status === runStatus.Cancelling) {
+    // Interim state required to avoid any other actions on pipelinerun that is currently being cancelled.
+    return (
+      <div
+        className={css(
+          pipelineStyles.topologyPipelinesStatusIcon,
+          getRunStatusModifier(RunStatus.Cancelled),
+        )}
+      >
+        <ExclamationTriangleIcon {...props} />
+      </div>
+    );
   }
+  return <PfStatusIcon status={status as RunStatus} {...props} />;
 };
 
 export const ColoredStatusIcon: React.FC<StatusIconProps> = ({ status, ...others }) => {
   return (
     <div
-      style={{
-        color: status
-          ? getRunStatusColor(status).pftoken.value
-          : getRunStatusColor(runStatus.Cancelled).pftoken.value,
-      }}
+      className={css(
+        'status-icon',
+        pipelineStyles.topologyPipelinesStatusIcon,
+        (status === RunStatus.Running || status === RunStatus.InProgress) && 'pf-m-spin',
+        getRunStatusModifier(status as RunStatus),
+      )}
     >
       <StatusIcon status={status} {...others} />
     </div>
@@ -67,15 +57,15 @@ export const StatusIconWithText: React.FC<
   return (
     <Label>
       <span
-        className="pf-u-mr-xs"
-        style={{
-          color: status
-            ? getRunStatusColor(status).labelColor
-            : getRunStatusColor(runStatus.Cancelled).pftoken.value,
-        }}
+        className={css(
+          'pf-u-mr-xs',
+          pipelineStyles.topologyPipelinesPillStatus,
+          (status === RunStatus.Running || status === RunStatus.InProgress) && 'pf-m-spin',
+          getRunStatusModifier(status as RunStatus),
+        )}
       >
         <StatusIcon status={status} {...others} />
-      </span>{' '}
+      </span>
       <span data-test={dataTestAttribute}>{text ?? status}</span>
     </Label>
   );

--- a/src/shared/components/pipeline-run-logs/__tests__/utils.spec.ts
+++ b/src/shared/components/pipeline-run-logs/__tests__/utils.spec.ts
@@ -15,9 +15,14 @@ import {
 
 describe('pipelineRunStatus', () => {
   it('should return null if an invalid pipelineruns', () => {
-    expect(pipelineRunStatus(testPipelineRuns[DataState.STATUS_WITHOUT_CONDITIONS])).toBeNull();
-    expect(pipelineRunStatus(testPipelineRuns[DataState.STATUS_WITH_EMPTY_CONDITIONS])).toBeNull();
     expect(pipelineRunStatus(testPipelineRuns[DataState.STATUS_WITHOUT_CONDITION_TYPE])).toBeNull();
+    expect(pipelineRunStatus(testPipelineRuns[DataState.STATUS_WITH_EMPTY_CONDITIONS])).toBeNull();
+  });
+
+  it('should return Pending status for pipelineruns with status but no conditions', () => {
+    expect(pipelineRunStatus(testPipelineRuns[DataState.STATUS_WITHOUT_CONDITIONS])).toBe(
+      'Pending',
+    );
   });
 
   it('should return Pending status for pipelinerun status  with type as "Succeeded" & Pending condition', () => {

--- a/src/shared/components/pipeline-run-logs/__tests__/utils.spec.ts
+++ b/src/shared/components/pipeline-run-logs/__tests__/utils.spec.ts
@@ -2,7 +2,7 @@ import { DataState, testPipelineRuns } from '../../../../__data__/pipelinerun-da
 import { ContainerStatus } from '../../types';
 import {
   containerToLogSourceStatus,
-  getRunStatusColor,
+  getLabelColorFromStatus,
   LOG_SOURCE_RESTARTING,
   LOG_SOURCE_RUNNING,
   LOG_SOURCE_TERMINATED,
@@ -114,30 +114,6 @@ describe('containerToLogSourceStatus', () => {
   });
 });
 
-describe('getRunStatusColor', () => {
-  it('should return the default case', () => {
-    const { message, pftoken, labelColor } = getRunStatusColor(runStatus.PipelineNotStarted);
-    expect(message).toBeDefined();
-    expect(pftoken).toBeDefined();
-    expect(labelColor).toBeDefined();
-  });
-
-  it('should result the message, pftoken and label colour for all the handled statuses', () => {
-    const handledStatuses = Object.keys(runStatus)
-      .filter((status) => status !== runStatus.PipelineNotStarted)
-      .map((status) => runStatus[status]);
-
-    expect(handledStatuses).not.toHaveLength(0);
-
-    handledStatuses.forEach((statusValue) => {
-      const { message, pftoken, labelColor } = getRunStatusColor(statusValue);
-      expect(message).toBeDefined();
-      expect(pftoken).toBeDefined();
-      expect(labelColor).toBeDefined();
-    });
-  });
-});
-
 describe('pipelineRunStatusToGitOpsStatus', () => {
   it('should return the default case', () => {
     expect(pipelineRunStatusToGitOpsStatus('-')).toBe('Unknown');
@@ -151,5 +127,27 @@ describe('pipelineRunStatusToGitOpsStatus', () => {
     expect(pipelineRunStatusToGitOpsStatus(runStatus.Cancelled)).toBe('Suspended');
     expect(pipelineRunStatusToGitOpsStatus(runStatus.Cancelling)).toBe('Suspended');
     expect(pipelineRunStatusToGitOpsStatus(runStatus.Skipped)).toBe('Missing');
+  });
+});
+
+describe('getLabelColorFromStatus', () => {
+  it('should return the null', () => {
+    expect(getLabelColorFromStatus(runStatus.Idle)).toBeNull();
+    expect(getLabelColorFromStatus(runStatus.Pending)).toBeNull();
+    expect(getLabelColorFromStatus(runStatus.Skipped)).toBeNull();
+    expect(getLabelColorFromStatus(runStatus.PipelineNotStarted)).toBeNull();
+  });
+
+  it('should return green for success', () => {
+    expect(getLabelColorFromStatus(runStatus.Succeeded)).toBe('green');
+  });
+
+  it('should return red for failed', () => {
+    expect(getLabelColorFromStatus(runStatus.Failed)).toBe('red');
+  });
+
+  it('should return gold for cancelled/cancelling status', () => {
+    expect(getLabelColorFromStatus(runStatus.Cancelled)).toBe('gold');
+    expect(getLabelColorFromStatus(runStatus.Cancelling)).toBe('gold');
   });
 });

--- a/src/shared/components/pipeline-run-logs/utils.ts
+++ b/src/shared/components/pipeline-run-logs/utils.ts
@@ -1,10 +1,4 @@
 import { K8sModelCommon } from '@openshift/dynamic-plugin-sdk-utils';
-import { chart_color_black_400 as skippedColor } from '@patternfly/react-tokens/dist/js/chart_color_black_400';
-import { chart_color_black_500 as cancelledColor } from '@patternfly/react-tokens/dist/js/chart_color_black_500';
-import { chart_color_blue_100 as pendingColor } from '@patternfly/react-tokens/dist/js/chart_color_blue_100';
-import { chart_color_blue_300 as runningColor } from '@patternfly/react-tokens/dist/js/chart_color_blue_300';
-import { chart_color_green_400 as successColor } from '@patternfly/react-tokens/dist/js/chart_color_green_400';
-import { global_danger_color_100 as failureColor } from '@patternfly/react-tokens/dist/js/global_danger_color_100';
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
 import { K8sGroupVersionKind } from '../../../dynamic-plugin-sdk';
@@ -149,41 +143,6 @@ export enum runStatus {
   Idle = 'Idle',
 }
 
-export const getRunStatusColor = (status: string) => {
-  switch (status) {
-    case runStatus.Succeeded:
-      return { message: 'Succeeded', pftoken: successColor, labelColor: 'green' };
-    case runStatus.Failed:
-      return { message: 'Failed', pftoken: failureColor, labelColor: 'red' };
-    case runStatus.FailedToStart:
-      return {
-        message: 'PipelineRun failed to start',
-        pftoken: failureColor,
-        labelColor: 'orange',
-      };
-    case runStatus.Running:
-      return { message: 'Running', pftoken: runningColor, labelColor: 'blue' };
-    case runStatus['In Progress']:
-      return { message: 'Running', pftoken: runningColor, labelColor: 'blue' };
-
-    case runStatus.Skipped:
-      return { message: 'Skipped', pftoken: skippedColor, labelColor: 'grey' };
-    case runStatus.Cancelled:
-      return { message: 'Cancelled', pftoken: cancelledColor, labelColor: 'grey' };
-    case runStatus.Cancelling:
-      return { message: 'Cancelling', pftoken: cancelledColor, labelColor: 'grey' };
-    case runStatus.Idle:
-    case runStatus.Pending:
-      return { message: 'Pending', pftoken: pendingColor, labelColor: 'yellow' };
-    default:
-      return {
-        message: 'PipelineRun not started yet',
-        pftoken: pendingColor,
-        labelColor: 'grey',
-      };
-  }
-};
-
 export const pipelineRunStatusToGitOpsStatus = (status: string): GitOpsDeploymentHealthStatus => {
   switch (status) {
     case 'Succeeded':
@@ -200,5 +159,27 @@ export const pipelineRunStatusToGitOpsStatus = (status: string): GitOpsDeploymen
       return GitOpsDeploymentHealthStatus.Missing;
     default:
       return GitOpsDeploymentHealthStatus.Unknown;
+  }
+};
+
+export const getLabelColorFromStatus = (
+  status: string,
+): 'blue' | 'cyan' | 'green' | 'orange' | 'purple' | 'red' | 'grey' | 'gold' => {
+  switch (status) {
+    case runStatus.Succeeded:
+      return 'green';
+    case runStatus.Failed:
+      return 'red';
+    case runStatus['In Progress']:
+    case runStatus.Running:
+      return 'blue';
+    case runStatus.Cancelled:
+    case runStatus.Cancelling:
+      return 'gold';
+    case runStatus.Idle:
+    case runStatus.Pending:
+    case runStatus.Skipped:
+    default:
+      return null;
   }
 };

--- a/src/shared/components/pipeline-run-logs/utils.ts
+++ b/src/shared/components/pipeline-run-logs/utils.ts
@@ -80,8 +80,10 @@ export const PipelineRunModel: K8sModelCommon = {
 // Converts the PipelineRun (and TaskRun) condition status into a human readable string.
 // See also tkn cli implementation at https://github.com/tektoncd/cli/blob/release-v0.15.0/pkg/formatted/k8s.go#L54-L83
 export const pipelineRunStatus = (pipelineRun): string => {
+  if (!pipelineRun?.status) return null;
+
   const conditions = get(pipelineRun, ['status', 'conditions'], []);
-  if (conditions.length === 0) return null;
+  if (conditions.length === 0) return 'Pending';
 
   const cancelledCondition = conditions.find((c) => c.reason === 'Cancelled');
   const succeedCondition = conditions.find((c) => c.type === 'Succeeded');


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-2863

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Pipeline visualization uses icons from pf-pipelines package and pipeline run logs uses a custom statusIcon component causing inconsistencies in the pipeline icons between graph and logs component.

**Solution:**

Using PF status icon as base and extending it to support some custom intermediate states (cancelling state - used to better notify the plr state to the user and avoid any actions on plrs that are being cancelled).

Note: we need this to be added in the PF package to avoid custom handling. will log a bug on PF for this new state.


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

<img width="400" alt="Screenshot 2023-01-12 at 10 29 22 PM" src="https://user-images.githubusercontent.com/9964343/212136205-2fc82624-50fb-4741-a142-249090565faa.png"> <img width="381" alt="Screenshot 2023-01-12 at 10 53 38 PM" src="https://user-images.githubusercontent.com/9964343/212136386-6a4a8ee2-1622-4ccf-a073-eafbc6044b69.png">

https://user-images.githubusercontent.com/9964343/212138664-70a2dc13-a2e3-42e1-82a5-44021026bdd0.mov

---
**Fixed the status label background colors**

 <img width="400" alt="Screenshot 2023-01-12 at 11 45 47 PM" src="https://user-images.githubusercontent.com/9964343/212147897-2b031ffb-ae3f-4e7f-b3fe-819ea2255053.png">  <img width="400" alt="Screenshot 2023-01-12 at 11 44 59 PM" src="https://user-images.githubusercontent.com/9964343/212147873-e6223cdd-d2bc-4f0c-af9f-9bd143780c96.png">

<img width="900" alt="Screenshot 2023-01-12 at 11 45 22 PM" src="https://user-images.githubusercontent.com/9964343/212147890-95c6813a-59a3-4e72-bcd6-dcdc1795bd6b.png">



## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

1. go to pipelinerun details page and switch between details and logs tab to see the icons


## Unit tests
```
  pipelineRunStatus
    ✓ should return null if an invalid pipelineruns (2 ms)
    ✓ should return Pending status for pipelineruns with status but no conditions
```    
## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


cc: @christianvogt 
