### PR TITLE
Fix navigation for activity page tab items

### DIFF
--- a/config/remotePlugin.js
+++ b/config/remotePlugin.js
@@ -180,6 +180,32 @@ module.exports = {
     {
       type: 'console.page/route',
       properties: {
+        path: '/stonesoup/:appName/commit/:commitName/:activeTab',
+        exact: true,
+        component: {
+          $codeRef: 'CommitsPage',
+        },
+      },
+      flags: {
+        required: ['HACBS', 'SIGNUP'],
+      },
+    },
+    {
+      type: 'core.page/route',
+      properties: {
+        path: '/stonesoup/:appName/commit/:commitName/:activeTab',
+        exact: true,
+        component: {
+          $codeRef: 'CommitsPage',
+        },
+      },
+      flags: {
+        required: ['HACBS', 'SIGNUP'],
+      },
+    },
+    {
+      type: 'console.page/route',
+      properties: {
         path: '/stonesoup/:appName/integrationtests/:testName',
         exact: true,
         component: {
@@ -298,6 +324,32 @@ module.exports = {
       type: 'core.page/route',
       properties: {
         path: '/stonesoup/applications/:appName/:activeTab',
+        exact: true,
+        component: {
+          $codeRef: 'ApplicationDetails',
+        },
+      },
+      flags: {
+        required: ['SIGNUP'],
+      },
+    },
+    {
+      type: 'console.page/route',
+      properties: {
+        path: '/stonesoup/applications/:appName/:activeTab/:activity',
+        exact: true,
+        component: {
+          $codeRef: 'ApplicationDetails',
+        },
+      },
+      flags: {
+        required: ['SIGNUP'],
+      },
+    },
+    {
+      type: 'core.page/route',
+      properties: {
+        path: '/stonesoup/applications/:appName/:activeTab/:activity',
         exact: true,
         component: {
           $codeRef: 'ApplicationDetails',
@@ -403,6 +455,34 @@ module.exports = {
       type: 'core.page/route',
       properties: {
         path: '/stonesoup/workspace-settings',
+        exact: true,
+        component: {
+          $codeRef: 'WorkspaceSettings',
+        },
+      },
+      flags: {
+        required: ['SIGNUP'],
+        disallowed: ['MVP'],
+      },
+    },
+    {
+      type: 'console.page/route',
+      properties: {
+        path: '/stonesoup/workspace-settings/:activeTab',
+        exact: true,
+        component: {
+          $codeRef: 'WorkspaceSettings',
+        },
+      },
+      flags: {
+        required: ['SIGNUP'],
+        disallowed: ['MVP'],
+      },
+    },
+    {
+      type: 'core.page/route',
+      properties: {
+        path: '/stonesoup/workspace-settings/:activeTab',
         exact: true,
         component: {
           $codeRef: 'WorkspaceSettings',

--- a/src/components/Activity/ActivityTab.tsx
+++ b/src/components/Activity/ActivityTab.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import { Tab, Tabs, TabTitleText, Title } from '@patternfly/react-core';
 import CommitsTab from '../ApplicationDetails/tabs/CommitsTab';
 import PipelineRunsTab from '../ApplicationDetails/tabs/PipelineRunsTab';
@@ -6,7 +7,19 @@ import PipelineRunsTab from '../ApplicationDetails/tabs/PipelineRunsTab';
 import './ActivityTab.scss';
 
 export const ActivityTab: React.FC<{ applicationName?: string }> = ({ applicationName }) => {
-  const [activeTab, setActiveTab] = React.useState('latest-commits');
+  const params = useParams();
+  const { activeTab: parentTab, activity: activeTab } = params;
+
+  const navigate = useNavigate();
+  const setActiveTab = React.useCallback(
+    (newTab: string) => {
+      if (activeTab !== newTab) {
+        navigate(`/stonesoup/applications/${applicationName}/${parentTab}/${newTab}`);
+      }
+    },
+    [applicationName, activeTab, navigate, parentTab],
+  );
+
   return (
     <>
       <Title size="xl" headingLevel="h3" className="pf-c-title pf-u-mt-lg pf-u-mb-sm">
@@ -17,13 +30,14 @@ export const ActivityTab: React.FC<{ applicationName?: string }> = ({ applicatio
           width: 'fit-content',
           marginBottom: 'var(--pf-global--spacer--md)',
         }}
-        activeKey={activeTab}
+        activeKey={activeTab || 'latest-commits'}
         onSelect={(_, k: string) => {
           setActiveTab(k);
         }}
         unmountOnExit
       >
         <Tab
+          data-testid={`activity__tabItem latest-commits`}
           title={<TabTitleText>Latest commits</TabTitleText>}
           key="latest-commits"
           eventKey="latest-commits"
@@ -32,6 +46,7 @@ export const ActivityTab: React.FC<{ applicationName?: string }> = ({ applicatio
           <CommitsTab applicationName={applicationName} />
         </Tab>
         <Tab
+          data-testid={`activity__tabItem pipelineruns`}
           title={<TabTitleText>Pipeline runs</TabTitleText>}
           key="pipelineruns"
           eventKey="pipelineruns"

--- a/src/components/Activity/__tests__/ActivityTab.spec.tsx
+++ b/src/components/Activity/__tests__/ActivityTab.spec.tsx
@@ -1,20 +1,52 @@
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { useNavigate } from 'react-router-dom';
+import { act, fireEvent, screen } from '@testing-library/react';
+import { routerRenderer } from '../../../utils/test-utils';
 import { ActivityTab } from '../ActivityTab';
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   useK8sWatchResource: () => [[], false],
 }));
 
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: jest.fn(),
+  };
+});
+
+const useNavigateMock = useNavigate as jest.Mock;
+
 describe('Activity Tab', () => {
+  let navigateMock;
+
+  beforeEach(() => {
+    navigateMock = jest.fn();
+    useNavigateMock.mockImplementation(() => navigateMock);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should render Activity Tab', () => {
-    render(<ActivityTab applicationName="abcd" />);
+    routerRenderer(<ActivityTab applicationName="abcd" />);
     screen.getByText('Activity By');
   });
 
-  it('should render two tabs under activity', () => {
-    render(<ActivityTab applicationName="abcd" />);
+  it('should render two tabs under activity', async () => {
+    routerRenderer(<ActivityTab applicationName="abcd" />);
     screen.getByText('Latest commits');
     screen.getByText('Pipeline runs');
+
+    const plrTab = screen.getByTestId('activity__tabItem pipelineruns');
+
+    await act(async () => {
+      fireEvent.click(plrTab);
+    });
+    expect(navigateMock).toHaveBeenCalledWith(
+      '/stonesoup/applications/abcd/undefined/pipelineruns',
+    );
   });
 });

--- a/src/components/ApplicationDetails/tabs/overview/visualization/utils/node-utils.ts
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/utils/node-utils.ts
@@ -143,7 +143,7 @@ export const getLinksForElement = (
 
   return {
     elementRef: linkData.path ? linkData.path : `${appPath}${tabPath}${filter}`,
-    pipelinesRef: `${appPath}/pipelineruns`,
+    pipelinesRef: `${appPath}/activity/pipelineruns`,
   };
 };
 

--- a/src/components/Commits/CommitsListView.tsx
+++ b/src/components/Commits/CommitsListView.tsx
@@ -184,7 +184,9 @@ const CommitsListView: React.FC<CommitsListViewProps> = ({
         <Button
           className="pf-u-mt-md"
           variant="secondary"
-          onClick={() => navigate(`/stonesoup/applications/${applicationName}/activity`)}
+          onClick={() =>
+            navigate(`/stonesoup/applications/${applicationName}/activity/latest-commits`)
+          }
         >
           View More
         </Button>

--- a/src/components/Commits/__tests__/CommitsListView.spec.tsx
+++ b/src/components/Commits/__tests__/CommitsListView.spec.tsx
@@ -54,11 +54,13 @@ describe('CommitsListView', () => {
     expect(screen.queryByText('Recent commits')).toBeInTheDocument();
   });
 
-  it('should navigate to activiy tab', () => {
+  it('should navigate to activity tab', () => {
     const navigate = jest.fn();
     mockNavigate.mockImplementation(() => navigate);
     render(<CommitsListView commits={commits} applicationName="purple-mermaid-app" recentOnly />);
     fireEvent.click(screen.getByText('View More'));
-    expect(navigate).toHaveBeenCalledWith(`/stonesoup/applications/purple-mermaid-app/activity`);
+    expect(navigate).toHaveBeenCalledWith(
+      `/stonesoup/applications/purple-mermaid-app/activity/latest-commits`,
+    );
   });
 });

--- a/src/components/ComponentSettingsForm/ComponentSettingsForm.tsx
+++ b/src/components/ComponentSettingsForm/ComponentSettingsForm.tsx
@@ -40,7 +40,7 @@ const ComponentSettingsForm: React.FunctionComponent<FormikProps<FormikValues>> 
           name: startCase(components[0].componentStub.application),
         },
         {
-          path: `/stonesoup/applications/${components[0].componentStub.application}?activeTab=components`,
+          path: `/stonesoup/applications/${components[0].componentStub.application}/components`,
           name: components[0].componentStub.componentName,
         },
         { path: '#', name: 'Component settings' },

--- a/src/components/PipelineRunDetailsView/PipelineRunDetailsView.tsx
+++ b/src/components/PipelineRunDetailsView/PipelineRunDetailsView.tsx
@@ -55,7 +55,7 @@ export const PipelineRunDetailsView: React.FC<PipelineRunDetailsViewProps> = ({
               name: applicationName,
             },
             {
-              path: `/stonesoup/applications/${applicationName}/pipelineruns`,
+              path: `/stonesoup/applications/${applicationName}/activity/pipelineruns`,
               name: 'Pipeline runs',
             },
             {

--- a/src/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
@@ -128,7 +128,7 @@ const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({ pipelineR
                           component={(props) => (
                             <Link
                               {...props}
-                              to={`/stonesoup/pipelineruns/${pipelineRun.metadata?.name}?activeTab=logs`}
+                              to={`/stonesoup/pipelineruns/${pipelineRun.metadata?.name}/logs`}
                             />
                           )}
                         >

--- a/src/components/WorkspaceSettings/WorkspaceSettings.tsx
+++ b/src/components/WorkspaceSettings/WorkspaceSettings.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import {
   Flex,
   FlexItem,
@@ -64,33 +64,18 @@ const WorkspaceSettings: React.FC<WorkspaceSettingsProps> = ({
   tabs,
 }) => {
   useQuickstartCloseOnUnmount();
-  const [searchParams, setSearchParams] = useSearchParams();
-  const activeTab = searchParams.get('activeTab');
-  const tabMatched =
-    activeTab === ENVIRONMENTS_TAB_KEY
-      ? ENVIRONMENTS_TAB_KEY
-      : tabs?.find((t) => t.key === activeTab)?.key;
+  const navigate = useNavigate();
+  const params = useParams();
+  const { activeTab } = params;
 
   const setActiveTab = React.useCallback(
-    (tab: string, replace = false) => {
-      if ((activeTab || ENVIRONMENTS_TAB_KEY) !== tab) {
-        const params = new URLSearchParams();
-        params.set('activeTab', tab);
-        setSearchParams(params, { replace });
+    (newTab: string) => {
+      if (activeTab !== newTab) {
+        navigate(`/stonesoup/workspace-settings/${newTab}`);
       }
     },
-    [setSearchParams, activeTab],
+    [activeTab, navigate],
   );
-
-  React.useEffect(() => {
-    if (!tabMatched) {
-      setSearchParams(new URLSearchParams(), { replace: true });
-    } else {
-      setActiveTab(tabMatched, true);
-    }
-    // Only run once
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const environments = (
     <>


### PR DESCRIPTION
## Fixes 
Fixes [HAC-2994](https://issues.redhat.com/browse/HAC-2994)
Fixes [HAC-2995](https://issues.redhat.com/browse/HAC-2995)
Fixes [HAC-3013](https://issues.redhat.com/browse/HAC-3013)
Fixes [HAC-3026](https://issues.redhat.com/browse/HAC-3026)

## Description
Fixes navigation to items moved into the Activity page tabs.
Updates the activity page to use the URL for active tab path rather than state.
Update workspace settings page to use URL path rather than search params for active tab

## Type of change
- [x] Bugfix

