### PR TITLE
Fix to hide action menus when bringing up another

### DIFF
--- a/src/shared/components/action-menu/ActionMenuToggle.tsx
+++ b/src/shared/components/action-menu/ActionMenuToggle.tsx
@@ -57,15 +57,19 @@ const ActionMenuToggle: React.FC<ActionMenuToggleProps> = ({
     }; // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]); // This needs to be run only on component mount/unmount
 
-  const handleToggleClick = (ev) => {
-    ev.stopPropagation(); // Stop handleClickOutside from handling
-    setTimeout(() => {
-      const firstElement = menuRef?.current?.querySelector<HTMLElement>(
-        'li > button:not(:disabled)',
-      );
-      firstElement?.focus();
-    }, 0);
-    onToggleClick((open) => !open);
+  const handleToggleClick = () => {
+    // let the click event propagate before opening (to avoid immediate close on window click)
+    requestAnimationFrame(() => {
+      onToggleClick((open) => !open);
+
+      // let the menu show before setting focus
+      requestAnimationFrame(() => {
+        const firstElement = menuRef?.current?.querySelector<HTMLElement>(
+          'li > button:not(:disabled)',
+        );
+        firstElement?.focus();
+      });
+    });
   };
 
   return (


### PR DESCRIPTION
## Fixes 
Fixes [HAC-3072](https://issues.redhat.com/browse/HAC-3072)

## Description
Action menu click was not propagating the event so other action menus did not close. Change to propagate the event, but delay the menu open so that it doesn't automatically close when catching the click event.


## Type of change
- [x] Bugfix
