### PR TITLE
Use sample component names as retrieved from CDQ

### DIFF
--- a/src/components/ImportForm/utils/__tests__/transform-utils.spec.ts
+++ b/src/components/ImportForm/utils/__tests__/transform-utils.spec.ts
@@ -1,9 +1,5 @@
 import { mockDetectedComponent } from '../__data__/mock-cdq';
-import {
-  createResourceData,
-  sampleComponentValues,
-  transformComponentValues,
-} from '../transform-utils';
+import { createResourceData, transformComponentValues } from '../transform-utils';
 
 const mockResourceRequests = {
   requests: {
@@ -74,23 +70,5 @@ describe('Transform Utils', () => {
         projectType: 'nodejs',
       },
     ]);
-  });
-});
-
-describe('sampleComponentValues', () => {
-  it('should prefix application to sample name', () => {
-    const mockDetectedComponents = {
-      node: { componentStub: { componentName: 'node', application: 'my-app' } },
-    };
-    const values = sampleComponentValues('my-app', mockDetectedComponents);
-    expect(values[0].componentStub).toHaveProperty('componentName', 'my-app-node-sample');
-  });
-
-  it('should sanitize application prefix', () => {
-    const mockDetectedComponents = {
-      node: { componentStub: { componentName: 'node', application: 'My Application' } },
-    };
-    const values = sampleComponentValues('My Application', mockDetectedComponents);
-    expect(values[0].componentStub).toHaveProperty('componentName', 'my-application-node-sample');
   });
 });

--- a/src/components/ImportForm/utils/submit-utils.ts
+++ b/src/components/ImportForm/utils/submit-utils.ts
@@ -1,7 +1,7 @@
 import { FormikHelpers } from 'formik';
 import { createApplication, createComponent } from '../../../utils/create-utils';
 import { detectComponents } from './cdq-utils';
-import { transformResources, sampleComponentValues } from './transform-utils';
+import { transformResources, transformComponentValues } from './transform-utils';
 import { DetectedFormComponent, ImportFormValues, ImportStrategy } from './types';
 
 export const createComponents = async (
@@ -50,7 +50,7 @@ export const createResources = async (formValues: ImportFormValues, strategy: Im
       source.git.context,
       source.git.revision,
     );
-    detectedComponents = sampleComponentValues(application, detectedSampleComponents);
+    detectedComponents = transformComponentValues(detectedSampleComponents);
   }
 
   if (shouldCreateApplication) {

--- a/src/components/ImportForm/utils/transform-utils.ts
+++ b/src/components/ImportForm/utils/transform-utils.ts
@@ -1,4 +1,3 @@
-import { sanitizeName } from '../../../utils/create-utils';
 import { ResourceRequirements, DetectedComponents } from './../../../types';
 import { CPUUnits, DetectedFormComponent, FormResources, MemoryUnits } from './types';
 
@@ -57,17 +56,4 @@ export const transformComponentValues = (
       },
     };
   }, []);
-};
-
-export const sampleComponentValues = (
-  application: string,
-  detectedComponents: DetectedComponents,
-): DetectedFormComponent[] => {
-  return transformComponentValues(detectedComponents).map((component) => ({
-    ...component,
-    componentStub: {
-      ...component.componentStub,
-      componentName: `${sanitizeName(application)}-${component.componentStub.componentName}-sample`,
-    },
-  }));
 };


### PR DESCRIPTION
## Fixes 
Fixes [HAC-3024](https://issues.redhat.com/browse/HAC-3024)

## Description
When creating sample components, use the suggested name returned by CDQ rather than prepending the application name and adding the `-sample` suffix.


## Type of change
- [x] Bugfix

