### PR TITLE
make component settings form responsive

### DIFF
--- a/src/components/ImportForm/ReviewSection/ReviewComponentCard.tsx
+++ b/src/components/ImportForm/ReviewSection/ReviewComponentCard.tsx
@@ -107,15 +107,15 @@ export const ReviewComponentCard: React.FC<ReviewComponentCardProps> = ({
           >
             <FormSection>
               <Grid hasGutter>
-                <GridItem span={3}>
+                <GridItem sm={6} md={3} lg={3}>
                   <InputField
                     name={`${fieldPrefix}.targetPort`}
                     label="Target port"
                     type={TextInputTypes.number}
                   />
                 </GridItem>
-                <GridItem span={5} />
-                <GridItem span={6}>
+                <GridItem span={6} className="pf-m-hidden pf-m-visible-on-lg" />
+                <GridItem sm={12} md={12} lg={6}>
                   <ResourceLimitField
                     name={`${fieldPrefix}.resources.cpu`}
                     unitName={`${fieldPrefix}.resources.cpuUnit`}
@@ -125,7 +125,7 @@ export const ReviewComponentCard: React.FC<ReviewComponentCardProps> = ({
                     helpText="The amount of CPU the container is guaranteed"
                   />
                 </GridItem>
-                <GridItem span={6}>
+                <GridItem sm={12} md={12} lg={6}>
                   <ResourceLimitField
                     name={`${fieldPrefix}.resources.memory`}
                     unitName={`${fieldPrefix}.resources.memoryUnit`}


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-3102

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Components settings form has broken responsive layout for component cpu and memory settings.

## Type of change
<!-- Please delete options that are not relevant. -->


- [x] Bugfix - Layout change, no functional changes.


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:

<img width="502" alt="image" src="https://user-images.githubusercontent.com/9964343/216928064-467e30c8-a8af-4a8a-9633-2c95840d83f2.png">

After:

<img width="587" alt="Screenshot 2023-02-06 at 2 17 46 PM" src="https://user-images.githubusercontent.com/9964343/216927412-0675d650-0473-4c11-8a8f-b7bd0d2dcd4a.png">


https://user-images.githubusercontent.com/9964343/216927595-7a503e23-ea3b-4dd7-ba39-3fe6c14eb1de.mov


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

