### PR TITLE
read PR number from pipeline run label

### DIFF
--- a/src/components/Commits/__data__/pipeline-with-commits.ts
+++ b/src/components/Commits/__data__/pipeline-with-commits.ts
@@ -89,6 +89,8 @@ export const pipelineWithCommits: PipelineRunKind[] = [
         'pipelinesascode.tekton.dev/url-org': 'openshift',
         'build.appstudio.redhat.com/url-repository': 'console',
         'pipelinesascode.tekton.dev/git-provider': 'github',
+        'pipelinesascode.tekton.dev/pull-request': '11',
+        'pipelinesascode.tekton.dev/event-type': 'pull_request',
       },
       name: 'nodejs-sample-zth6t',
       namespace: 'test',

--- a/src/utils/__tests__/commits-utils.spec.ts
+++ b/src/utils/__tests__/commits-utils.spec.ts
@@ -26,6 +26,8 @@ describe('commit-utils', () => {
     expect(result[result.length - 1].components.length).toBe(2);
     expect(result[result.length - 1].user).toBe('abhi');
     expect(result[result.length - 1].pipelineRuns).toHaveLength(2);
+    expect(result[1].isPullRequest).toBe(true);
+    expect(result[1].pullRequestNumber).toBe('11');
   });
 
   it('Should return 2 commits with correct details', () => {

--- a/src/utils/commits-utils.ts
+++ b/src/utils/commits-utils.ts
@@ -25,7 +25,7 @@ export const createCommitObjectFromPLR = (plr: PipelineRunKind): Commit => {
   const repoURL = plr.metadata.labels[PipelineRunLabel.COMMIT_REPO_URL_LABEL];
   const repoOrg = plr.metadata.labels[PipelineRunLabel.COMMIT_REPO_ORG_LABEL];
   const gitProvider = plr.metadata.labels[PipelineRunLabel.COMMIT_PROVIDER_LABEL];
-  const pullRequestNumber = plr.metadata.annotations[PipelineRunLabel.PULL_REQUEST_NUMBER_LABEL];
+  const pullRequestNumber = plr.metadata.labels[PipelineRunLabel.PULL_REQUEST_NUMBER_LABEL];
   const isPullRequest =
     plr.metadata.labels[PipelineRunLabel.COMMIT_EVENT_TYPE_LABEL] === PipelineRunEventType.PULL;
 


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-2993

## Description
PR number is displayed as `#undefined` in the UI because the PR number is being read from PLR annotations instead of labels


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
before:
![image](https://user-images.githubusercontent.com/14068621/213801798-16996adf-8114-459a-a9c9-dc0e765d6645.png)

after:
![image](https://user-images.githubusercontent.com/14068621/213801818-93be6a34-8084-4e88-bfba-db90210bfabb.png)



## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ x Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
