### PR TITLE
running icon speed should be consistent

### DIFF
--- a/src/shared/components/pipeline-run-logs/StatusIcon.scss
+++ b/src/shared/components/pipeline-run-logs/StatusIcon.scss
@@ -1,4 +1,4 @@
-.status-icon.pf-m-spin svg {
+.status-icon.icon-spin svg {
     filter: blur(0);
     -webkit-filter: blur(0);
     transform-box: fill-box;

--- a/src/shared/components/pipeline-run-logs/StatusIcon.tsx
+++ b/src/shared/components/pipeline-run-logs/StatusIcon.tsx
@@ -42,7 +42,7 @@ export const ColoredStatusIcon: React.FC<StatusIconProps> = ({ status, ...others
       className={css(
         'status-icon',
         pipelineStyles.topologyPipelinesStatusIcon,
-        (status === RunStatus.Running || status === RunStatus.InProgress) && 'pf-m-spin',
+        (status === RunStatus.Running || status === RunStatus.InProgress) && 'icon-spin',
         getRunStatusModifier(status as RunStatus),
       )}
     >
@@ -60,7 +60,7 @@ export const StatusIconWithText: React.FC<
         className={css(
           'pf-u-mr-xs status-icon',
           pipelineStyles.topologyPipelinesPillStatus,
-          (status === RunStatus.Running || status === RunStatus.InProgress) && 'pf-m-spin',
+          (status === RunStatus.Running || status === RunStatus.InProgress) && 'icon-spin',
           getRunStatusModifier(status as RunStatus),
         )}
       >


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-3040

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Pipelinerun running icons uses different speeds in different spots. This PR makes the running icon speed consistent in all the places.



## Type of change
<!-- Please delete options that are not relevant. -->


- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


https://user-images.githubusercontent.com/9964343/215699780-7879ae31-faa5-46f5-b471-5de279ff8b74.mov






## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
