### PR TITLE
add commit link in pipeline run details page

### DIFF
--- a/src/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
@@ -20,6 +20,7 @@ import { getPLRLogSnippet } from '../../../shared/components/pipeline-run-logs/l
 import { StatusIconWithText } from '../../../shared/components/pipeline-run-logs/StatusIcon';
 import { Timestamp } from '../../../shared/components/timestamp/Timestamp';
 import { PipelineRunKind } from '../../../types';
+import { getCommitShortName } from '../../../utils/commits-utils';
 import { calculateDuration } from '../../../utils/pipeline-utils';
 import MetadataList from '../MetadataList';
 import PipelineRunVisualization from '../PipelineRunVisualization';
@@ -37,6 +38,9 @@ const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({ pipelineR
       ? pipelineRun.status?.completionTime
       : '',
   );
+  const sha =
+    pipelineRun?.metadata?.labels[PipelineRunLabel.COMMIT_LABEL] ||
+    pipelineRun?.metadata?.labels[PipelineRunLabel.TEST_SERVICE_COMMIT];
 
   return (
     <>
@@ -182,6 +186,21 @@ const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({ pipelineR
                     )}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
+
+                {sha && (
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Commit</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <Link
+                        to={`/stonesoup/${
+                          pipelineRun.metadata.labels[PipelineRunLabel.APPLICATION]
+                        }/commit/${sha}`}
+                      >
+                        {getCommitShortName(sha)}
+                      </Link>
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                )}
 
                 <DescriptionListGroup>
                   <DescriptionListTerm>Source</DescriptionListTerm>

--- a/src/components/PipelineRunDetailsView/tabs/__tests__/PipelineRunDetailsTab.spec.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/__tests__/PipelineRunDetailsTab.spec.tsx
@@ -5,6 +5,7 @@ import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { configure, render, screen } from '@testing-library/react';
 import { CustomError } from '../../../../shared/utils/error/custom-error';
 import { sampleBuildPipelines } from '../../../ApplicationDetails/tabs/overview/visualization/hooks/__data__/workflow-data';
+import { pipelineWithCommits } from '../../../Commits/__data__/pipeline-with-commits';
 import { testPipelineRun } from '../../../topology/__data__/pipeline-test-data';
 import PipelineRunDetailsTab from '../PipelineRunDetailsTab';
 
@@ -119,15 +120,25 @@ describe('PipelineRunDetailsTab', () => {
 
   it('should render the component link', () => {
     watchResourceMock.mockReturnValue([[], true]);
-    render(
-      <PipelineRunDetailsTab
-        pipelineRun={testPipelineRun}
-        error={new CustomError('Model not found')}
-      />,
-      {
-        wrapper: BrowserRouter,
-      },
-    );
-    screen.getByTestId('graph-error-state');
+    render(<PipelineRunDetailsTab pipelineRun={testPipelineRun} error={null} />, {
+      wrapper: BrowserRouter,
+    });
+    screen.getByText('Component');
+  });
+
+  it('should not render the commit link for simple pipelinerun', () => {
+    watchResourceMock.mockReturnValue([[], true]);
+    render(<PipelineRunDetailsTab pipelineRun={testPipelineRun} error={null} />, {
+      wrapper: BrowserRouter,
+    });
+    expect(screen.queryByText('Commit')).not.toBeInTheDocument();
+  });
+
+  it('should render the commit link for pac pipelinerun', () => {
+    watchResourceMock.mockReturnValue([[], true]);
+    render(<PipelineRunDetailsTab pipelineRun={pipelineWithCommits[0]} error={null} />, {
+      wrapper: BrowserRouter,
+    });
+    screen.getByText('Commit');
   });
 });


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/HAC-2951

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

There's no way to navigate back to the commit details page after clicking on a pipeline run from the commit details page.



## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


<img width="1504" alt="image" src="https://user-images.githubusercontent.com/9964343/215757803-d5b927a5-c860-4fdb-ba0e-82da9df85393.png">


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

visit pac pipeline run details page, it should have link to commit details page.


## Unit tests

```
PipelineRunDetailsTab
    ✓ should not render the commit link for simple pipelinerun (19 ms)
    ✓ should render the commit link for pac pipelinerun (23 ms)
```

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

cc: @christianvogt @MariaLeonova 