### PR TITLE
Add spin animation to running build status icon

### DIFF
--- a/src/utils/gitops-utils.scss
+++ b/src/utils/gitops-utils.scss
@@ -1,0 +1,7 @@
+.status-icon-spin {
+    filter: blur(0);
+    -webkit-filter: blur(0);
+    transform-box: fill-box;
+    transform-origin: center;
+    animation: status-spin 2s infinite linear;
+}

--- a/src/utils/gitops-utils.tsx
+++ b/src/utils/gitops-utils.tsx
@@ -12,6 +12,8 @@ import {
   GitOpsDeploymentStrategy,
 } from '../types/gitops-deployment';
 
+import './gitops-utils.scss';
+
 export const getGitOpsDeploymentHealthStatusIcon = (status: GitOpsDeploymentHealthStatus) => {
   switch (status) {
     case GitOpsDeploymentHealthStatus.Healthy:
@@ -41,7 +43,7 @@ export const getBuildStatusIcon = (status: runStatus) => {
       return <ExclamationCircleIcon color={redColor.value} />;
     case runStatus.Running:
     case runStatus['In Progress']:
-      return <InProgressIcon />;
+      return <InProgressIcon className="status-icon-spin" />;
     default:
       return <NotStartedIcon />;
   }


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-2953
## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Spin animation was missing for build running status in component list view.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->



https://user-images.githubusercontent.com/9964343/213522839-54b50448-e0fa-4c69-8bd5-e68087e2a005.mov



## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
