### PR TITLE
add component reference to pipeline run details

### DIFF
--- a/src/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
@@ -161,6 +161,29 @@ const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({ pipelineR
                   </DescriptionListDescription>
                 </DescriptionListGroup>
                 <DescriptionListGroup>
+                  <DescriptionListTerm>Component</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {pipelineRun.metadata?.labels?.[PipelineRunLabel.COMPONENT] ? (
+                      pipelineRun.metadata?.labels?.[PipelineRunLabel.APPLICATION] ? (
+                        <Link
+                          to={`/stonesoup/applications/${
+                            pipelineRun.metadata.labels[PipelineRunLabel.APPLICATION]
+                          }/components?name=${
+                            pipelineRun.metadata.labels[PipelineRunLabel.COMPONENT]
+                          }`}
+                        >
+                          {pipelineRun.metadata.labels[PipelineRunLabel.COMPONENT]}
+                        </Link>
+                      ) : (
+                        pipelineRun.metadata.labels[PipelineRunLabel.COMPONENT]
+                      )
+                    ) : (
+                      '-'
+                    )}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+
+                <DescriptionListGroup>
                   <DescriptionListTerm>Source</DescriptionListTerm>
                   <DescriptionListDescription>
                     {pipelineRun.metadata?.annotations?.[

--- a/src/components/PipelineRunDetailsView/tabs/__tests__/PipelineRunDetailsTab.spec.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/__tests__/PipelineRunDetailsTab.spec.tsx
@@ -45,6 +45,14 @@ describe('PipelineRunDetailsTab', () => {
     screen.getByText('Pipeline run details');
   });
 
+  it('should render the pipelinerun component reference', () => {
+    watchResourceMock.mockReturnValue([[], true]);
+    render(<PipelineRunDetailsTab pipelineRun={sampleBuildPipelines[0]} error={null} />, {
+      wrapper: BrowserRouter,
+    });
+    expect(screen.getByRole('link', { name: /1-nodejs/ })).toBeInTheDocument();
+  });
+
   it('should not render the pipelinerun visualization if the status field is missing', () => {
     watchResourceMock.mockReturnValue([[], true]);
     render(<PipelineRunDetailsTab pipelineRun={sampleBuildPipelines[1]} error={null} />, {
@@ -96,6 +104,20 @@ describe('PipelineRunDetailsTab', () => {
   });
 
   it('should render the graph error state', () => {
+    watchResourceMock.mockReturnValue([[], true]);
+    render(
+      <PipelineRunDetailsTab
+        pipelineRun={testPipelineRun}
+        error={new CustomError('Model not found')}
+      />,
+      {
+        wrapper: BrowserRouter,
+      },
+    );
+    screen.getByTestId('graph-error-state');
+  });
+
+  it('should render the component link', () => {
     watchResourceMock.mockReturnValue([[], true]);
     render(
       <PipelineRunDetailsTab


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-2918

## Description
Adds component reference to the pipeline run details page.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
![image](https://user-images.githubusercontent.com/14068621/213813025-802724fc-07ae-461a-ac93-2d3d6c511ddd.png)


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
