### PR TITLE
view build logs should only show the build pipelinerun logs

### DIFF
--- a/src/components/LogViewer/BuildLogViewer.tsx
+++ b/src/components/LogViewer/BuildLogViewer.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import { ModalVariant, Stack, StackItem } from '@patternfly/react-core';
 import dayjs from 'dayjs';
+import { PipelineRunType } from '../../consts/pipelinerun';
 import { useComponentPipelineRun } from '../../hooks';
 import PipelineRunLogs from '../../shared/components/pipeline-run-logs/PipelineRunLogs';
 import { EmptyBox, LoadingBox } from '../../shared/components/status-box/StatusBox';
 import { ComponentKind } from '../../types';
 import { ComponentProps, createModalLauncher } from '../modal/createModalLauncher';
-import './BuildLogViewer.scss';
 import { useModalLauncher } from '../modal/ModalProvider';
+
+import './BuildLogViewer.scss';
 
 type BuildLogViewerProps = ComponentProps & {
   component: ComponentKind;
@@ -18,6 +20,7 @@ export const BuildLogViewer: React.FC<BuildLogViewerProps> = ({ component }) => 
     component.metadata.name,
     component.spec.application,
     component.metadata.namespace,
+    PipelineRunType.BUILD,
   );
 
   if (loaded && !pipelineRun) {

--- a/src/hooks/useComponentPipelineRun.tsx
+++ b/src/hooks/useComponentPipelineRun.tsx
@@ -9,11 +9,13 @@ export const useComponentPipelineRun = (
   name: string,
   application: string,
   namespace: string,
+  type?: string,
 ): { pipelineRun: PipelineRunKind; loaded: boolean } => {
   const watchResource: WatchK8sResource = React.useMemo(() => {
     const matchLabels = {
       [PipelineRunLabel.COMPONENT]: name,
       [PipelineRunLabel.APPLICATION]: application,
+      ...(type && { [PipelineRunLabel.PIPELINE_TYPE]: type }),
     };
 
     return {
@@ -22,7 +24,7 @@ export const useComponentPipelineRun = (
       selector: { matchLabels },
       isList: true,
     };
-  }, [name, application, namespace]);
+  }, [name, application, namespace, type]);
 
   const [pipelineRuns, loaded, error] = useK8sWatchResource(watchResource);
 


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-2983

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

view build logs opens logs with test pipelineruns but the Build logs modal should always show the build pipelinerun logs.

## Type of change
<!-- Please delete options that are not relevant. -->


- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

**Before:**

<img width="1318" alt="test_pipleinerun_logs" src="https://user-images.githubusercontent.com/9964343/213771309-ec88e96c-2c73-4e3d-ae17-0d7f6d3d65f5.png">

**After:**
<img width="1318" alt="Screenshot 2023-01-20 at 11 16 35 PM" src="https://user-images.githubusercontent.com/9964343/213771360-ee715ae7-6aa3-4666-a40d-43c266b58ff7.png">

## unit tests
```
  BuildLogViewer
    ✓ should show empty box if it is not a build pipelinerun (3 ms)
```
## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

When your component has both build and test pipelineruns, the build log viewer should always show the logs for your build pipelinerun.


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
