### PR TITLE
Fix environment status in env list view and graph nodes

### DIFF
--- a/src/components/ApplicationDetails/tabs/overview/sections/__data__/WorkflowSnapshotsEnvironmentBindingsData.ts
+++ b/src/components/ApplicationDetails/tabs/overview/sections/__data__/WorkflowSnapshotsEnvironmentBindingsData.ts
@@ -1,4 +1,6 @@
-export const mockSnapshotsEnvironmentBindings = [
+import { SnapshotEnvironmentBinding } from '../../../../../../types/coreBuildService';
+
+export const mockSnapshotsEnvironmentBindings: SnapshotEnvironmentBinding[] = [
   {
     apiVersion: 'appstudio.redhat.com/v1alpha1',
     kind: 'SnapshotEnvironmentBinding',
@@ -77,6 +79,7 @@ export const mockSnapshotsEnvironmentBindings = [
         {
           configuration: {
             replicas: 1,
+            env: [],
           },
           name: 'test-nodeapp',
         },
@@ -95,6 +98,191 @@ export const mockSnapshotsEnvironmentBindings = [
             url: 'https://github.com/HACbs-ui-org/test-application-jephilli-define-laugh',
           },
           name: 'test-nodeapp',
+        },
+      ],
+      bindingConditions: [
+        {
+          lastTransitionTime: '2023-01-24T09:31:03Z',
+          message:
+            'SnapshotEventBinding Component status is required to generate GitOps deployment, waiting for the Application Service controller to finish reconciling',
+          binding: 'test-app-2-development-binding-w7f2z',
+          reason: 'ErrorOccurred',
+          status: 'True',
+          type: 'ErrorOccurred',
+        },
+      ],
+
+      componentDeploymentConditions: [
+        {
+          lastTransitionTime: '2023-01-24T09:31:34Z',
+          message: '1 of 1 components deployed',
+          reason: 'CommitsSynced',
+          status: 'True',
+          type: 'AllComponentsDeployed',
+        },
+      ],
+      gitopsDeployments: [
+        {
+          componentName: 'test-nodeapp',
+          gitopsDeployment:
+            'test-application-development-binding-8h9wl-test-application-development-test-nodeapp',
+        },
+      ],
+      gitopsRepoConditions: [
+        {
+          lastTransitionTime: '2022-11-09T17:33:47Z',
+          message: 'GitOps repository sync successful',
+          reason: 'OK',
+          status: 'True',
+          type: 'GitOpsResourcesGenerated',
+        },
+      ],
+    },
+  },
+  {
+    apiVersion: 'appstudio.redhat.com/v1alpha1',
+    kind: 'SnapshotEnvironmentBinding',
+    metadata: {
+      generateName: 'test-application-development-binding-',
+      resourceVersion: '199299',
+      name: 'test-application-development-binding-8h9wl',
+      uid: 'ddc191ed-aa42-43d5-9820-826ae24601ad',
+      creationTimestamp: '2022-11-09T17:33:45Z',
+      generation: 1,
+      namespace: 'test-namespace',
+      labels: {
+        'appstudio.application': 'test-application',
+        'appstudio.environment': 'development',
+      },
+    },
+    spec: {
+      application: 'test-application',
+      components: [
+        {
+          configuration: {
+            replicas: 1,
+            env: [],
+          },
+          name: 'test-nodeapp',
+        },
+      ],
+      environment: 'production',
+      snapshot: 'test-application-dgkqg',
+    },
+    status: {
+      components: [
+        {
+          gitopsRepository: {
+            branch: 'main',
+            commitID: '95598ffacde7586c92a1eecf7c813080b8a9a1c8\n',
+            generatedResources: ['deployment-patch.yaml'],
+            path: 'components/test-nodeapp/overlays/production',
+            url: 'https://github.com/HACbs-ui-org/test-application-jephilli-define-laugh',
+          },
+          name: 'test-nodeapp',
+        },
+      ],
+      bindingConditions: [
+        {
+          lastTransitionTime: '2023-01-24T09:31:03Z',
+          message:
+            'SnapshotEventBinding Component status is required to generate GitOps deployment, waiting for the Application Service controller to finish reconciling',
+          binding: 'test-app-2-development-binding-w7f2z',
+          reason: 'ErrorOccurred',
+          status: 'True',
+          type: 'ErrorOccurred',
+        },
+      ],
+
+      componentDeploymentConditions: [
+        {
+          lastTransitionTime: '2023-01-24T09:31:34Z',
+          message: '1 of 1 components deployed',
+          reason: 'CommitsUnsynced',
+          status: 'False',
+          type: 'AllComponentsDeployed',
+        },
+      ],
+      gitopsDeployments: [
+        {
+          componentName: 'test-nodeapp',
+          gitopsDeployment:
+            'test-application-development-binding-8h9wl-test-application-development-test-nodeapp',
+        },
+      ],
+      gitopsRepoConditions: [
+        {
+          lastTransitionTime: '2022-11-09T17:33:47Z',
+          message: 'GitOps repository sync successful',
+          reason: 'OK',
+          status: 'True',
+          type: 'GitOpsResourcesGenerated',
+        },
+      ],
+    },
+  },
+  {
+    apiVersion: 'appstudio.redhat.com/v1alpha1',
+    kind: 'SnapshotEnvironmentBinding',
+    metadata: {
+      generateName: 'test-application-development-binding-',
+      resourceVersion: '199299',
+      name: 'test-application-development-binding-8h9wl',
+      uid: 'ddc191ed-aa42-43d5-9820-826ae24601ad',
+      creationTimestamp: '2022-11-09T17:33:45Z',
+      generation: 1,
+      namespace: 'test-namespace',
+      labels: {
+        'appstudio.application': 'test-application',
+        'appstudio.environment': 'development',
+      },
+    },
+    spec: {
+      application: 'test-application',
+      components: [
+        {
+          configuration: {
+            replicas: 1,
+            env: [],
+          },
+          name: 'test-nodeapp',
+        },
+      ],
+      environment: 'production',
+      snapshot: 'test-application-dgkqg',
+    },
+    status: {
+      components: [
+        {
+          gitopsRepository: {
+            branch: 'main',
+            commitID: '95598ffacde7586c92a1eecf7c813080b8a9a1c8\n',
+            generatedResources: ['deployment-patch.yaml'],
+            path: 'components/test-nodeapp/overlays/production',
+            url: 'https://github.com/HACbs-ui-org/test-application-jephilli-define-laugh',
+          },
+          name: 'test-nodeapp',
+        },
+      ],
+      bindingConditions: [
+        {
+          lastTransitionTime: '2023-01-24T09:31:03Z',
+          message:
+            'SnapshotEventBinding Component status is required to generate GitOps deployment, waiting for the Application Service controller to finish reconciling',
+          binding: 'test-app-2-development-binding-w7f2z',
+          reason: 'ErrorOccurred',
+          status: 'True',
+          type: 'ErrorOccurred',
+        },
+      ],
+
+      componentDeploymentConditions: [
+        {
+          lastTransitionTime: '2023-01-24T09:31:34Z',
+          message: '1 of 1 components deployed',
+          reason: 'CommitsUnsynced',
+          status: 'False',
+          type: 'ErrorOccurred',
         },
       ],
       gitopsDeployments: [

--- a/src/components/ApplicationDetails/tabs/overview/visualization/hooks/__tests__/useCommitWorkflowData.spec.ts
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/hooks/__tests__/useCommitWorkflowData.spec.ts
@@ -7,6 +7,7 @@ import { useEnvironments } from '../../../../../../../hooks/useEnvironments';
 import { useIntegrationTestScenarios } from '../../../../../../../hooks/useIntegrationTestScenarios';
 import { useReleasePlans } from '../../../../../../../hooks/useReleasePlans';
 import { useReleases } from '../../../../../../../hooks/useReleases';
+import { useSnapshots } from '../../../../../../../hooks/useSnapshots';
 import { useSnapshotsEnvironmentBindings } from '../../../../../../../hooks/useSnapshotsEnvironmentBindings';
 import { useTestPipelines } from '../../../../../../../hooks/useTestPipelines';
 import { createCommitObjectFromPLR } from '../../../../../../../utils/commits-utils';
@@ -58,6 +59,10 @@ jest.mock('../../../../../../../hooks/useSnapshotsEnvironmentBindings', () => ({
   useSnapshotsEnvironmentBindings: jest.fn(),
 }));
 
+jest.mock('../../../../../../../hooks/useSnapshots', () => ({
+  useSnapshots: jest.fn(),
+}));
+
 jest.mock('@openshift/dynamic-plugin-sdk', () => ({
   useFeatureFlag: jest.fn(),
 }));
@@ -71,6 +76,7 @@ const useReleasesMock = useReleases as jest.Mock;
 const useReleasePlansMock = useReleasePlans as jest.Mock;
 const useTestPipelinesMock = useTestPipelines as jest.Mock;
 const useSnapshotsEnvironmentBindingsMock = useSnapshotsEnvironmentBindings as jest.Mock;
+const useSnapshotsMock = useSnapshots as jest.Mock;
 const useFeatureFlagMock = useFeatureFlag as jest.Mock;
 
 describe('useCommitWorkflowData hook', () => {
@@ -84,6 +90,7 @@ describe('useCommitWorkflowData hook', () => {
     useReleasesMock.mockReturnValue([sampleReleases, true]);
     useTestPipelinesMock.mockReturnValue([[sampleTestPipelines[0]], true]);
     useSnapshotsEnvironmentBindingsMock.mockReturnValue([sampleSnapshotsEnvironmentBindings, true]);
+    useSnapshotsMock.mockReturnValue([[], true]);
     useFeatureFlagMock.mockReturnValue([false]);
 
     const createElement = document.createElement.bind(document);

--- a/src/consts/pipelinerun.ts
+++ b/src/consts/pipelinerun.ts
@@ -20,6 +20,7 @@ export enum PipelineRunLabel {
   PULL_REQUEST_NUMBER_LABEL = 'pipelinesascode.tekton.dev/pull-request',
 
   TEST_SERVICE_COMMIT = 'pac.test.appstudio.openshift.io/sha',
+  TEST_SERVICE_EVENT_TYPE_LABEL = 'pac.test.appstudio.openshift.io/event-type',
   TEST_SERVICE_SCENARIO = 'test.appstudio.openshift.io/scenario',
   ASEB_APPLICATION = 'appstudio.application',
 }

--- a/src/hacbs/components/Environment/__data__/mockAppEnvWithHealthStatus.ts
+++ b/src/hacbs/components/Environment/__data__/mockAppEnvWithHealthStatus.ts
@@ -108,4 +108,21 @@ export const mockAppEnvWithHealthStatus = [
     },
     healthStatus: 'Missing',
   },
+  {
+    apiVersion: 'appstudio.redhat.com/v1alpha1',
+    kind: 'Environment',
+    metadata: {
+      creationTimestamp: '2022-09-15T18:08:46Z',
+      name: 'sre-env',
+      namespace: 'test-namespace',
+      resourceVersion: '1090588522',
+      uid: '76a54ef3-f655-4fda-ab30-dc2348ca250d',
+    },
+    spec: {
+      deploymentStrategy: 'Manual',
+      displayName: 'SRE environment',
+      type: 'poc',
+    },
+    healthStatus: 'Healthy',
+  },
 ];

--- a/src/hacbs/components/Environment/__tests__/EnvironmentCard.spec.tsx
+++ b/src/hacbs/components/Environment/__tests__/EnvironmentCard.spec.tsx
@@ -48,5 +48,19 @@ describe('', () => {
     expect(screen.getByText(testEnv.metadata.name)).toBeVisible();
     expect(screen.queryByText(testEnv.spec.displayName)).toBeNull();
   });
+
+  it('should render Application Healthy card in the list view', () => {
+    const env = {
+      ...testEnv,
+      spec: {
+        ...testEnv.spec,
+        displayName: undefined,
+      },
+      healthStatus: 'Healthy',
+    };
+    render(<EnvironmentCard environment={env} applicationName="test" />);
+    expect(screen.getByText('Manual')).toBeVisible();
+    expect(screen.getByText('Application Healthy')).toBeVisible();
+  });
 });
 EnvironmentCard;

--- a/src/hacbs/components/Environment/__tests__/EnvironmentListView.spec.tsx
+++ b/src/hacbs/components/Environment/__tests__/EnvironmentListView.spec.tsx
@@ -146,7 +146,7 @@ describe('EnvironmentListView', () => {
 
     cleanup();
     render(<EnvironmentListView validTypes={[EnvironmentType.static]} />);
-    expect(screen.getAllByTestId('environment-card')).toHaveLength(3);
+    expect(screen.getAllByTestId('environment-card')).toHaveLength(4);
 
     cleanup();
     render(<EnvironmentListView validTypes={[EnvironmentType.managed]} />);
@@ -160,12 +160,12 @@ describe('EnvironmentListView', () => {
     render(
       <EnvironmentListView validTypes={[EnvironmentType.static, EnvironmentType.ephemeral]} />,
     );
-    expect(screen.getAllByTestId('environment-card')).toHaveLength(3);
+    expect(screen.getAllByTestId('environment-card')).toHaveLength(4);
   });
 
   it('should filter cards by type', async () => {
     render(<EnvironmentListView />);
-    expect(screen.getAllByTestId('environment-card')).toHaveLength(3);
+    expect(screen.getAllByTestId('environment-card')).toHaveLength(4);
 
     // interact with filters
     const filterMenuButton = screen.getByRole('button', { name: /filter/i });
@@ -174,19 +174,19 @@ describe('EnvironmentListView', () => {
     const staticCb = screen.getByLabelText(/Static/i, { selector: 'input' }) as HTMLInputElement;
     fireEvent.click(staticCb);
     expect(staticCb.checked).toBe(true);
-    expect(screen.getAllByTestId('environment-card')).toHaveLength(3);
+    expect(screen.getAllByTestId('environment-card')).toHaveLength(4);
 
     const managedCb = screen.getByLabelText(/Managed/i, { selector: 'input' }) as HTMLInputElement;
     fireEvent.click(managedCb);
     expect(managedCb.checked).toBe(true);
-    expect(screen.getAllByTestId('environment-card')).toHaveLength(3);
+    expect(screen.getAllByTestId('environment-card')).toHaveLength(4);
 
     const ephemeralCb = screen.getByLabelText(/Ephemeral/i, {
       selector: 'input',
     }) as HTMLInputElement;
     fireEvent.click(ephemeralCb);
     expect(ephemeralCb.checked).toBe(true);
-    expect(screen.getAllByTestId('environment-card')).toHaveLength(3);
+    expect(screen.getAllByTestId('environment-card')).toHaveLength(4);
 
     // filter only some of the envs
     fireEvent.click(staticCb);
@@ -196,12 +196,12 @@ describe('EnvironmentListView', () => {
     // clear the filter
     const clearFilterButton = screen.getAllByRole('button', { name: 'Clear filters' })[1];
     fireEvent.click(clearFilterButton);
-    expect(screen.getAllByTestId('environment-card')).toHaveLength(3);
+    expect(screen.getAllByTestId('environment-card')).toHaveLength(4);
   });
 
   it('should filter cards by name', () => {
     render(<EnvironmentListView />);
-    expect(screen.getAllByTestId('environment-card')).toHaveLength(3);
+    expect(screen.getAllByTestId('environment-card')).toHaveLength(4);
 
     const textFilterInput = screen.getByRole('textbox', { name: 'name filter' });
     fireEvent.change(textFilterInput, { target: { value: 'd' } });
@@ -212,7 +212,7 @@ describe('EnvironmentListView', () => {
 
   it('should clear filters from empty state', () => {
     render(<EnvironmentListView />);
-    expect(screen.getAllByTestId('environment-card')).toHaveLength(3);
+    expect(screen.getAllByTestId('environment-card')).toHaveLength(4);
 
     const textFilterInput = screen.getByRole('textbox', { name: 'name filter' });
     fireEvent.change(textFilterInput, { target: { value: 'no match' } });
@@ -221,12 +221,12 @@ describe('EnvironmentListView', () => {
 
     const clearFilterButton = screen.getByRole('button', { name: 'Clear all filters' });
     fireEvent.click(clearFilterButton);
-    expect(screen.getAllByTestId('environment-card')).toHaveLength(3);
+    expect(screen.getAllByTestId('environment-card')).toHaveLength(4);
   });
 
   it('should filter cards by status', async () => {
     render(<EnvironmentListView applicationName="application-to-test" />);
-    expect(screen.getAllByTestId('environment-card')).toHaveLength(3);
+    expect(screen.getAllByTestId('environment-card')).toHaveLength(4);
 
     // interact with filters
     const filterMenuButton = screen.getByRole('button', { name: /filter/i });
@@ -251,6 +251,18 @@ describe('EnvironmentListView', () => {
     // clear the filter
     const clearFilterButton = screen.getAllByRole('button', { name: 'Clear filters' })[1];
     fireEvent.click(clearFilterButton);
-    await expect(screen.getAllByTestId('environment-card')).toHaveLength(3);
+    await expect(screen.getAllByTestId('environment-card')).toHaveLength(4);
+  });
+
+  it('should contain Healthy application status', () => {
+    useAllEnvironmentsMock.mockReturnValue([mockAppEnvWithHealthStatus, true]);
+    render(<EnvironmentListView applicationName="test" />);
+    screen.getByText('Application Healthy');
+  });
+
+  it('should contain application Missing status', () => {
+    useAllEnvironmentsMock.mockReturnValue([[mockAppEnvWithHealthStatus[0]], true]);
+    render(<EnvironmentListView applicationName="test" />);
+    screen.queryByText('Application Missing');
   });
 });

--- a/src/hooks/useSnapshots.ts
+++ b/src/hooks/useSnapshots.ts
@@ -1,0 +1,16 @@
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { PipelineRunLabel } from '../consts/pipelinerun';
+import { SnapshotGroupVersionKind } from '../models';
+import { Snapshot } from '../types/coreBuildService';
+
+export const useSnapshots = (namespace: string, commit?: string): [Snapshot[], boolean, unknown] =>
+  useK8sWatchResource<Snapshot[]>({
+    groupVersionKind: SnapshotGroupVersionKind,
+    namespace,
+    selector: {
+      matchLabels: {
+        ...(commit && { [PipelineRunLabel.TEST_SERVICE_COMMIT]: commit }),
+      },
+    },
+    isList: true,
+  });

--- a/src/types/coreBuildService.ts
+++ b/src/types/coreBuildService.ts
@@ -99,11 +99,51 @@ export type component = {
   configuration: Configuration;
 };
 
+export type Snapshot = K8sResourceCommon & {
+  spec: {
+    application: string;
+    displayName?: string;
+    displayDescription?: string;
+    components: {
+      containerImage: string;
+      name: string;
+    }[];
+    artifacts?: {
+      [key: string]: unknown;
+    };
+  };
+  status?: {
+    conditions: Condition[];
+  };
+};
+export interface GitopsRepository {
+  branch: string;
+  commitID: string;
+  generatedResources: string[];
+  path: string;
+  url: string;
+}
+
+export interface GitopsDeployment {
+  componentName: string;
+  gitopsDeployment: string;
+}
+
 export type SnapshotEnvironmentBinding = K8sResourceCommon & {
   spec: {
     application: string;
     components: component[];
     environment: string;
     snapshot: string;
+  };
+  status?: {
+    bindingConditions: Condition[];
+    componentDeploymentConditions: Condition[];
+    components: {
+      gitopsRepository: GitopsRepository;
+      name: string;
+    }[];
+    gitopsDeployments: GitopsDeployment[];
+    gitopsRepoConditions: Condition[];
   };
 };

--- a/src/types/coreBuildService.ts
+++ b/src/types/coreBuildService.ts
@@ -53,11 +53,6 @@ export type Env = {
   value: string;
 };
 
-export type SnapshotEnvironmentBindingKind = K8sResourceCommon & {
-  spec: ReleaseSpec;
-  status: ReleaseStatus;
-};
-
 export type ReleaseKind = K8sResourceCommon & {
   spec: ReleaseSpec;
   status: ReleaseStatus;

--- a/src/types/pipeline-run.ts
+++ b/src/types/pipeline-run.ts
@@ -87,6 +87,7 @@ export type Condition = {
   status: string;
   reason?: string;
   message?: string;
+  binding?: string;
   lastTransitionTime?: string;
 };
 

--- a/src/utils/__tests__/environment-utils.spec.ts
+++ b/src/utils/__tests__/environment-utils.spec.ts
@@ -1,5 +1,12 @@
+import { RunStatus } from '@patternfly/react-topology';
+import { mockSnapshotsEnvironmentBindings } from '../../components/ApplicationDetails/tabs/overview/sections/__data__';
 import { EnvironmentKind } from '../../types';
-import { sortEnvironmentsBasedonParent } from '../environment-utils';
+import { GitOpsDeploymentHealthStatus } from '../../types/gitops-deployment';
+import {
+  getComponentDeploymentRunStatus,
+  getComponentDeploymentStatus,
+  sortEnvironmentsBasedonParent,
+} from '../environment-utils';
 
 describe('environment-utils', () => {
   const a = {
@@ -117,5 +124,55 @@ describe('environment-utils', () => {
       cb,
       ac,
     ]);
+  });
+
+  describe('getComponentDeploymentStatus', () => {
+    it('should return Missing status for SEB without status', () => {
+      expect(
+        getComponentDeploymentStatus({ ...mockSnapshotsEnvironmentBindings[0], status: undefined }),
+      ).toBe(GitOpsDeploymentHealthStatus.Missing);
+    });
+
+    it('should return Progressing status for SEB with progressing status', () => {
+      expect(
+        getComponentDeploymentStatus({
+          ...mockSnapshotsEnvironmentBindings[1],
+        }),
+      ).toBe(GitOpsDeploymentHealthStatus.Progressing);
+    });
+
+    it('should return Healthy status', () => {
+      expect(getComponentDeploymentStatus(mockSnapshotsEnvironmentBindings[0])).toBe(
+        GitOpsDeploymentHealthStatus.Healthy,
+      );
+    });
+
+    it('should return Degraded status', () => {
+      expect(getComponentDeploymentStatus(mockSnapshotsEnvironmentBindings[2])).toBe(
+        GitOpsDeploymentHealthStatus.Degraded,
+      );
+    });
+  });
+
+  describe('getComponentDeploymentRunStatus', () => {
+    it('should return Pending status for SEB without status', () => {
+      const missingApplication = { ...mockSnapshotsEnvironmentBindings[0], status: undefined };
+      expect(getComponentDeploymentRunStatus(missingApplication)).toBe(RunStatus.Pending);
+    });
+
+    it('should return Running status for progressing application', () => {
+      const progressingApplication = mockSnapshotsEnvironmentBindings[1];
+      expect(getComponentDeploymentRunStatus(progressingApplication)).toBe(RunStatus.Running);
+    });
+
+    it('should return Succeeded status for healthy application', () => {
+      const healthyApplication = mockSnapshotsEnvironmentBindings[0];
+      expect(getComponentDeploymentRunStatus(healthyApplication)).toBe(RunStatus.Succeeded);
+    });
+
+    it('should return Succeeded status for healthy application', () => {
+      const degradedApplication = mockSnapshotsEnvironmentBindings[2];
+      expect(getComponentDeploymentRunStatus(degradedApplication)).toBe(RunStatus.Failed);
+    });
   });
 });

--- a/src/utils/environment-utils.ts
+++ b/src/utils/environment-utils.ts
@@ -1,4 +1,7 @@
+import { RunStatus } from '@patternfly/react-topology';
 import { EnvironmentKind } from '../types';
+import { SnapshotEnvironmentBinding } from '../types/coreBuildService';
+import { GitOpsDeploymentHealthStatus } from '../types/gitops-deployment';
 
 export enum EnvironmentDeploymentStrategy {
   AppStudioAutomated = 'Automatic',
@@ -79,4 +82,40 @@ export const sortEnvironmentsBasedonParent = (
   const positionedEnvs = environments.filter((env) => isPositionedEnvironment(env, environments));
   insertPositionedEnvironments(positionedEnvs, sortedEnvs);
   return sortedEnvs;
+};
+
+export const getComponentDeploymentStatus = (
+  snapshotEnvironmentBinding: SnapshotEnvironmentBinding,
+): GitOpsDeploymentHealthStatus => {
+  if (!snapshotEnvironmentBinding || !snapshotEnvironmentBinding.status) {
+    return GitOpsDeploymentHealthStatus.Missing;
+  }
+  const allcomponentsDeployed =
+    snapshotEnvironmentBinding?.status?.componentDeploymentConditions?.some(
+      (c) =>
+        c.reason === 'CommitsSynced' && c.status === 'True' && c.type === 'AllComponentsDeployed',
+    );
+
+  if (allcomponentsDeployed) {
+    return GitOpsDeploymentHealthStatus.Healthy;
+  }
+
+  return GitOpsDeploymentHealthStatus.Progressing;
+};
+
+export const getComponentDeploymentRunStatus = (
+  snapshotEnvironmentBinding: SnapshotEnvironmentBinding,
+): RunStatus => {
+  const status = getComponentDeploymentStatus(snapshotEnvironmentBinding);
+
+  switch (status) {
+    case GitOpsDeploymentHealthStatus.Healthy:
+      return RunStatus.Succeeded;
+    case GitOpsDeploymentHealthStatus.Progressing:
+      return RunStatus.Running;
+    case GitOpsDeploymentHealthStatus.Degraded:
+      return RunStatus.Failed;
+    default:
+      return RunStatus.Pending;
+  }
 };

--- a/src/utils/environment-utils.ts
+++ b/src/utils/environment-utils.ts
@@ -89,7 +89,14 @@ export const getComponentDeploymentStatus = (
 ): GitOpsDeploymentHealthStatus => {
   if (!snapshotEnvironmentBinding || !snapshotEnvironmentBinding.status) {
     return GitOpsDeploymentHealthStatus.Missing;
+  } else if (
+    snapshotEnvironmentBinding?.status?.componentDeploymentConditions?.some(
+      (c) => c.type === 'ErrorOccurred',
+    )
+  ) {
+    return GitOpsDeploymentHealthStatus.Degraded;
   }
+
   const allcomponentsDeployed =
     snapshotEnvironmentBinding?.status?.componentDeploymentConditions?.some(
       (c) =>


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-2935

https://issues.redhat.com/browse/HAC-2978

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Environment Card, lifecycle and commit visualization always showing Application Missing/Pending status.

**RCA:** 

Snapshot fetching logic was based on the integration test pipelineruns, since we will not use any integration tests for mvp, the snapshot + environment map was always resulting in "Application Missing" state as there are not test pipelineruns.

**Solution**:

Removed the logic for fetching the snapshot from the test pipelineruns, and now we have the commit labels available in the snapshot, so directly use commit label to query the latest snapshot (for commit Visualization) and for lifecycle, environment cards we are now relying on SEB's `componentDeploymentConditions` to determine the overall application status.




## Type of change
<!-- Please delete options that are not relevant. -->


- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

**Before**:

![image-2023-01-19-16-47-10-602](https://user-images.githubusercontent.com/9964343/214292950-82f7b931-6b41-44b7-a37f-798cbd231828.png)

---

**After:**

**Environment list:**

<img width="649" alt="Screenshot 2023-01-24 at 3 02 58 PM" src="https://user-images.githubusercontent.com/9964343/214292707-90bba0a0-b595-4a3f-accf-0bda01b46cdf.png">

**Lifecycle graph:**

<img width="1464" alt="Screenshot 2023-01-24 at 3 03 17 PM" src="https://user-images.githubusercontent.com/9964343/214292714-0fad1dda-11d7-417d-99c5-6b987cd33b8e.png">

**commit graph:**

<img width="730" alt="Screenshot 2023-01-24 at 3 46 11 PM" src="https://user-images.githubusercontent.com/9964343/214292718-2c8e5212-db92-41fd-b232-f648423f2ab8.png">

## Unit tests:


```
environment-utils.spec.ts

    getComponentDeploymentStatus
      ✓ should return Missing status for SEB without status
      ✓ should return Progressing status for SEB with progressing status
      ✓ should return Healthy status
      ✓ should return Degraded status
    getComponentDeploymentRunStatus
      ✓ should return Pending status for SEB without status (1 ms)
      ✓ should return Running status for progressing application
      ✓ should return Succeeded status for healthy application
      ✓ should return Succeeded status for healthy application
```
```
EnvironmentCard.spec.tsx
 ✓ should render Application Healthy card in the list view (43 ms)
```

```
  EnvironmentListView.spec.tsx
    ✓ should contain Healthy application status (28 ms)
    ✓ should contain application Missing status (14 ms)
```

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

1. Go through App import flow and at the end the deployment status should be reflecting in the environment cards and graphs.


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


cc: @christianvogt 
