### PR TITLE
fix build logs loading, alignment and pending state messages

### DIFF
--- a/src/__data__/pod-data.ts
+++ b/src/__data__/pod-data.ts
@@ -1,0 +1,173 @@
+import { PodKind } from '../shared/components/types';
+
+export const samplePod: PodKind = {
+  kind: 'Pod',
+  apiVersion: 'v1',
+  metadata: {
+    name: 'go-app-5few-65cc6-appstudio-init-pod',
+    namespace: 'test-tenant',
+    uid: '297258bd-c1d2-42dd-87a2-e42611fdc822',
+  },
+  spec: {
+    volumes: [],
+    initContainers: [],
+    containers: [
+      {
+        command: ['/bin/bash', '-c', 'echo', 'hello world'],
+        image: 'registry.redhat.io/ubi7/ubi-minimal',
+        name: 'step-init',
+        resources: {},
+      },
+    ],
+    restartPolicy: 'Never',
+    terminationGracePeriodSeconds: 30,
+    activeDeadlineSeconds: 5395,
+    dnsPolicy: 'ClusterFirst',
+    serviceAccountName: 'pipeline',
+    serviceAccount: 'pipeline',
+    nodeName: 'ip-10-0-202-33.us-east-2.compute.internal',
+    securityContext: {
+      seLinuxOptions: {
+        level: 's0:c57,c49',
+      },
+      fsGroup: 1003290000,
+    },
+    imagePullSecrets: [
+      {
+        name: 'pipeline-dockercfg-vk7gx',
+      },
+    ],
+    schedulerName: 'default-scheduler',
+    tolerations: [
+      {
+        key: 'node.kubernetes.io/not-ready',
+        operator: 'Exists',
+        effect: 'NoExecute',
+        tolerationSeconds: 300,
+      },
+      {
+        key: 'node.kubernetes.io/unreachable',
+        operator: 'Exists',
+        effect: 'NoExecute',
+        tolerationSeconds: 300,
+      },
+      {
+        key: 'node.kubernetes.io/memory-pressure',
+        operator: 'Exists',
+        effect: 'NoSchedule',
+      },
+    ],
+    priorityClassName: 'sandbox-users-pods',
+    priority: -3,
+    enableServiceLinks: true,
+    preemptionPolicy: 'PreemptLowerPriority',
+  },
+  status: {
+    phase: 'Succeeded',
+    conditions: [
+      {
+        type: 'Initialized',
+        status: 'True',
+        lastProbeTime: null,
+        lastTransitionTime: '2023-02-03T09:58:51Z',
+        reason: 'PodCompleted',
+      },
+      {
+        type: 'Ready',
+        status: 'False',
+        lastProbeTime: null,
+        lastTransitionTime: '2023-02-03T09:58:57Z',
+        reason: 'PodCompleted',
+      },
+      {
+        type: 'ContainersReady',
+        status: 'False',
+        lastProbeTime: null,
+        lastTransitionTime: '2023-02-03T09:58:57Z',
+        reason: 'PodCompleted',
+      },
+      {
+        type: 'PodScheduled',
+        status: 'True',
+        lastProbeTime: null,
+        lastTransitionTime: '2023-02-03T09:58:47Z',
+      },
+    ],
+    hostIP: '10.0.202.33',
+    podIP: '10.130.14.58',
+    podIPs: [
+      {
+        ip: '10.130.14.58',
+      },
+    ],
+    startTime: '2023-02-03T09:58:47Z',
+    initContainerStatuses: [
+      {
+        name: 'prepare',
+        state: {
+          terminated: {
+            exitCode: 0,
+            reason: 'Completed',
+            startedAt: '2023-02-03T09:58:50Z',
+            finishedAt: '2023-02-03T09:58:50Z',
+            containerID: 'cri-o://fac0b3262d49bab9e3ff43dfde9949ee19520ef48cc854c1852449d361d0c0c5',
+          },
+        },
+        lastState: {},
+        ready: true,
+        restartCount: 0,
+        image:
+          'registry.redhat.io/openshift-pipelines/pipelines-entrypoint-rhel8@sha256:3580541d0912cdba214343b79868d2adcfa1c60a6e5ee940c255fa76d4431f07',
+        imageID:
+          'registry.redhat.io/openshift-pipelines/pipelines-entrypoint-rhel8@sha256:3580541d0912cdba214343b79868d2adcfa1c60a6e5ee940c255fa76d4431f07',
+        containerID: 'cri-o://fac0b3262d49bab9e3ff43dfde9949ee19520ef48cc854c1852449d361d0c0c5',
+      },
+      {
+        name: 'place-scripts',
+        state: {
+          terminated: {
+            exitCode: 0,
+            reason: 'Completed',
+            startedAt: '2023-02-03T09:58:51Z',
+            finishedAt: '2023-02-03T09:58:51Z',
+            containerID: 'cri-o://72b2e1972f51f21e4e284b0438d0516038f81b8236db7fb0e870d21be2397d35',
+          },
+        },
+        lastState: {},
+        ready: true,
+        restartCount: 0,
+        image:
+          'registry.redhat.io/ubi8/ubi-minimal@sha256:c7b45019f4db32e536e69e102c4028b66bf5cde173cfff4ffd3281ccf7bb3863',
+        imageID:
+          'registry.redhat.io/ubi8/ubi-minimal@sha256:2c8e091b26cc5a73cc7c61f4baee718021cfe5bd2fbc556d1411499c9a99ccdb',
+        containerID: 'cri-o://72b2e1972f51f21e4e284b0438d0516038f81b8236db7fb0e870d21be2397d35',
+      },
+    ],
+    containerStatuses: [
+      {
+        name: 'step-init',
+        state: {
+          terminated: {
+            exitCode: 0,
+            reason: 'Completed',
+            message:
+              '[{"key":"build","value":"false","type":1},{"key":"StartedAt","value":"2023-02-03T09:58:56.096Z","type":3}]',
+            startedAt: '2023-02-03T09:58:53Z',
+            finishedAt: '2023-02-03T09:58:56Z',
+            containerID: 'cri-o://5e596b389a3c995e30138eff66b3d310b477e0859700902e7656ac82ecf6f2d9',
+          },
+        },
+        lastState: {},
+        ready: false,
+        restartCount: 0,
+        image:
+          'registry.access.redhat.com/ubi9/skopeo@sha256:6ebbdfce633f9915a6a99d8ee035d9fd258121aa1acf944229e90696eb353549',
+        imageID:
+          'registry.access.redhat.com/ubi9/skopeo@sha256:6ebbdfce633f9915a6a99d8ee035d9fd258121aa1acf944229e90696eb353549',
+        containerID: 'cri-o://5e596b389a3c995e30138eff66b3d310b477e0859700902e7656ac82ecf6f2d9',
+        started: false,
+      },
+    ],
+    qosClass: 'Burstable',
+  },
+};

