### PR TITLE
align dropdown groups with PF styles

### DIFF
--- a/src/components/ApplicationDetails/ApplicationDetails.tsx
+++ b/src/components/ApplicationDetails/ApplicationDetails.tsx
@@ -107,11 +107,6 @@ const ApplicationDetails: React.FC<HacbsApplicationDetailsProps> = ({ applicatio
             label: 'Add',
           },
           {
-            type: 'separator',
-            key: 'add-separator',
-            label: '',
-          },
-          {
             key: 'add-component',
             label: 'Add components',
             component: (
@@ -141,14 +136,14 @@ const ApplicationDetails: React.FC<HacbsApplicationDetailsProps> = ({ applicatio
             hidden: mvpFeature,
           },
           {
-            type: 'section-label',
-            key: 'help',
-            label: 'Help',
-          },
-          {
             type: 'separator',
             key: 'help-separator',
             label: '',
+          },
+          {
+            type: 'section-label',
+            key: 'help',
+            label: 'Help',
           },
           {
             key: 'application-quickstart',

--- a/src/components/ApplicationDetails/DetailsPage.tsx
+++ b/src/components/ApplicationDetails/DetailsPage.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
   Dropdown,
+  DropdownGroup,
   DropdownItem,
   DropdownItemProps,
   DropdownSeparator,
@@ -86,14 +87,13 @@ const DetailsPage: React.FC<DetailsPageProps> = ({
         }
         if (type === 'separator') {
           acc.push(<DropdownSeparator key={key} />);
+          if (label) {
+            acc.push(<DropdownGroup key={`${key}-group`} label={label} />);
+          }
           return acc;
         }
         if (type === 'section-label') {
-          acc.push(
-            <DropdownItem key={key} data-test={key} {...props} isDisabled>
-              <span className="pf-u-color-400 pf-u-font-size-sm">{label}</span>
-            </DropdownItem>,
-          );
+          acc.push(<DropdownGroup key={`${key}-group`} label={label} data-test={key} />);
           return acc;
         }
         acc.push(

--- a/src/components/ApplicationDetails/__tests__/DetailsPage.spec.tsx
+++ b/src/components/ApplicationDetails/__tests__/DetailsPage.spec.tsx
@@ -72,4 +72,24 @@ describe('DetailsPage', () => {
     routerRenderer(<DetailsPage title="Details" baseURL="/" tabs={[]} actions={null} />);
     expect(screen.queryByTestId('details__actions')).not.toBeInTheDocument();
   });
+
+  it('should render the DetailsPage action groups', () => {
+    const { getByTestId, getByRole } = routerRenderer(
+      <DetailsPage
+        title="Details"
+        baseURL="/"
+        tabs={[]}
+        actions={[
+          {
+            type: 'section-label',
+            key: 'help-section',
+            label: 'Help-Section',
+          },
+        ]}
+      />,
+    );
+    const actionsMenu = getByRole('button', { name: /Actions/ });
+    act(() => actionsMenu.click());
+    expect(getByTestId('help-section')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-2970

## Description
Updated action menu groups to use PF styling.
See examples here: https://www.patternfly.org/v4/components/menu


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
before:
![image](https://user-images.githubusercontent.com/14068621/213808397-c2982389-e988-4f94-8405-bf1213974f74.png)


after:
![image](https://user-images.githubusercontent.com/14068621/213808234-bc5810e3-a541-4748-9fa5-03dddb6f59df.png)


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
