### PR TITLE
add plr results to details page

### DIFF
--- a/src/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
@@ -11,6 +11,7 @@ import {
   Flex,
   FlexItem,
   Title,
+  Divider,
 } from '@patternfly/react-core';
 import { PipelineRunLabel } from '../../../consts/pipelinerun';
 import { pipelineRunFilterReducer } from '../../../shared';
@@ -25,6 +26,7 @@ import { calculateDuration } from '../../../utils/pipeline-utils';
 import MetadataList from '../MetadataList';
 import PipelineRunVisualization from '../PipelineRunVisualization';
 import RelatedPipelineRuns from '../RelatedPipelineRuns';
+import RunResultsList from './RunResultsList';
 
 type PipelineRunDetailsTabProps = {
   pipelineRun: PipelineRunKind;
@@ -42,6 +44,7 @@ const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({ pipelineR
     pipelineRun?.metadata?.labels[PipelineRunLabel.COMMIT_LABEL] ||
     pipelineRun?.metadata?.labels[PipelineRunLabel.TEST_SERVICE_COMMIT];
 
+  const pipelineRunStatus = !error ? pipelineRunFilterReducer(pipelineRun) : null;
   return (
     <>
       <Title headingLevel="h4" className="pf-c-title pf-u-mt-lg pf-u-mb-lg" size="lg">
@@ -107,7 +110,7 @@ const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({ pipelineR
                 <DescriptionListGroup>
                   <DescriptionListTerm>Status</DescriptionListTerm>
                   <DescriptionListDescription>
-                    <StatusIconWithText status={pipelineRunFilterReducer(pipelineRun)} />
+                    <StatusIconWithText status={pipelineRunStatus} />
                   </DescriptionListDescription>
                 </DescriptionListGroup>
                 {Object.keys(pipelineRunFailed).length > 0 && (
@@ -235,6 +238,15 @@ const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({ pipelineR
               </DescriptionList>
             </FlexItem>
           </Flex>
+          {pipelineRun.status?.pipelineResults ? (
+            <>
+              <Divider style={{ padding: 'var(--pf-global--spacer--lg) 0' }} />
+              <RunResultsList
+                results={pipelineRun.status.pipelineResults}
+                status={pipelineRunStatus}
+              />
+            </>
+          ) : null}
         </Flex>
       )}
     </>

--- a/src/components/PipelineRunDetailsView/tabs/RunResultsList.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/RunResultsList.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import {
+  Bullseye,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Title,
+} from '@patternfly/react-core';
+import { TableComposable, Thead, Tbody, Th, Td, Tr } from '@patternfly/react-table';
+import { TektonResultsRun } from '../../../types';
+import { handleURLs } from '../../../utils/render-utils';
+
+type Props = {
+  results: TektonResultsRun[];
+  status: string;
+};
+
+const RunResultsList: React.FC<Props> = ({ results, status }) => (
+  <>
+    <Title headingLevel="h2" size="lg">
+      Results
+    </Title>
+    {status !== 'Failed' ? (
+      <TableComposable aria-label="results">
+        <Thead>
+          <Tr>
+            <Th>Name</Th>
+            <Th>Value</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {results.map(({ name, value }) => (
+            <Tr key={`row-${name}`}>
+              <Td>{name}</Td>
+              <Td>{handleURLs(value)}</Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </TableComposable>
+    ) : (
+      <Bullseye>
+        <EmptyState variant={EmptyStateVariant.full}>
+          <EmptyStateBody>No results available due to failure</EmptyStateBody>
+        </EmptyState>
+      </Bullseye>
+    )}
+  </>
+);
+
+export default RunResultsList;

--- a/src/components/PipelineRunDetailsView/tabs/__tests__/RunResultsList.spec.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/__tests__/RunResultsList.spec.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import RunResultsList from '../RunResultsList';
+
+describe('RunResultsList', () => {
+  it('should render empty state', () => {
+    const renderResult = render(<RunResultsList results={[]} status="Failed" />);
+    const element = renderResult.getByText('No results available due to failure');
+    expect(element).toBeInTheDocument();
+  });
+
+  it('should not render empty state', () => {
+    const renderResult = render(<RunResultsList results={[]} status="Success" />);
+    const element = renderResult.queryByText('No results available due to failure');
+    expect(element).toBeNull();
+  });
+
+  it('should render results', () => {
+    const renderResult = render(
+      <RunResultsList results={[{ name: 'test', value: 'result' }]} status="Success" />,
+    );
+    expect(renderResult.getByText('test')).toBeInTheDocument();
+    expect(renderResult.getByText('result')).toBeInTheDocument();
+  });
+});

--- a/src/utils/__tests__/render-utils.spec.tsx
+++ b/src/utils/__tests__/render-utils.spec.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { handleURLs } from '../render-utils';
+
+describe('handleURLs', () => {
+  it('should return the same value if it is not a string', () => {
+    // We will only likely get strings, but it shouldn't break/NPE if they are not
+    expect(handleURLs(null)).toBe(null);
+    expect(handleURLs(undefined)).toBe(undefined);
+    expect(handleURLs(true as any)).toBe(true);
+    const v = {};
+    expect(handleURLs(v as any)).toBe(v);
+  });
+
+  it('should not do anything if there are no URLs in the string', () => {
+    const stringsWithoutURLs = ['not a URL', 'redhat.com', 'http', '://something.com'];
+    stringsWithoutURLs.forEach((string: string) => {
+      expect(handleURLs(string)).toBe(string);
+    });
+  });
+
+  describe('Test easy URL Examples', () => {
+    const validStringsWithURL: { [testName: string]: string } = {
+      straightURL: 'https://redhat.com',
+      prefixedURL: 'Red Hat website: https://redhat.com',
+      suffixedURL: "https://redhat.com is Red Hat's website",
+      bothPrefixAndSuffixURL: 'This is the company website https://redhat.com for Red Hat',
+    };
+
+    Object.keys(validStringsWithURL).forEach((testName: string) => {
+      const string = validStringsWithURL[testName];
+      it(`should create a link for the URL, test ${testName}`, () => {
+        const reactRendering = handleURLs(string);
+        expect(typeof reactRendering).not.toBe('string');
+        const renderResult = render(<div>{reactRendering}</div>);
+        const link = renderResult.getByRole('link');
+        expect(link.getAttribute('href')).toBe('https://redhat.com');
+        expect(link.textContent).toBe('https://redhat.com');
+      });
+    });
+  });
+
+  describe('Test edge-case URL Examples', () => {
+    it('should create multiple ExternalLinks and not lose the interim prefix/suffix values', () => {
+      const data =
+        'some prefix https://github.com/openshift/console some middle http://example.com some suffix';
+      const result = handleURLs(data);
+      const renderResult = render(<div>{result}</div>);
+      const links = renderResult.getAllByRole('link');
+      expect(links).toHaveLength(2);
+      expect(renderResult.container.textContent).toEqual(data);
+    });
+
+    it('should create multiple ExternalLinks when more than one url is present', () => {
+      const links = [
+        'https://github.com/openshift/console',
+        'https://github.com/openshift/api',
+        'https://github.com/openshift/kubernetes',
+        'https://github.com/openshift/origin',
+        'https://github.com/openshift/release',
+      ];
+      const data = links.join(' '); // join multiple links together with a space (so they are unique urls);
+      const result = handleURLs(data);
+      const renderResult = render(<div>{result}</div>);
+      expect(renderResult.getAllByRole('link')).toHaveLength(links.length);
+    });
+
+    it('should handle escaped URLs (such as googling for a URL)', () => {
+      // Google for 'https://github.com/openshift/console'
+      const data =
+        'https://www.google.com/search?q=https%3A%2F%2Fgithub.com%2Fopenshift%2Fconsole&ei=SO5lYNXrK_Ox5NoPwN-soAw&oq=https%3A%2F%2Fgithub.com%2Fopenshift%2Fconsole&gs_lcp=Cgdnd3Mtd2l6EAM6BwgAEEcQsAM6BwgAELADEEM6DgguEMcBEK8BEJECEJMCOgsILhDHARCvARCRAjoICAAQsQMQgwE6DgguELEDEIMBEMcBEKMCOgUIABCxAzoLCC4QsQMQxwEQowI6AggAOgQIABBDOgcIABCxAxBDOgQIABAKOgYIABAWEB5QlzVYmKYBYJ2nAWgCcAJ4AIABbYgBvBmSAQQzMy40mAEAoAEBqgEHZ3dzLXdpesgBCsABAQ&sclient=gws-wiz&ved=0ahUKEwjVr7S5td3vAhXzGFkFHcAvC8QQ4dUDCA0&uact=5';
+      const result = handleURLs(data);
+      const renderResult = render(<div>{result}</div>);
+      expect(renderResult.getAllByRole('link')).toHaveLength(1);
+    });
+
+    it('should handle redirect wrapper URLs', () => {
+      // Probably not a common case, but some sites wrap all links by a query param at the end of the URL
+      const data = 'https://github.com/openshift?externalLink=https://github.com/openshift/console';
+      const result = handleURLs(data);
+      const renderResult = render(<div>{result}</div>);
+      expect(renderResult.getAllByRole('link')).toHaveLength(1);
+    });
+  });
+});

--- a/src/utils/render-utils.tsx
+++ b/src/utils/render-utils.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import ExternalLink from '../shared/components/links/ExternalLink';
+
+const URL_REGEXP =
+  /https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_+.~#?&/=]*)/;
+export const GROUP_MATCH_REGEXP = new RegExp(`^(.*\\s)?(${URL_REGEXP.source})(\\s.*)?$`, 'i');
+
+export const handleURLs = (value: string): React.ReactNode => {
+  if (typeof value !== 'string') return value;
+
+  const matches = value.match(GROUP_MATCH_REGEXP);
+  const [, prefix, link, suffix] = matches || [];
+
+  if (link) {
+    return (
+      <>
+        {handleURLs(prefix)}
+        <ExternalLink href={link}>{link}</ExternalLink>
+        {handleURLs(suffix)}
+      </>
+    );
+  }
+
+  return value;
+};


### PR DESCRIPTION
## Fixes 
TBD

## Description
Displays a table of the key value pair of results for the pipeline run on the details page.
If a URL is present in the data, it is converted to a link.
For the most part, the code was taken from the developer console.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
When results are present, a new table is shown at the bottom of the page:
![image](https://user-images.githubusercontent.com/14068621/214959364-69f90b7a-c750-4bda-a915-24fe2a70aa9d.png)

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
