### PR TITLE
Show routes as component URL on component cards

### DIFF
--- a/integration-tests/support/pageObjects/createApplication-po.ts
+++ b/integration-tests/support/pageObjects/createApplication-po.ts
@@ -56,7 +56,7 @@ export const applicationDetailPagePO = {
   componentBuildLog: '[data-testid="view-build-logs"]',
   componentSettings: '[data-testid="Component settings"]',
   detailsArrow: '[aria-label="Details"]',
-  cpuRamLabel: 'CPU/Mem Requests',
+  cpuRamLabel: 'CPU / Memory',
   replicaLabel: 'Instances',
 };
 

--- a/src/components/ComponentsListView/ComponentListItem.tsx
+++ b/src/components/ComponentsListView/ComponentListItem.tsx
@@ -10,13 +10,13 @@ import {
   DescriptionList,
   DescriptionListDescription,
   DescriptionListGroup,
-  DescriptionListTermHelpText,
-  DescriptionListTermHelpTextButton,
+  DescriptionListTerm,
   Flex,
   FlexItem,
   Tooltip,
 } from '@patternfly/react-core';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 import { global_palette_red_100 as redColor } from '@patternfly/react-tokens/dist/js/global_palette_red_100';
 import ActionMenu from '../../shared/components/action-menu/ActionMenu';
 import ExternalLink from '../../shared/components/links/ExternalLink';
