### PR TITLE
Fix disappearing advanced options when switching runtime

### DIFF
--- a/src/components/ImportForm/ReviewSection/ReviewComponentCard.tsx
+++ b/src/components/ImportForm/ReviewSection/ReviewComponentCard.tsx
@@ -65,8 +65,11 @@ export const ReviewComponentCard: React.FC<ReviewComponentCardProps> = ({
         }}
       >
         <CardTitle>
-          <Flex>
-            <FlexItem spacer={{ default: 'spacer4xl' }}>
+          <Flex alignItems={{ default: 'alignItemsCenter' }}>
+            <FlexItem
+              style={{ marginBottom: 'var(--pf-global--spacer--md)' }}
+              spacer={{ default: 'spacer4xl' }}
+            >
               {editMode ? (
                 <p>{name}</p>
               ) : (

--- a/src/components/ImportForm/ReviewSection/ReviewComponentCard.tsx
+++ b/src/components/ImportForm/ReviewSection/ReviewComponentCard.tsx
@@ -13,7 +13,6 @@ import {
   GridItem,
   TextInputTypes,
 } from '@patternfly/react-core';
-import { useFormikContext } from 'formik';
 import {
   EditableLabelField,
   EnvironmentField,
@@ -23,7 +22,7 @@ import {
   ResourceLimitField,
 } from '../../../shared';
 import ExternalLink from '../../../shared/components/links/ExternalLink';
-import { CPUUnits, DetectedFormComponent, ImportFormValues, MemoryUnits } from '../utils/types';
+import { CPUUnits, DetectedFormComponent, MemoryUnits } from '../utils/types';
 import { RuntimeSelector } from './RuntimeSelector';
 
 type ReviewComponentCardProps = {
@@ -46,9 +45,6 @@ export const ReviewComponentCard: React.FC<ReviewComponentCardProps> = ({
   const fieldPrefix = `components[${detectedComponentIndex}].componentStub`;
   const [expandedComponent, setExpandedComponent] = React.useState(isExpanded);
   const [expandedConfig, setExpandedConfig] = React.useState(true);
-  const {
-    values: { isDetected },
-  } = useFormikContext<ImportFormValues>();
 
   return (
     <Card
@@ -99,73 +95,71 @@ export const ReviewComponentCard: React.FC<ReviewComponentCardProps> = ({
         </CardTitle>
       </CardHeader>
       <CardExpandableContent>
-        {isDetected && (
-          <CardBody style={{ marginLeft: '2em', maxWidth: '70%' }}>
-            <ExpandableSection
-              isExpanded={expandedConfig}
-              onToggle={() => setExpandedConfig((v) => !v)}
-              toggleText="Deploy configuration"
-              isIndented
-            >
-              <FormSection>
-                <Grid hasGutter>
-                  <GridItem span={3}>
-                    <InputField
-                      name={`${fieldPrefix}.targetPort`}
-                      label="Target port"
-                      type={TextInputTypes.number}
-                    />
-                  </GridItem>
-                  <GridItem span={5} />
-                  <GridItem span={6}>
-                    <ResourceLimitField
-                      name={`${fieldPrefix}.resources.cpu`}
-                      unitName={`${fieldPrefix}.resources.cpuUnit`}
-                      label="CPU"
-                      minValue={0}
-                      unitOptions={CPUUnits}
-                      helpText="The amount of CPU the container is guaranteed"
-                    />
-                  </GridItem>
-                  <GridItem span={6}>
-                    <ResourceLimitField
-                      name={`${fieldPrefix}.resources.memory`}
-                      unitName={`${fieldPrefix}.resources.memoryUnit`}
-                      label="Memory"
-                      minValue={0}
-                      unitOptions={MemoryUnits}
-                      helpText="The amount of memory the container is guaranteed"
-                    />
-                  </GridItem>
-                </Grid>
-                <ExpandableSection toggleText="Show advanced deployment options">
-                  <FormSection>
-                    <NumberSpinnerField
-                      name={`${fieldPrefix}.replicas`}
-                      label="Instances"
-                      min={0}
-                      helpText="Number of instances of your image"
-                    />
-                    {/* <InputField
+        <CardBody style={{ marginLeft: '2em', maxWidth: '70%' }}>
+          <ExpandableSection
+            isExpanded={expandedConfig}
+            onToggle={() => setExpandedConfig((v) => !v)}
+            toggleText="Deploy configuration"
+            isIndented
+          >
+            <FormSection>
+              <Grid hasGutter>
+                <GridItem span={3}>
+                  <InputField
+                    name={`${fieldPrefix}.targetPort`}
+                    label="Target port"
+                    type={TextInputTypes.number}
+                  />
+                </GridItem>
+                <GridItem span={5} />
+                <GridItem span={6}>
+                  <ResourceLimitField
+                    name={`${fieldPrefix}.resources.cpu`}
+                    unitName={`${fieldPrefix}.resources.cpuUnit`}
+                    label="CPU"
+                    minValue={0}
+                    unitOptions={CPUUnits}
+                    helpText="The amount of CPU the container is guaranteed"
+                  />
+                </GridItem>
+                <GridItem span={6}>
+                  <ResourceLimitField
+                    name={`${fieldPrefix}.resources.memory`}
+                    unitName={`${fieldPrefix}.resources.memoryUnit`}
+                    label="Memory"
+                    minValue={0}
+                    unitOptions={MemoryUnits}
+                    helpText="The amount of memory the container is guaranteed"
+                  />
+                </GridItem>
+              </Grid>
+              <ExpandableSection toggleText="Show advanced deployment options">
+                <FormSection>
+                  <NumberSpinnerField
+                    name={`${fieldPrefix}.replicas`}
+                    label="Instances"
+                    min={0}
+                    helpText="Number of instances of your image"
+                  />
+                  {/* <InputField
                       name={`${fieldPrefix}.route`}
                       label="Route"
                       placeholder="Route exposed by the deployment"
                     /> */}
-                    <EnvironmentField
-                      name={`${fieldPrefix}.env`}
-                      envs={component.env}
-                      label="Environment variables"
-                      description="Component will have access during build and runtimes."
-                      labelIcon={
-                        <HelpTooltipIcon content="Set environment variables to define the behaviour of your application environment." />
-                      }
-                    />
-                  </FormSection>
-                </ExpandableSection>
-              </FormSection>
-            </ExpandableSection>
-          </CardBody>
-        )}
+                  <EnvironmentField
+                    name={`${fieldPrefix}.env`}
+                    envs={component.env}
+                    label="Environment variables"
+                    description="Component will have access during build and runtimes."
+                    labelIcon={
+                      <HelpTooltipIcon content="Set environment variables to define the behaviour of your application environment." />
+                    }
+                  />
+                </FormSection>
+              </ExpandableSection>
+            </FormSection>
+          </ExpandableSection>
+        </CardBody>
       </CardExpandableContent>
     </Card>
   );

--- a/src/components/ImportForm/ReviewSection/__tests__/ReviewComponentCard.spec.tsx
+++ b/src/components/ImportForm/ReviewSection/__tests__/ReviewComponentCard.spec.tsx
@@ -90,7 +90,7 @@ describe('ReviewComponentCard', () => {
     expect(screen.getByText('Deploy configuration')).toBeInTheDocument();
   });
 
-  it('should hide expandable config when components are not detected', async () => {
+  it('should not hide expandable config when components are not detected', async () => {
     useComponentDetectionMock.mockReturnValue([]);
     formikRenderer(
       <ReviewComponentCard
@@ -98,11 +98,11 @@ describe('ReviewComponentCard', () => {
         detectedComponentIndex={0}
         showRuntimeSelector
       />,
-      { isDetected: false, source: { git: {} } },
+      { source: { git: {} } },
     );
     await act(async () => screen.getByRole('button', { expanded: false }).click());
 
-    expect(screen.queryByText('Deploy configuration')).not.toBeInTheDocument();
+    expect(screen.queryByText('Deploy configuration')).toBeInTheDocument();
   });
 
   it('should not show runtime selector when not specified', async () => {


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-2908

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

During import, if the runtime is changed, the advanced options disappear entirely while the CDQ is running. Furthermore the expanded advanced settings which were expanded prior to selecting a new runtime return collapsed after the CDQ completes.


Now showing the deploy configuration options all the time with default values and fixed the content jumping caused due to conditional rendering of spinner.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

**Before:**

![runtime_switching_before](https://user-images.githubusercontent.com/9964343/213624690-d3d6914c-3bf3-439c-afa5-4de41443dc8a.gif)

**After:**
![runtimeSelector_after](https://user-images.githubusercontent.com/9964343/213624697-e50950f1-b0cc-4d3b-9d3c-4f4ffd9a6d33.gif)

## Unit tests
```
  ReviewComponentCard

    ✓ should not hide expandable config when components are not detected (76 ms)
```
## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Change the runtime in the component review step.

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
