### PR TITLE
Enhance test for build log

### DIFF
--- a/integration-tests/support/pageObjects/createApplication-po.ts
+++ b/integration-tests/support/pageObjects/createApplication-po.ts
@@ -53,7 +53,7 @@ export const ComponentsPagePO = {
 
 export const applicationDetailPagePO = {
   item: '[data-testid="component-list-item-name"] > b',
-  componentBuildLog: '[data-testid="view-build-logs"]',
+  componentBuildLog: (param: string) => `[data-testid="view-build-logs-${param}"]`,
   componentSettings: '[data-testid="Component settings"]',
   detailsArrow: '[aria-label="Details"]',
   cpuRamLabel: 'CPU / Memory',
@@ -67,5 +67,7 @@ export const componentsListPagePO = {
 };
 
 export const buildLogModalContentPO = {
+  modal: '[id="pf-modal-part-2"]',
   closeButton: '[aria-label="Close"]',
+  logText: '[class="logs__content"]',
 };

--- a/integration-tests/support/pages/ApplicationDetailPage.ts
+++ b/integration-tests/support/pages/ApplicationDetailPage.ts
@@ -33,10 +33,19 @@ export class ApplicationDetailPage {
     cy.testA11y(`${pageTitles.componentSettings} page`);
   }
 
-  checkBuildLog(componentName: string, textToVerify: string) {
-    cy.get(`[data-testid="view-build-logs-${componentName}"]`, { timeout: 60000 }).click();
-    //verify text
+  checkBuildLog(tasklistItem: string, textToVerify: string, taskTimeout: number = 20000 ) {
+    cy.get('span[class="pipeline-run-logs__namespan"]').contains(tasklistItem,{timeout: taskTimeout}).click();
+    cy.get(buildLogModalContentPO.logText).should('contain.text', textToVerify);
+  }
+
+  openBuildLog(componentName: string) {
+    cy.get(applicationDetailPagePO.componentBuildLog(componentName), { timeout: 60000 }).click();
+    cy.get(buildLogModalContentPO.modal).should('exist');
+  }
+
+  closeBuildLog() {
     cy.get(buildLogModalContentPO.closeButton).click();
+    cy.get(buildLogModalContentPO.modal).should('not.exist');
   }
 
   createdComponentExists(component: string, application: string) {

--- a/integration-tests/tests/create-application-from-public-git-source.spec.ts
+++ b/integration-tests/tests/create-application-from-public-git-source.spec.ts
@@ -80,8 +80,13 @@ describe('Create Component from Public Git Source', { tags: ['@PR-check', '@publ
     });
 
     it('Check Component Build Log', () => {
-      // TODO: implement check for build log appropriate text
-      applicationDetailPage.checkBuildLog(componentPage.componentName, 'text to verify');
+      applicationDetailPage.openBuildLog(componentPage.componentName);
+
+      // Workaround for https://issues.redhat.com/browse/HAC-3071
+      cy.get('div[class="multi-stream-logs__taskName"]', {timeout: 40000}).should("include.text", "clone-repository");
+
+      applicationDetailPage.checkBuildLog("appstudio-init", 'Determine if Image Already Exists');
+      applicationDetailPage.closeBuildLog();
     });
 
     it('Check Resources Value', () => {


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-3063

## Description
Add meaningful test for the build log modal.
It used to check just that the modal was opened. Now it also checks that the task has run and shows the expected output.