@@ -81,16 +81,16 @@ export const ComponentListItem: React.FC<ComponentListViewItemProps> = ({
                   <b>{name}</b>
                 </FlexItem>
                 <FlexItem>
-                  Source:{' '}
-                  <ExternalLink
-                    href={
-                      component.spec.source?.git?.url ||
-                      (component.spec.containerImage.includes('http')
-                        ? component.spec.containerImage
-                        : `https://${component.spec.containerImage}`)
-                    }
-                    text={component.spec.source?.git?.url || component.spec.containerImage}
-                  />
+                  <ExternalLink href={component.spec.source?.git?.url}>
+                    Git repository <ExternalLinkAltIcon />
+                  </ExternalLink>
+                </FlexItem>
+                <FlexItem>
+                  {componentRouteWebURL && (
+                    <ExternalLink href={componentRouteWebURL}>
+                      Route <ExternalLinkAltIcon />
+                    </ExternalLink>
+                  )}
                 </FlexItem>
               </Flex>
             </DataListCell>,
@@ -130,11 +130,7 @@ export const ComponentListItem: React.FC<ComponentListViewItemProps> = ({
         >
           {resourceRequests && (
             <DescriptionListGroup>
-              <DescriptionListTermHelpText>
-                <DescriptionListTermHelpTextButton>
-                  CPU/Mem Requests
-                </DescriptionListTermHelpTextButton>
-              </DescriptionListTermHelpText>
+              <DescriptionListTerm>CPU / Memory</DescriptionListTerm>
               <DescriptionListDescription>
                 {`${resourceRequests.cpu}, ${resourceRequests.memory}`}
               </DescriptionListDescription>
@@ -142,25 +138,19 @@ export const ComponentListItem: React.FC<ComponentListViewItemProps> = ({
           )}
           {replicas && (
             <DescriptionListGroup>
-              <DescriptionListTermHelpText>
-                <DescriptionListTermHelpTextButton>Instances</DescriptionListTermHelpTextButton>
-              </DescriptionListTermHelpText>
+              <DescriptionListTerm>Instances</DescriptionListTerm>
               <DescriptionListDescription>{replicas}</DescriptionListDescription>
             </DescriptionListGroup>
           )}
           {targetPort && (
             <DescriptionListGroup>
-              <DescriptionListTermHelpText>
-                <DescriptionListTermHelpTextButton>Target Port</DescriptionListTermHelpTextButton>
-              </DescriptionListTermHelpText>
+              <DescriptionListTerm>Target Port</DescriptionListTerm>
               <DescriptionListDescription>{targetPort}</DescriptionListDescription>
             </DescriptionListGroup>
           )}
           {componentRouteWebURL && (
             <DescriptionListGroup>
-              <DescriptionListTermHelpText>
-                <DescriptionListTermHelpTextButton>Route</DescriptionListTermHelpTextButton>
-              </DescriptionListTermHelpText>
+              <DescriptionListTerm>Route</DescriptionListTerm>
               <DescriptionListDescription>
                 <ExternalLink href={componentRouteWebURL} text={componentRouteWebURL} />
               </DescriptionListDescription>
@@ -168,11 +158,7 @@ export const ComponentListItem: React.FC<ComponentListViewItemProps> = ({
           )}
           {containerImage && (
             <DescriptionListGroup>
-              <DescriptionListTermHelpText>
-                <DescriptionListTermHelpTextButton>
-                  Built container image
-                </DescriptionListTermHelpTextButton>
-              </DescriptionListTermHelpText>
+              <DescriptionListTerm>Built container image</DescriptionListTerm>
               <DescriptionListDescription>
                 <ExternalLink href={`https://${containerImage}`} text={containerImage} />
               </DescriptionListDescription>

--- a/src/components/ComponentsListView/__tests__/ComponentListItem.spec.tsx
+++ b/src/components/ComponentsListView/__tests__/ComponentListItem.spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
 import { configure, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { mockRoutes } from '../../../hooks/__data__/mock-data';
 import { useLatestPipelineRunForComponent } from '../../../hooks/usePipelineRunsForApplication';
 import { componentCRMocks } from '../../ApplicationDetailsView/__data__/mock-data';
 import { mockPipelineRuns } from '../../ApplicationDetailsView/__data__/mock-pipeline-run';
@@ -24,6 +25,17 @@ describe('ComponentListItem', () => {
   it('should render display name of the component', () => {
     render(<ComponentListItem component={componentCRMocks[0]} routes={[]} />);
     screen.getByText('basic-node-js');
+  });
+
+  it('should render git repository link of the component', () => {
+    render(<ComponentListItem component={componentCRMocks[0]} routes={[]} />);
+    screen.getByText('Git repository');
+    expect(screen.queryByText('Route')).not.toBeInTheDocument();
+  });
+
+  it('should render component URL link of the component if route exists', () => {
+    render(<ComponentListItem component={componentCRMocks[0]} routes={mockRoutes} />);
+    screen.getAllByText('Route');
   });
 
   it('should render View Build logs action item', async () => {

--- a/src/hooks/__data__/mock-data.ts
+++ b/src/hooks/__data__/mock-data.ts
@@ -15,7 +15,7 @@ export const mockRoutes: RouteKind[] = [
         'app.kubernetes.io/created-by': 'application-service',
         'app.kubernetes.io/instance': 'gitopsdepl-f56e3027-168b-43cf-aa3a-99d784d69b05',
         'app.kubernetes.io/managed-by': 'kustomize',
-        'app.kubernetes.io/name': 'nodejs',
+        'app.kubernetes.io/name': 'basic-node-js',
         'app.kubernetes.io/part-of': 'new-application',
       },
       name: 'nodejs',

--- a/src/utils/__tests__/route-utils.spec.ts
+++ b/src/utils/__tests__/route-utils.spec.ts
@@ -3,7 +3,7 @@ import { getComponentRouteWebURL } from './../route-utils';
 
 describe('Route Utils', () => {
   it('Should return route url for given component', async () => {
-    const result = getComponentRouteWebURL(mockRoutes, 'nodejs');
+    const result = getComponentRouteWebURL(mockRoutes, 'basic-node-js');
 
     expect(result).toEqual('https://nodejs-test.apps.appstudio-stage.x99m.p1.openshiftapps.com');
   });


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
- https://issues.redhat.com/browse/HAC-2787
- https://issues.redhat.com/browse/HAC-2929
- https://issues.redhat.com/browse/HAC-2968

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- Update the component list view to show routes for the component on top of the card.
- Updated component details labels.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
<img width="2516" alt="Screenshot 2023-01-18 at 10 38 53 PM" src="https://user-images.githubusercontent.com/6041994/213249240-bc881b73-d2db-424a-aef0-b3a104adaf01.png">




## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge

