### PR TITLE
Stop detection if cdq fails with error status

### DIFF
--- a/src/components/ImportForm/utils/__data__/mock-cdq.ts
+++ b/src/components/ImportForm/utils/__data__/mock-cdq.ts
@@ -52,4 +52,68 @@ export const mockCDQ = {
   },
 };
 
+export const mockEmptyCDQ = {
+  apiVersion: 'appstudio.redhat.com/v1alpha1',
+  kind: 'ComponentDetectionQuery',
+  metadata: {
+    name: 'test-cdq',
+    namespace: 'test-ns',
+  },
+  spec: {
+    git: {
+      url: 'https://github.com/example/empty-repo',
+    },
+  },
+  status: {
+    conditions: [
+      {
+        lastTransitionTime: '2022-06-01T19:46:56Z',
+        message: 'ComponentDetectionQuery is processing',
+        reason: 'Success',
+        status: 'True',
+        type: 'Processing',
+      },
+      {
+        lastTransitionTime: '2022-06-01T19:46:56Z',
+        message: 'ComponentDetectionQuery has successfully finished',
+        reason: 'OK',
+        status: 'True',
+        type: 'Completed',
+      },
+    ],
+  },
+};
+
+export const mockFailedCDQ = {
+  apiVersion: 'appstudio.redhat.com/v1alpha1',
+  kind: 'ComponentDetectionQuery',
+  metadata: {
+    name: 'test-cdq',
+    namespace: 'test-ns',
+  },
+  spec: {
+    git: {
+      url: 'https://github.com/openshift/dynamic-plugin-sdk/tree/main/packages/sample-app',
+    },
+  },
+  status: {
+    conditions: [
+      {
+        lastTransitionTime: '2022-06-01T19:46:56Z',
+        message: 'ComponentDetectionQuery is processing',
+        reason: 'Success',
+        status: 'True',
+        type: 'Processing',
+      },
+      {
+        lastTransitionTime: '2022-06-01T19:46:56Z',
+        message: 'Error when cloning repository',
+        reason: 'Error',
+        status: 'True',
+        type: 'Completed',
+      },
+    ],
+  },
+};
+
 export const mockDetectedComponent = mockCDQ.status.componentDetected;

--- a/src/components/ImportForm/utils/cdq-utils.ts
+++ b/src/components/ImportForm/utils/cdq-utils.ts
@@ -81,7 +81,9 @@ export const useComponentDetection = (
   const detectionCompleted = React.useMemo(() => {
     if (cdqName && loaded && cdq) {
       return cdq?.status?.conditions?.some(
-        (condition) => condition.type === 'Completed' && condition.reason === 'OK',
+        (condition) =>
+          condition.type === 'Completed' &&
+          (condition.reason === 'OK' || condition.reason === 'Error'),
       );
     }
     return false;


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-2989
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
The component detection hook did not consider cdq status to be completed when the condition is in error, this caused the hook to still be in detecting state.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

https://user-images.githubusercontent.com/20013884/215988752-f9c436dd-8126-4d69-b76f-c8493be4dfa7.mp4

<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