--- a/src/shared/components/pipeline-run-logs/PipelineRunLogs.scss
+++ b/src/shared/components/pipeline-run-logs/PipelineRunLogs.scss
@@ -22,7 +22,7 @@
   }
   &__log {
     height: 100%;
-    padding-top: var(--pf-global--spacer--md);
+    padding-top: var(--pf-global--spacer--lg);
   }
   &__logtext {
     position: relative;

--- a/src/shared/components/pipeline-run-logs/PipelineRunLogs.tsx
+++ b/src/shared/components/pipeline-run-logs/PipelineRunLogs.tsx
@@ -102,11 +102,11 @@ class PipelineRunLogs extends React.Component<PipelineRunLogsProps, PipelineRunL
 
     const waitingForPods = !!(activeItem && !resource);
     const taskName = get(taskRunFromYaml, [activeItem, 'pipelineTaskName'], '-');
-    const pipelineRunFinished = ![runStatus.Running].includes(pipelineRunStatus);
+    const pipelineRunFinished = pipelineRunStatus !== runStatus.Running;
 
     return (
       <div className="pipeline-run-logs">
-        <div className="pipeline-run-logs__tasklist" data-test-id="logs-tasklist">
+        <div className="pipeline-run-logs__tasklist" data-testid="logs-tasklist">
           {taskCount > 0 ? (
             <Nav onSelect={this.onNavSelect} theme="light">
               <NavList className="pipeline-run-logs__nav">
@@ -145,7 +145,7 @@ class PipelineRunLogs extends React.Component<PipelineRunLogsProps, PipelineRunL
             />
           ) : (
             <div className="pipeline-run-logs__log">
-              <div className="pipeline-run-logs__logtext">
+              <div className="pipeline-run-logs__logtext" data-testid="task-logs-error">
                 {waitingForPods && !pipelineRunFinished && `Waiting for ${taskName} task to start `}
                 {!resource &&
                   pipelineRunFinished &&

--- a/src/shared/components/pipeline-run-logs/__tests__/PipelineRunLogs.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/__tests__/PipelineRunLogs.spec.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { screen, render, within } from '@testing-library/react';
+import { DataState, testPipelineRuns } from '../../../../__data__/pipelinerun-data';
+import { HttpError } from '../../../utils/error/http-error';
+import PipelineRunLogs from '../PipelineRunLogs';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  useK8sWatchResource: jest.fn(),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: jest.fn(() => ({ t: (x) => x })),
+}));
+
+const watchResourceMock = useK8sWatchResource as jest.Mock;
+
+describe('PipelineRunLogs', () => {
+  const pipelineRun = testPipelineRuns[DataState.SUCCEEDED];
+
+  beforeEach(() => {
+    watchResourceMock.mockReturnValue([{ metadata: { name: 'test-pod' } }, true]);
+  });
+
+  it('should render task list and log window', () => {
+    render(<PipelineRunLogs obj={pipelineRun} />);
+
+    screen.getByTestId('logs-tasklist');
+    screen.getByTestId('logs-task-container');
+  });
+
+  it('should render select and render the first task log', () => {
+    render(<PipelineRunLogs obj={pipelineRun} activeTask="first" />);
+
+    screen.getByTestId('logs-tasklist');
+    within(screen.getByTestId('logs-taskName')).getByText('first');
+  });
+
+  it('should render waiting for logs message', () => {
+    const runningPipelineRun = testPipelineRuns[DataState.RUNNING];
+    runningPipelineRun.status.taskRuns['test-caseqfvdj-first'].status.podName = '';
+
+    render(<PipelineRunLogs obj={runningPipelineRun} />);
+
+    screen.getByTestId('logs-tasklist');
+    screen.getByTestId('task-logs-error');
+
+    screen.getByText('Waiting for first task to start');
+  });
+
+  it('should no logs found message when pipelinerun status is misisng', () => {
+    const plrWithNoStatus = testPipelineRuns[DataState.RUNNING];
+    plrWithNoStatus.status = undefined;
+
+    render(<PipelineRunLogs obj={plrWithNoStatus} />);
+
+    screen.getByTestId('logs-tasklist');
+    screen.getByTestId('task-logs-error');
+
+    screen.getByText('No logs found');
+  });
+
+  it('should render logs no longer available message when pods are not available', () => {
+    watchResourceMock.mockReturnValue([
+      null,
+      true,
+      new HttpError('pod not found', 404, null, { statusText: 'some status message' }),
+    ]);
+    render(<PipelineRunLogs obj={pipelineRun} />);
+
+    screen.getByTestId('logs-error-message');
+    screen.getByText('Logs are no longer accessible for do-something task');
+  });
+});

--- a/src/shared/components/pipeline-run-logs/logs/Logs.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/Logs.tsx
@@ -13,6 +13,7 @@ type LogsProps = {
   render: boolean;
   autoScroll?: boolean;
   onComplete: (containerName: string) => void;
+  errorMessage?: string;
 };
 
 const Logs: React.FC<LogsProps> = ({
@@ -22,6 +23,7 @@ const Logs: React.FC<LogsProps> = ({
   onComplete,
   render,
   autoScroll = true,
+  errorMessage,
 }) => {
   const { t } = useTranslation();
   const { name } = container;
@@ -113,13 +115,18 @@ const Logs: React.FC<LogsProps> = ({
   return (
     <div className="logs" style={{ display: render ? '' : 'none' }}>
       <p className="logs__name">{name}</p>
-      {error && (
-        <Alert
-          variant="danger"
-          isInline
-          title={t('An error occurred while retrieving the requested logs.')}
-        />
-      )}
+      {error ||
+        (!resource && errorMessage && (
+          <Alert
+            variant="danger"
+            isInline
+            title={
+              errorMessage
+                ? errorMessage
+                : t('An error occurred while retrieving the requested logs.')
+            }
+          />
+        ))}
       <div>
         <div className="logs__content" ref={contentRef} />
         <div ref={scrollToRef} />

--- a/src/shared/components/pipeline-run-logs/logs/LogsWrapperComponent.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/LogsWrapperComponent.tsx
@@ -22,10 +22,11 @@ const LogsWrapperComponent: React.FC<LogsWrapperComponentProps> = ({ resource, .
     resourceRef.current = null;
   }
 
-  let errorMessage;
-  if ((error as HttpError)?.code === 404) {
-    errorMessage = `Logs are no longer accessible for ${props.taskName} task`;
-  }
+  const errorMessage =
+    (error as HttpError)?.code === 404
+      ? `Logs are no longer accessible for ${props.taskName} task`
+      : null;
+
   return (
     <MultiStreamLogs
       {...props}

--- a/src/shared/components/pipeline-run-logs/logs/LogsWrapperComponent.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/LogsWrapperComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { WatchK8sResource } from '../../../../dynamic-plugin-sdk';
-import { LoadingBox } from '../../status-box/StatusBox';
+import { HttpError } from '../../../utils/error/http-error';
 import { PodKind } from '../../types';
 import { MultiStreamLogs } from './MultiStreamLogs';
 
@@ -18,12 +18,21 @@ const LogsWrapperComponent: React.FC<LogsWrapperComponentProps> = ({ resource, .
 
   if (loaded && !error && resource.name === obj.metadata.name) {
     resourceRef.current = obj;
+  } else if (error) {
+    resourceRef.current = null;
   }
 
-  return resourceRef.current ? (
-    <MultiStreamLogs {...props} resourceName={resource.name} resource={resourceRef.current} />
-  ) : (
-    <LoadingBox />
+  let errorMessage;
+  if ((error as HttpError)?.code === 404) {
+    errorMessage = `Logs are no longer accessible for ${props.taskName} task`;
+  }
+  return (
+    <MultiStreamLogs
+      {...props}
+      resourceName={resource?.name}
+      resource={resourceRef.current}
+      errorMessage={errorMessage}
+    />
   );
 };
 

--- a/src/shared/components/pipeline-run-logs/logs/MultiStreamLogs.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/MultiStreamLogs.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Flex, FlexItem } from '@patternfly/react-core';
 import { DownloadIcon, CompressIcon, ExpandIcon } from '@patternfly/react-icons/dist/js/icons';
-import * as classNames from 'classnames';
+import classNames from 'classnames';
 import { saveAs } from 'file-saver';
 import { useFullscreen } from '../../../hooks/fullscreen';
 import { useScrollDirection, ScrollDirection } from '../../../hooks/scroll';
@@ -136,7 +136,7 @@ export const MultiStreamLogs: React.FC<MultiStreamLogsProps> = ({
           </FlexItem>
         )}
       </Flex>
-      <div className="multi-stream-logs__taskName">
+      <div className="multi-stream-logs__taskName" data-testid="logs-taskName">
         {taskName}
         {(loadingContainers || stillFetching) && resource && (
           <span className="multi-stream-logs__taskName__loading-indicator">
@@ -147,11 +147,13 @@ export const MultiStreamLogs: React.FC<MultiStreamLogsProps> = ({
       <div
         className="multi-stream-logs__container"
         onScroll={handleScrollCallback}
-        data-test-id="logs-task-container"
+        data-testid="logs-task-container"
       >
         <div className="multi-stream-logs__container__logs" ref={scrollPane}>
           {resource === null && errorMessage && (
-            <div className="pipeline-run-logs__logtext">{errorMessage}</div>
+            <div className="pipeline-run-logs__logtext" data-testid="logs-error-message">
+              {errorMessage}
+            </div>
           )}
           {!loadingContainers &&
             containers.map((container, idx) => {

--- a/src/shared/components/pipeline-run-logs/logs/MultiStreamLogs.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/MultiStreamLogs.tsx
@@ -19,6 +19,7 @@ type MultiStreamLogsProps = {
   taskName: string;
   downloadAllLabel?: string;
   onDownloadAll?: () => Promise<Error>;
+  errorMessage?: string;
 };
 
 export const MultiStreamLogs: React.FC<MultiStreamLogsProps> = ({
@@ -27,6 +28,7 @@ export const MultiStreamLogs: React.FC<MultiStreamLogsProps> = ({
   resourceName,
   downloadAllLabel,
   onDownloadAll,
+  errorMessage,
 }) => {
   const { t } = useTranslation();
   const scrollPane = React.useRef<HTMLDivElement>();
@@ -40,7 +42,7 @@ export const MultiStreamLogs: React.FC<MultiStreamLogsProps> = ({
   const dataRef = React.useRef(null);
   dataRef.current = containers;
 
-  const loadingContainers = resource.metadata.name !== resourceName;
+  const loadingContainers = resource?.metadata?.name !== resourceName;
 
   const handleComplete = React.useCallback((containerName) => {
     const index = dataRef.current.findIndex(({ name }) => name === containerName);
@@ -83,7 +85,7 @@ export const MultiStreamLogs: React.FC<MultiStreamLogsProps> = ({
     saveAs(blob, `${taskName}.log`);
   };
 
-  const containerStatus = resource.status?.containerStatuses ?? [];
+  const containerStatus = resource?.status?.containerStatuses ?? [];
   const divider = <FlexItem className="multi-stream-logs__divider">|</FlexItem>;
   return (
     <div ref={fullscreenRef} className="multi-stream-logs">
@@ -136,7 +138,7 @@ export const MultiStreamLogs: React.FC<MultiStreamLogsProps> = ({
       </Flex>
       <div className="multi-stream-logs__taskName">
         {taskName}
-        {(loadingContainers || stillFetching) && (
+        {(loadingContainers || stillFetching) && resource && (
           <span className="multi-stream-logs__taskName__loading-indicator">
             <LoadingInline />
           </span>
@@ -148,6 +150,9 @@ export const MultiStreamLogs: React.FC<MultiStreamLogsProps> = ({
         data-test-id="logs-task-container"
       >
         <div className="multi-stream-logs__container__logs" ref={scrollPane}>
+          {resource === null && errorMessage && (
+            <div className="pipeline-run-logs__logtext">{errorMessage}</div>
+          )}
           {!loadingContainers &&
             containers.map((container, idx) => {
               const statusIndex = containerStatus.findIndex((c) => c.name === container.name);

--- a/src/shared/components/pipeline-run-logs/logs/log-utils.spec.ts
+++ b/src/shared/components/pipeline-run-logs/logs/log-utils.spec.ts
@@ -1,0 +1,18 @@
+import { samplePod } from '../../../../__data__/pod-data';
+import { getRenderContainers } from './logs-utils';
+
+describe('getRenderContainers', () => {
+  it('should render default values if invalid value is passed', () => {
+    expect(getRenderContainers(null)).toEqual({
+      containers: [],
+      stillFetching: false,
+    });
+  });
+
+  it('should render containers for the given pod', () => {
+    expect(getRenderContainers(samplePod)).toEqual({
+      containers: samplePod.spec.containers,
+      stillFetching: false,
+    });
+  });
+});

--- a/src/shared/components/pipeline-run-logs/logs/logs-utils.ts
+++ b/src/shared/components/pipeline-run-logs/logs/logs-utils.ts
@@ -30,8 +30,8 @@ const getSortedContainerStatus = (
 export const getRenderContainers = (
   pod: PodKind,
 ): { containers: ContainerSpec[]; stillFetching: boolean } => {
-  const containers: ContainerSpec[] = pod.spec?.containers ?? [];
-  const containerStatuses: ContainerStatus[] = pod.status?.containerStatuses ?? [];
+  const containers: ContainerSpec[] = pod?.spec?.containers ?? [];
+  const containerStatuses: ContainerStatus[] = pod?.status?.containerStatuses ?? [];
 
   const sortedContainerStatuses = getSortedContainerStatus(containers, containerStatuses);
 


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-2808
https://issues.redhat.com/browse/HAC-3025
https://issues.redhat.com/browse/HAC-3071


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

UI doesn't tell user when the selected log isn't available any more. Due to the pod limit, the pruner will start to remove the old pods in order to create new pods, so the user will not be able to view the logs for the pods that are pruned already.

This PR fixes few issues around the build logs:

1. Display the message in the UI to notify that the logs are no longer available for the <selected_task>.
2. Display the pending state message if the task is not started yet.
3. Clicking on the build log should show the last completed task logs.


Note: Pods limit are now increased to 150 (130 for taskruns , 20 for deployments), so the pruner will kick in when the pods count reaches 130

## Type of change
<!-- Please delete options that are not relevant. -->


- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Clone repository task's pod was pruned in the below screenshot:

<img width="1118" alt="Screenshot 2023-02-03 at 4 31 40 PM" src="https://user-images.githubusercontent.com/9964343/216587469-b7c2dd05-e234-408f-9e9b-6f6bcedcaf86.png">

Task's Pending state message: 

<img width="1178" alt="Screenshot 2023-02-03 at 2 42 27 PM" src="https://user-images.githubusercontent.com/9964343/216586853-ed7a211c-f6c4-452b-8bd8-e82542d0d4fe.png">

Fixed Alignment of the task list and log window:

![alignment-after](https://user-images.githubusercontent.com/9964343/216586928-3181dd10-129f-4712-a470-229de07a1500.png)

## Unit tests

```
  PipelineRunLogs
    ✓ should render task list and log window (58 ms)
    ✓ should render select and render the first task log (18 ms)
    ✓ should render waiting for logs message (7 ms)
    ✓ should no logs found message when pipelinerun status is misisng (4 ms)
    ✓ should render logs no longer available message when pods are not available (17 ms)
 ```
 
 ```
   getRenderContainers
    ✓ should render default values if invalid value is passed (2 ms)
    ✓ should render containers for the given pod (1 ms)
 
 ```

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

cc: @beaumorley @christianvogt 
