### PR TITLE
replace Stonesoup with CI/CD for now in browser titles

### DIFF
--- a/src/components/ApplicationDetails/DetailsPage.tsx
+++ b/src/components/ApplicationDetails/DetailsPage.tsx
@@ -142,7 +142,7 @@ const DetailsPage: React.FC<DetailsPageProps> = ({
 
   return (
     <PageGroup data-test="details">
-      <HeadTitle>{`${headTitle} - ${activeTab?.label} | Stonesoup`}</HeadTitle>
+      <HeadTitle>{`${headTitle} - ${activeTab?.label} | CI/CD`}</HeadTitle>
       <PageSection type="breadcrumb">
         {breadcrumbs && (
           <BreadCrumbs

--- a/src/components/ApplicationDetails/__tests__/DetailsPage.spec.tsx
+++ b/src/components/ApplicationDetails/__tests__/DetailsPage.spec.tsx
@@ -117,6 +117,6 @@ describe('DetailsPage', () => {
       />,
     );
 
-    await waitFor(() => expect(document.title).toEqual('tab-title - Tab 1 | Stonesoup'));
+    await waitFor(() => expect(document.title).toEqual('tab-title - Tab 1 | CI/CD'));
   });
 });

--- a/src/components/ImportForm/ApplicationSection/ApplicationSection.tsx
+++ b/src/components/ImportForm/ApplicationSection/ApplicationSection.tsx
@@ -6,7 +6,7 @@ import { HeadTitle } from '../../HeadTitle';
 const ApplicationSection: React.FunctionComponent = () => {
   return (
     <>
-      <HeadTitle>Import - Name application | Stonesoup</HeadTitle>
+      <HeadTitle>Import - Name application | CI/CD</HeadTitle>
       <TextContent>
         <Text component="h2">Name your application</Text>
         <HelperText>Enter a name for your application.</HelperText>

--- a/src/components/ImportForm/ReviewSection/ReviewSection.tsx
+++ b/src/components/ImportForm/ReviewSection/ReviewSection.tsx
@@ -134,7 +134,7 @@ const ReviewSection: React.FunctionComponent = () => {
 
   return (
     <>
-      <HeadTitle>Import - Configure components | Stonesoup</HeadTitle>
+      <HeadTitle>Import - Configure components | CI/CD</HeadTitle>
       <TextContent>
         <Text component="h2">Configure your components for deployment</Text>
         <HelperText>

--- a/src/components/ImportForm/SampleSection/SampleSection.tsx
+++ b/src/components/ImportForm/SampleSection/SampleSection.tsx
@@ -96,7 +96,7 @@ const SampleSection = ({ onStrategyChange }) => {
 
   return (
     <>
-      <HeadTitle>Import - Select sample | Stonesoup</HeadTitle>
+      <HeadTitle>Import - Select sample | CI/CD</HeadTitle>
       <PageSection variant="light" isFilled>
         <TextContent>
           <Text component={TextVariants.h2}>

--- a/src/components/ImportForm/SourceSection/SourceSection.tsx
+++ b/src/components/ImportForm/SourceSection/SourceSection.tsx
@@ -146,7 +146,7 @@ export const SourceSection: React.FC<SourceSectionProps> = ({ onStrategyChange }
 
   return (
     <>
-      <HeadTitle>Import - Add components | Stonesoup</HeadTitle>
+      <HeadTitle>Import - Add components | CI/CD</HeadTitle>
       <TextContent>
         <Text component="h2">Add components to your application</Text>
         <HelperText>

--- a/src/pages/ApplicationsPage.tsx
+++ b/src/pages/ApplicationsPage.tsx
@@ -8,7 +8,7 @@ const ApplicationsPage = () => {
   useQuickstartCloseOnUnmount();
   return (
     <NamespacedPage>
-      <HeadTitle>Applications | Stonesoup</HeadTitle>
+      <HeadTitle>Applications | CI/CD</HeadTitle>
       <ApplicationListView />
     </NamespacedPage>
   );

--- a/src/pages/ComponentSettingsPage.tsx
+++ b/src/pages/ComponentSettingsPage.tsx
@@ -45,7 +45,7 @@ const ComponentSettingsPage: React.FunctionComponent = () => {
 
   return (
     <NamespacedPage>
-      <HeadTitle>{componentName} - Component Settings | Stonesoup</HeadTitle>
+      <HeadTitle>{componentName} - Component Settings | CI/CD</HeadTitle>
       <ComponentSettingsView componentName={componentName} />
     </NamespacedPage>
   );


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-3057

## Description
Removes `Stonesoup` from browser titles and replaces the string with `CI/CD`

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
![image](https://user-images.githubusercontent.com/14068621/215128255-fe5c2d68-c2b0-4871-b65a-979901b37fb8.png)


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
