### PR TITLE
Add skip initial check annotation while creating components

### DIFF
--- a/src/utils/__tests__/create-utils.spec.ts
+++ b/src/utils/__tests__/create-utils.spec.ts
@@ -3,6 +3,7 @@ import {
   k8sGetResource,
   k8sUpdateResource,
 } from '@openshift/dynamic-plugin-sdk-utils';
+import omit from 'lodash/omit';
 import { SPIAccessTokenBindingModel } from '../../models';
 import { ApplicationModel } from './../../models/application';
 import { ComponentDetectionQueryModel, ComponentModel } from './../../models/component';
@@ -58,6 +59,9 @@ const mockComponentData = {
   metadata: {
     name: 'test-component',
     namespace: 'test-ns',
+    annotations: {
+      'skip-initial-checks': 'true',
+    },
   },
   spec: {
     componentName: mockComponent.componentName,
@@ -85,6 +89,11 @@ const mockComponentDataWithDevfile = {
     },
   },
 };
+
+const mockComponentDataWithoutAnnotation = omit(
+  mockComponentDataWithDevfile,
+  'metadata.annotations',
+);
 
 const mockComponentDataWithPAC = {
   ...mockComponentDataWithDevfile,
@@ -247,6 +256,24 @@ describe('Create Utils', () => {
     expect(k8sUpdateResource).toHaveBeenCalledWith({
       model: ComponentModel,
       resource: mockComponentDataWithDevfile,
+    });
+  });
+
+  it('Should not add skip-initial-checks annotations while updating existing components', async () => {
+    await createComponent(
+      mockComponentWithDevfile,
+      'test-application',
+      'test-ns',
+      undefined,
+      false,
+      mockComponentDataWithoutAnnotation,
+      'update',
+      false,
+    );
+
+    expect(k8sUpdateResource).toHaveBeenCalledWith({
+      model: ComponentModel,
+      resource: mockComponentDataWithoutAnnotation,
     });
   });
 

--- a/src/utils/create-utils.ts
+++ b/src/utils/create-utils.ts
@@ -93,12 +93,18 @@ export const createComponent = (
     metadata: {
       name,
       namespace,
-      ...(enablePac &&
-        verb === 'create' && {
-          annotations: {
-            pipelinesascode: '1',
-          },
-        }),
+      ...(verb === 'create' &&
+        (enablePac
+          ? {
+              annotations: {
+                pipelinesascode: '1',
+              },
+            }
+          : {
+              annotations: {
+                'skip-initial-checks': 'true',
+              },
+            })),
     },
     spec: {
       componentName,


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
- https://issues.redhat.com/browse/HAC-2830

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- Add `'skip-initial-check': 'true'` annotation when creating component without PAC.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
No change in the UI.


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

