### PR TITLE
reduce default resources

### DIFF
--- a/src/components/ImportForm/utils/__tests__/transform-utils.spec.ts
+++ b/src/components/ImportForm/utils/__tests__/transform-utils.spec.ts
@@ -5,6 +5,13 @@ import {
   transformComponentValues,
 } from '../transform-utils';
 
+const mockResourceRequests = {
+  requests: {
+    cpu: '2',
+    memory: '1Gi',
+  },
+};
+
 const mockResourceLimits = {
   limits: {
     cpu: '48m',
@@ -13,12 +20,32 @@ const mockResourceLimits = {
 };
 
 describe('Transform Utils', () => {
-  it('Should create resource data from resource limits', () => {
+  it('should create resource data from resource requests', () => {
+    const result = createResourceData(mockResourceRequests);
+    expect(result).toEqual({
+      cpu: '2',
+      cpuUnit: 'cores',
+      memory: '1',
+      memoryUnit: 'Gi',
+    });
+  });
+
+  it('should create resource data from resource limits', () => {
     const result = createResourceData(mockResourceLimits);
     expect(result).toEqual({
       cpu: '48',
       cpuUnit: 'millicores',
       memory: '516',
+      memoryUnit: 'Mi',
+    });
+  });
+
+  it('should create default resource data', () => {
+    const result = createResourceData({});
+    expect(result).toEqual({
+      cpu: '10',
+      cpuUnit: 'millicores',
+      memory: '50',
       memoryUnit: 'Mi',
     });
   });
@@ -36,7 +63,7 @@ describe('Transform Utils', () => {
               url: 'https://github.com/nodeshift-starters/devfile-sample.git',
             },
           },
-          resources: { cpu: '1', cpuUnit: 'cores', memory: '512', memoryUnit: 'Mi' },
+          resources: { cpu: '10', cpuUnit: 'millicores', memory: '50', memoryUnit: 'Mi' },
           replicas: 1,
           targetPort: 8080,
           route: undefined,

--- a/src/components/ImportForm/utils/transform-utils.ts
+++ b/src/components/ImportForm/utils/transform-utils.ts
@@ -1,15 +1,15 @@
 import { sanitizeName } from '../../../utils/create-utils';
 import { ResourceRequirements, DetectedComponents } from './../../../types';
-import { DetectedFormComponent, FormResources, MemoryUnits } from './types';
+import { CPUUnits, DetectedFormComponent, FormResources, MemoryUnits } from './types';
 
-const getResourceData = (res: string) => {
+const getResourceData = (res?: string) => {
   const resourcesRegEx = /^[0-9]*|[a-zA-Z]*/g;
-  return res.match(resourcesRegEx);
+  return res ? res.match(resourcesRegEx) : [];
 };
 
 const CPUResourceMap = {
-  m: 'millicores',
-  '': 'cores',
+  m: CPUUnits.millicores,
+  '': CPUUnits.cores,
 };
 
 type ResourceData = {
@@ -18,16 +18,16 @@ type ResourceData = {
 };
 
 export const createResourceData = (resources: ResourceData): FormResources => {
-  const memory = (resources?.requests?.memory || resources?.limits?.memory) ?? '512Mi';
-  const cpu = (resources?.requests?.cpu || resources?.limits?.cpu) ?? '1';
+  const memory = resources?.requests?.memory || resources?.limits?.memory;
+  const cpu = resources?.requests?.cpu || resources?.limits?.cpu;
   const [memoryResource, memoryUnit] = getResourceData(memory);
   const [cpuResource, cpuUnit] = getResourceData(cpu);
 
   return {
-    cpu: cpuResource || '',
-    cpuUnit: CPUResourceMap[cpuUnit] || CPUResourceMap[''],
-    memory: memoryResource || '',
-    memoryUnit: (memoryUnit as MemoryUnits) || MemoryUnits.Gi,
+    cpu: cpuResource || '10',
+    cpuUnit: CPUResourceMap[cpuUnit] || CPUUnits.millicores,
+    memory: memoryResource || '50',
+    memoryUnit: MemoryUnits[memoryUnit] || MemoryUnits.Mi,
   };
 };
 


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-2882

## Description
In certain circumstances, CDQ responds with no default values for the CPU and memory limits. As such the UI had implemented values which were considered too high.

Reduced the defaults to 50Mi and 10millicores.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
