### PR TITLE
[WIP] Enable private tests again.

### DIFF
--- a/integration-tests/config/hac-dev-default.json
+++ b/integration-tests/config/hac-dev-default.json
@@ -1,5 +1,5 @@
 {
-  "ignoreTestFiles": ["*private*"],
+  "ignoreTestFiles": ["*private-git-form.spec.ts"],
   "extends": "../cypress.json",
   "reporterOptions": {
     "reporterEnabled": "spec, mocha-junit-reporter, @reportportal/agent-js-cypress",

--- a/integration-tests/support/pages/tabs/OverviewTabPage.ts
+++ b/integration-tests/support/pages/tabs/OverviewTabPage.ts
@@ -8,6 +8,6 @@ export class OverviewTabPage {
 
     addComponent() {
         Common.waitForLoad();
-        cy.get(overviewTabPO.addComponent).click();
+        cy.wait(500).get(overviewTabPO.addComponent).click({ force: true });
     }
 }

--- a/integration-tests/tests/create-application-from-private-git-form.spec.ts
+++ b/integration-tests/tests/create-application-from-private-git-form.spec.ts
@@ -73,6 +73,7 @@ describe('Create Component from Private Git Using Login Form', { tags: ['@PR-che
       const appPage = new CreateApplicationPage();
       appPage.setApplicationName(applicationName);
       appPage.clickNext();
+      appPage.clickNext();
 
       addComponent.setSource(privateRepo);
       addComponent.waitRepoValidated();

--- a/integration-tests/utils/Tokens.ts
+++ b/integration-tests/utils/Tokens.ts
@@ -5,7 +5,7 @@ export class Tokens {
     static removeBindingsAndTokens(){
         cy.getCookie('cs_jwt').should('exist').then((cookie) => { 
             let token = cookie.value;
-            let namespace = Cypress.env("USERNAME").toLowerCase();
+            let namespace = (Cypress.env("USERNAME").toLowerCase()).concat("-tenant");
 
             removeAllResources(token, namespace, "spiaccesstokenbinding");
             removeAllResources(token, namespace, "spiaccesstoken");

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -86,11 +86,11 @@ docker run ${COMMON_SETUP} \
     ${TEST_IMAGE} \
     bash -c "startcypress run" || TEST_RUN=1
 
-# docker run ${COMMON_SETUP} \
-#     -e CYPRESS_GH_PASSWORD=${CYPRESS_GH_PASSWORD} \
-#     -e CYPRESS_RP_TOKEN=${CYPRESS_RP_HAC} \
-#     ${TEST_IMAGE} \
-#     bash -c "startcypress run -e configFile=hac-dev-experimental" || TEST_RUN=2
+docker run ${COMMON_SETUP} \
+    -e CYPRESS_GH_PASSWORD=${CYPRESS_GH_PASSWORD} \
+    -e CYPRESS_RP_TOKEN=${CYPRESS_RP_HAC} \
+    ${TEST_IMAGE} \
+    bash -c "startcypress run -e configFile=hac-dev-experimental" || TEST_RUN=2
 
 bonfire namespace release ${NAMESPACE}
 


### PR DESCRIPTION
## Fixes 
After the SPI OAuth app fix, enable private tests again on our PR check.

## Description
The SPI configuration on our Stonesoup cluster was not properly done and that prevented us from running private repo tests. Fix the config and enable tests again. 
