### PR TITLE
fix initial pipelinerun status text and duration field

### DIFF
--- a/src/components/Commits/__tests__/commit-status.spec.ts
+++ b/src/components/Commits/__tests__/commit-status.spec.ts
@@ -11,16 +11,16 @@ jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
 const watchResourceMock = useK8sWatchResource as jest.Mock;
 
 describe('useCommitStatus', () => {
-  it('returns empty status if pipelineruns are not loaded', () => {
+  it('returns Pending status if pipelineruns are not loaded', () => {
     watchResourceMock.mockReturnValue([null, false]);
     const { result } = renderHook(() => useCommitStatus('app', 'commit'));
-    expect(result.current).toEqual(['-', false, undefined]);
+    expect(result.current).toEqual(['Pending', false, undefined]);
   });
 
-  it('returns empty status if pipelineruns for given commit are not found', () => {
+  it('returns Pending status if pipelineruns for given commit are not found', () => {
     watchResourceMock.mockReturnValue([pipelineWithCommits, true]);
     const { result } = renderHook(() => useCommitStatus('app', 'commit123'));
-    expect(result.current).toEqual(['-', true, undefined]);
+    expect(result.current).toEqual(['Pending', true, undefined]);
   });
 
   it('returns correct status if pipelineruns are loaded', () => {

--- a/src/components/Commits/commit-status.ts
+++ b/src/components/Commits/commit-status.ts
@@ -32,14 +32,14 @@ export const useCommitStatus = (
 
   const commitStatus = React.useMemo(() => {
     if (!loaded || loadErr) {
-      return '-';
+      return 'Pending';
     }
 
     const plrStatus = pipelineRunFilterReducer(plrsForCommit[plrsForCommit.length - 1]);
     if (statuses.includes(plrStatus)) {
       return plrStatus;
     }
-    return '-';
+    return 'Pending';
   }, [loaded, loadErr, plrsForCommit]);
 
   return [commitStatus, loaded, loadErr];

--- a/src/components/PipelineRunListView/PipelineRunListRow.tsx
+++ b/src/components/PipelineRunListView/PipelineRunListRow.tsx
@@ -32,10 +32,12 @@ const PipelineListRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({ obj }) =>
         />
       </TableData>
       <TableData className={pipelineRunTableColumnClasses.duration}>
-        {calculateDuration(
-          typeof obj.status?.startTime === 'string' ? obj.status?.startTime : '',
-          typeof obj.status?.completionTime === 'string' ? obj.status?.completionTime : '',
-        )}
+        {status !== 'Pending'
+          ? calculateDuration(
+              typeof obj.status?.startTime === 'string' ? obj.status?.startTime : '',
+              typeof obj.status?.completionTime === 'string' ? obj.status?.completionTime : '',
+            )
+          : '-'}
       </TableData>
       <TableData className={pipelineRunTableColumnClasses.status}>
         <StatusIconWithText status={status} />

--- a/src/shared/components/pipeline-run-logs/__tests__/utils.spec.ts
+++ b/src/shared/components/pipeline-run-logs/__tests__/utils.spec.ts
@@ -14,13 +14,14 @@ import {
 } from '../utils';
 
 describe('pipelineRunStatus', () => {
-  it('should return null if an invalid pipelineruns', () => {
-    expect(pipelineRunStatus(testPipelineRuns[DataState.STATUS_WITHOUT_CONDITION_TYPE])).toBeNull();
-    expect(pipelineRunStatus(testPipelineRuns[DataState.STATUS_WITH_EMPTY_CONDITIONS])).toBeNull();
-  });
-
-  it('should return Pending status for pipelineruns with status but no conditions', () => {
+  it('should return Pending status for pipelineruns with no status or no conditions', () => {
     expect(pipelineRunStatus(testPipelineRuns[DataState.STATUS_WITHOUT_CONDITIONS])).toBe(
+      'Pending',
+    );
+    expect(pipelineRunStatus(testPipelineRuns[DataState.STATUS_WITHOUT_CONDITION_TYPE])).toBe(
+      'Pending',
+    );
+    expect(pipelineRunStatus(testPipelineRuns[DataState.STATUS_WITH_EMPTY_CONDITIONS])).toBe(
       'Pending',
     );
   });
@@ -69,9 +70,9 @@ describe('pipelineRunFilterReducer', () => {
     expect(pipelineRunFilterReducer(testPipelineRuns[DataState.RUNNING])).toBe('Running');
   });
 
-  it('should return "-" for pipelinerun status with empty conditions', () => {
+  it('should return "Pending" state for pipelinerun status with empty conditions', () => {
     expect(pipelineRunFilterReducer(testPipelineRuns[DataState.STATUS_WITH_EMPTY_CONDITIONS])).toBe(
-      '-',
+      'Pending',
     );
   });
 });

--- a/src/shared/components/pipeline-run-logs/utils.ts
+++ b/src/shared/components/pipeline-run-logs/utils.ts
@@ -74,7 +74,7 @@ export const PipelineRunModel: K8sModelCommon = {
 // Converts the PipelineRun (and TaskRun) condition status into a human readable string.
 // See also tkn cli implementation at https://github.com/tektoncd/cli/blob/release-v0.15.0/pkg/formatted/k8s.go#L54-L83
 export const pipelineRunStatus = (pipelineRun): string => {
-  if (!pipelineRun?.status) return null;
+  if (!pipelineRun?.status) return 'Pending';
 
   const conditions = get(pipelineRun, ['status', 'conditions'], []);
   if (conditions.length === 0) return 'Pending';
@@ -82,7 +82,7 @@ export const pipelineRunStatus = (pipelineRun): string => {
   const cancelledCondition = conditions.find((c) => c.reason === 'Cancelled');
   const succeedCondition = conditions.find((c) => c.type === 'Succeeded');
   if (!succeedCondition || !succeedCondition.status) {
-    return null;
+    return 'Pending';
   }
   const status =
     succeedCondition.status === 'True'
@@ -126,7 +126,7 @@ export const pipelineRunStatus = (pipelineRun): string => {
 };
 export const pipelineRunFilterReducer = (pipelineRun): runStatus => {
   const status = pipelineRunStatus(pipelineRun);
-  return (status || '-') as runStatus;
+  return (status || 'Pending') as runStatus;
 };
 
 export enum runStatus {


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-2917

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The status and duration of a new pipeline run that has yet to start is incorrect. The duration should probably show `-` and the status should as well or some other waiting to start state.



## Type of change
<!-- Please delete options that are not relevant. -->


- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


https://user-images.githubusercontent.com/9964343/213528869-99efaee5-e575-4438-9ac9-d2b2e5338532.mov



## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

1. rerun the pipelinerun in the pipelinerun list view.

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

cc: @christianvogt 