### PR TITLE
Fix to show error state rather than spinner

### DIFF
--- a/config/remotePlugin.js
+++ b/config/remotePlugin.js
@@ -324,7 +324,7 @@ const routeExtensions = [
     },
   },
   {
-    type: 'console.page/route',
+    type: 'core.page/route',
     properties: {
       path: '/stonesoup/workspace-settings/environment/create',
       exact: true,
@@ -339,10 +339,10 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
-      path: '/stonesoup/workspace-settings/environment/create',
-      exact: true,
+      path: '/stonesoup',
+      exact: false,
       component: {
-        $codeRef: 'CreateEnvironment',
+        $codeRef: 'NotFound',
       },
     },
     flags: {
@@ -372,6 +372,7 @@ module.exports = {
       OverviewPage: resolve(__dirname, '../src/pages/OverviewPage'),
       FlagUtils: resolve(__dirname, '../src/utils/flag-utils'),
       Redirect: resolve(__dirname, '../src/pages/RedirectPage'),
+      NotFound: resolve(__dirname, '../src/pages/NotFoundPage'),
     },
   },
   extensions: [

--- a/src/components/ApplicationDetails/__tests__/ApplicationDetails.spec.tsx
+++ b/src/components/ApplicationDetails/__tests__/ApplicationDetails.spec.tsx
@@ -105,6 +105,13 @@ describe('ApplicationDetails', () => {
     expect(screen.queryByTestId('spinner')).toBeInTheDocument();
   });
 
+  it('should render the error state if the application is not found', () => {
+    watchResourceMock.mockReturnValue([[], false, { code: 404 }]);
+    routerRenderer(<ApplicationDetails applicationName="test" />);
+    screen.getByText('404: Page not found');
+    screen.getByText('Go to applications list');
+  });
+
   it('should render application display name if application data is loaded', () => {
     watchResourceMock.mockReturnValueOnce([mockApplication, true]);
     routerRenderer(<ApplicationDetails applicationName="test" />);

--- a/src/components/Commits/CommitDetailsView.tsx
+++ b/src/components/Commits/CommitDetailsView.tsx
@@ -6,16 +6,10 @@ import {
   Drawer,
   DrawerContent,
   DrawerContentBody,
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateIcon,
   Spinner,
   Text,
   TextVariants,
-  Title,
 } from '@patternfly/react-core';
-import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
-import { SearchIcon } from '@patternfly/react-icons/dist/js/icons';
 import { GithubIcon } from '@patternfly/react-icons/dist/js/icons/github-icon';
 import { PipelineRunLabel } from '../../consts/pipelinerun';
 import { PipelineRunGroupVersionKind } from '../../models';
@@ -23,6 +17,7 @@ import { pipelineRunFilterReducer } from '../../shared';
 import ExternalLink from '../../shared/components/links/ExternalLink';
 import { StatusIconWithTextLabel } from '../../shared/components/pipeline-run-logs/StatusIcon';
 import { Timestamp } from '../../shared/components/timestamp/Timestamp';
+import { HttpError } from '../../shared/utils/error/http-error';
 import { PipelineRunKind } from '../../types';
 import {
   createCommitObjectFromPLR,
@@ -33,6 +28,7 @@ import {
 } from '../../utils/commits-utils';
 import { useNamespace } from '../../utils/namespace-context-utils';
 import DetailsPage from '../ApplicationDetails/DetailsPage';
+import ErrorEmptyState from '../EmptyState/ErrorEmptyState';
 import { useCommitStatus } from './commit-status';
 import { CommitIcon } from './CommitIcon';
 import CommitSidePanel from './CommitSidePanel';
@@ -139,18 +135,11 @@ const CommitDetailsView: React.FC<CommitDetailsViewProps> = ({ commitName, appli
 
   if (loadErr || (loaded && !commit)) {
     return (
-      <Bullseye>
-        <EmptyState>
-          <EmptyStateIcon
-            style={{ color: 'var(--pf-global--danger-color--100)' }}
-            icon={loadErr ? ExclamationCircleIcon : SearchIcon}
-          />
-          <Title size="lg" headingLevel="h4">
-            {loadErr ? `Could not load ${PipelineRunGroupVersionKind.kind}` : 'Commit not found'}
-          </Title>
-          <EmptyStateBody>{loadErr ? 'Not found' : 'No such commit'}</EmptyStateBody>
-        </EmptyState>
-      </Bullseye>
+      <ErrorEmptyState
+        httpError={HttpError.fromCode(loadErr ? (loadErr as any).code : 404)}
+        title={`Could not load ${PipelineRunGroupVersionKind.kind}`}
+        body={(loadErr as any)?.message ?? 'Not found'}
+      />
     );
   }
 

--- a/src/components/Commits/__tests__/CommitDetailsView.spec.tsx
+++ b/src/components/Commits/__tests__/CommitDetailsView.spec.tsx
@@ -46,7 +46,7 @@ describe('CommitDetailsView', () => {
   });
 
   it('should show plr fetching error if unable to load plrs', () => {
-    watchResourceMock.mockReturnValueOnce([[], true, true]);
+    watchResourceMock.mockReturnValueOnce([[], true, { code: 503 }]);
     routerRenderer(<CommitDetailsView applicationName="test" commitName="commit123" />);
     screen.getByText('Could not load PipelineRun');
     screen.getByText('Not found');
@@ -55,8 +55,8 @@ describe('CommitDetailsView', () => {
   it('should show commit not found error if no matching pipelineruns are found ', () => {
     watchResourceMock.mockReturnValueOnce([[], true]);
     routerRenderer(<CommitDetailsView applicationName="test" commitName="commit123" />);
-    screen.getByText('Commit not found');
-    screen.getByText('No such commit');
+    screen.getByText('404: Page not found');
+    screen.getByText('Go to applications list');
   });
 
   it('should render proper commit details', () => {

--- a/src/components/EmptyState/EmptyState.scss
+++ b/src/components/EmptyState/EmptyState.scss
@@ -13,5 +13,8 @@
     &.m-is-xl {
       width: var(--pf-global--spacer--4xl);
     }
+    &.m-is-error {
+      color: var(--pf-global--danger-color--100);
+    }
   }
 }

--- a/src/components/EmptyState/ErrorEmptyState.tsx
+++ b/src/components/EmptyState/ErrorEmptyState.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Button,
+  ButtonVariant,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateProps,
+  EmptyStateVariant,
+  Title,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+import { css } from '@patternfly/react-styles';
+import emptySearchImgUrl from '../../imgs/Not-found.svg';
+import { HttpError } from '../../shared/utils/error/http-error';
+
+import './EmptyState.scss';
+
+export const NotFoundEmptyState: React.FC<{ className?: string }> = ({ className }) => {
+  const navigate = useNavigate();
+  return (
+    <EmptyState className={css('app-empty-state', className)} variant={EmptyStateVariant.full}>
+      <EmptyStateIcon
+        className={css('app-empty-state__icon m-is-error')}
+        icon={() => <img className="app-empty-state__icon" src={emptySearchImgUrl} alt="" />}
+      />
+      <Title className="pf-u-mt-lg" headingLevel="h2" size="lg">
+        404: Page not found
+      </Title>
+      <EmptyStateBody>
+        {`Looks like that page doesn't exist. Let's get you back to your applications list.`}
+      </EmptyStateBody>
+      <Button variant={ButtonVariant.primary} onClick={() => navigate('/stonesoup/applications')}>
+        Go to applications list
+      </Button>
+    </EmptyState>
+  );
+};
+
+type ErrorEmptyStateProps = {
+  httpError?: HttpError;
+  title?: React.ReactNode;
+  body?: React.ReactNode;
+  children?: React.ReactNode;
+} & Omit<EmptyStateProps, 'children'>;
+
+const ErrorEmptyState: React.FC<ErrorEmptyStateProps> = ({
+  title,
+  body,
+  httpError,
+  className,
+  children,
+  ...props
+}) => {
+  if (httpError?.code === 404) {
+    return <NotFoundEmptyState className={className} {...props} />;
+  }
+  return (
+    <EmptyState
+      className={css('app-empty-state', className)}
+      variant={EmptyStateVariant.full}
+      {...props}
+    >
+      <EmptyStateIcon
+        className={css('app-empty-state__icon m-is-error')}
+        icon={ExclamationCircleIcon}
+      />
+      {title ? (
+        <Title className="pf-u-mt-lg" headingLevel="h2" size="lg">
+          {title}
+        </Title>
+      ) : null}
+      {body ? <EmptyStateBody>{body}</EmptyStateBody> : null}
+      {children}
+    </EmptyState>
+  );
+};
+
+export default ErrorEmptyState;

--- a/src/components/EmptyState/__tests__/ErrorEmptyState.spec.tsx
+++ b/src/components/EmptyState/__tests__/ErrorEmptyState.spec.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { EmptyStateBody, Title } from '@patternfly/react-core';
+import { act, render, screen, fireEvent } from '@testing-library/react';
+import { HttpError } from '../../../shared/utils/error/http-error';
+import ErrorEmptyState from '../ErrorEmptyState';
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: jest.fn(),
+  };
+});
+
+const useNavigateMock = useNavigate as jest.Mock;
+
+describe('ErrorEmptyState', () => {
+  let navigateMock;
+
+  beforeEach(() => {
+    navigateMock = jest.fn();
+    useNavigateMock.mockImplementation(() => navigateMock);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('Should show 404 page on a 404 error', async () => {
+    render(
+      <ErrorEmptyState httpError={HttpError.fromCode(404)} title="test title" body="test body" />,
+    );
+    screen.getByText('404: Page not found');
+    expect(screen.queryByText('test title')).toBeNull();
+    expect(screen.queryByText('test body')).toBeNull();
+
+    const appsButton = screen.getByText('Go to applications list');
+    await act(async () => {
+      fireEvent.click(appsButton);
+    });
+    expect(navigateMock).toHaveBeenCalledWith('/stonesoup/applications');
+  });
+
+  it('Should show title and body on non-404 errors', async () => {
+    render(
+      <ErrorEmptyState httpError={HttpError.fromCode(403)} title="test title" body="test body" />,
+    );
+    screen.getByText('test title');
+    screen.getByText('test body');
+
+    expect(screen.queryByText('Go to applications list')).toBeNull();
+  });
+
+  it('Should allow custom errors', async () => {
+    render(
+      <ErrorEmptyState>
+        <Title headingLevel="h4" size="lg">
+          custom title
+        </Title>
+        <EmptyStateBody>custom body</EmptyStateBody>
+      </ErrorEmptyState>,
+    );
+    screen.getByText('custom title');
+    screen.getByText('custom body');
+
+    expect(screen.queryByText('Go to applications list')).toBeNull();
+  });
+});

--- a/src/components/IntegrationTest/IntegrationTestDetailsView.tsx
+++ b/src/components/IntegrationTest/IntegrationTestDetailsView.tsx
@@ -1,22 +1,13 @@
 import React from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
-import {
-  Bullseye,
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateIcon,
-  Spinner,
-  Text,
-  TextVariants,
-  Title,
-} from '@patternfly/react-core';
-import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
-import { SearchIcon } from '@patternfly/react-icons/dist/js/icons';
+import { Bullseye, Spinner, Text, TextVariants } from '@patternfly/react-core';
 import { IntegrationTestScenarioGroupVersionKind } from '../../models';
+import { HttpError } from '../../shared/utils/error/http-error';
 import { IntegrationTestScenarioKind } from '../../types/coreBuildService';
 import { useNamespace } from '../../utils/namespace-context-utils';
 import DetailsPage from '../ApplicationDetails/DetailsPage';
+import ErrorEmptyState from '../EmptyState/ErrorEmptyState';
 import { useModalLauncher } from '../modal/ModalProvider';
 import { integrationTestDeleteModalAndNavigate } from './IntegrationTestsListView/useIntegrationTestActions';
 import IntegrationTestOverviewTab from './tabs/IntegrationTestOverviewTab';
@@ -44,20 +35,11 @@ const IntegrationTestDetailsView: React.FC<IntegrationTestDetailsViewProps> = ({
 
   if (loadErr || (loaded && !integrationTest)) {
     return (
-      <Bullseye>
-        <EmptyState>
-          <EmptyStateIcon
-            style={{ color: 'var(--pf-global--danger-color--100)' }}
-            icon={loadErr ? ExclamationCircleIcon : SearchIcon}
-          />
-          <Title size="lg" headingLevel="h4">
-            {loadErr
-              ? `Could not load ${IntegrationTestScenarioGroupVersionKind.kind}`
-              : 'Integration test not found'}
-          </Title>
-          <EmptyStateBody>{loadErr ? 'Not found' : 'No such Integration test'}</EmptyStateBody>
-        </EmptyState>
-      </Bullseye>
+      <ErrorEmptyState
+        httpError={HttpError.fromCode(loadErr ? (loadErr as any).code : 404)}
+        title="Integration test not found"
+        body="No such Integration test"
+      />
     );
   }
 

--- a/src/components/IntegrationTest/__tests__/IntegrationTestDetailsView.spec.tsx
+++ b/src/components/IntegrationTest/__tests__/IntegrationTestDetailsView.spec.tsx
@@ -46,9 +46,13 @@ describe('IntegrationTestDetailsView', () => {
   });
 
   it('should show error state if test cannot be loaded', () => {
-    watchResourceMock.mockReturnValue([[], false, { message: 'Application does not exist' }]);
+    watchResourceMock.mockReturnValue([
+      [],
+      false,
+      { message: 'Application does not exist', code: 404 },
+    ]);
     routerRenderer(<IntegrationTestDetailsView testName="int-test" applicationName="test" />);
-    screen.getByText('Could not load IntegrationTestScenario');
+    screen.getByText('404: Page not found');
   });
 
   it('should display test data when loaded', () => {

--- a/src/components/PipelineRunDetailsView/PipelineRunDetailsView.tsx
+++ b/src/components/PipelineRunDetailsView/PipelineRunDetailsView.tsx
@@ -5,10 +5,12 @@ import { PipelineRunLabel } from '../../consts/pipelinerun';
 import { PipelineRunGroupVersionKind } from '../../models/pipelineruns';
 import { pipelineRunFilterReducer } from '../../shared';
 import { StatusIconWithTextLabel } from '../../shared/components/pipeline-run-logs/StatusIcon';
+import { HttpError } from '../../shared/utils/error/http-error';
 import { PipelineRunKind } from '../../types';
 import { useNamespace } from '../../utils/namespace-context-utils';
 import { pipelineRunCancel, pipelineRunStop } from '../../utils/pipeline-actions';
 import DetailsPage from '../ApplicationDetails/DetailsPage';
+import ErrorEmptyState from '../EmptyState/ErrorEmptyState';
 import PipelineRunDetailsTab from './tabs/PipelineRunDetailsTab';
 import PipelineRunLogsTab from './tabs/PipelineRunLogsTab';
 import PipelineRunTaskRunsTab from './tabs/PipelineRunTaskRunsTab';
@@ -32,6 +34,17 @@ export const PipelineRunDetailsView: React.FC<PipelineRunDetailsViewProps> = ({
     () => loaded && pipelineRun && pipelineRunFilterReducer(pipelineRun),
     [loaded, pipelineRun],
   );
+
+  if (error) {
+    const httpError = HttpError.fromCode((error as any).code);
+    return (
+      <ErrorEmptyState
+        httpError={httpError}
+        title={`Unable to load pipeline run ${pipelineRunName}`}
+        body={httpError.message}
+      />
+    );
+  }
 
   if (!loaded) {
     return (

--- a/src/components/PipelineRunDetailsView/__tests__/PipelineRunDetailsView.spec.tsx
+++ b/src/components/PipelineRunDetailsView/__tests__/PipelineRunDetailsView.spec.tsx
@@ -120,6 +120,13 @@ describe('PipelineRunDetailsView', () => {
     screen.getByRole('progressbar');
   });
 
+  it('should render the error state if the application is not found', () => {
+    watchResourceMock.mockReturnValue([[], false, { code: 404 }]);
+    routerRenderer(<PipelineRunDetailsView pipelineRunName={pipelineRunName} />);
+    screen.getByText('404: Page not found');
+    screen.getByText('Go to applications list');
+  });
+
   it('should render application display name if application data is loaded', () => {
     watchResourceMock.mockReturnValueOnce([mockApplication, true]).mockReturnValue([[], true]);
     routerRenderer(<PipelineRunDetailsView pipelineRunName={pipelineRunName} />);

--- a/src/pages/EditIntegrationTestPage.tsx
+++ b/src/pages/EditIntegrationTestPage.tsx
@@ -2,22 +2,16 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { useParams } from 'react-router-dom';
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
-import {
-  Bullseye,
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateIcon,
-  Spinner,
-  Title,
-} from '@patternfly/react-core';
-import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+import { Bullseye, Spinner } from '@patternfly/react-core';
+import ErrorEmptyState from '../components/EmptyState/ErrorEmptyState';
 import IntegrationTestView from '../components/IntegrationTest/IntegrationTestForm/IntegrationTestView';
 import NamespacedPage from '../components/NamespacedPage/NamespacedPage';
 import { IntegrationTestScenarioGroupVersionKind } from '../models';
+import { HttpError } from '../shared/utils/error/http-error';
 import { IntegrationTestScenarioKind } from '../types/coreBuildService';
 import { useNamespace } from '../utils/namespace-context-utils';
 
-const IntegrationTestPage: React.FunctionComponent = () => {
+const EditIntegrationTestPage: React.FunctionComponent = () => {
   const { name } = useParams();
 
   const namespace = useNamespace();
@@ -33,25 +27,23 @@ const IntegrationTestPage: React.FunctionComponent = () => {
       : null,
   );
 
+  if (loadErr) {
+    const httpError = HttpError.fromCode((loadErr as any).code);
+    return (
+      <ErrorEmptyState
+        httpError={HttpError.fromCode((loadErr as any).code)}
+        title={`Unable to load integration test ${name}`}
+        body={httpError.message}
+      />
+    );
+  }
+
   return (
     <NamespacedPage>
       <Helmet>
         <title>Edit integration test</title>
       </Helmet>
-      {loadErr ? (
-        <Bullseye>
-          <EmptyState>
-            <EmptyStateIcon
-              style={{ color: 'var(--pf-global--danger-color--100)' }}
-              icon={ExclamationCircleIcon}
-            />
-            <Title size="lg" headingLevel="h4">
-              {`Could not load ${IntegrationTestScenarioGroupVersionKind.kind} named ${name}.`}
-            </Title>
-            <EmptyStateBody>Not found</EmptyStateBody>
-          </EmptyState>
-        </Bullseye>
-      ) : loaded ? (
+      {loaded ? (
         <IntegrationTestView
           applicationName={integrationTest.spec.application}
           integrationTest={integrationTest}
@@ -65,4 +57,4 @@ const IntegrationTestPage: React.FunctionComponent = () => {
   );
 };
 
-export default IntegrationTestPage;
+export default EditIntegrationTestPage;

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ErrorEmptyState from '../components/EmptyState/ErrorEmptyState';
+import NamespacedPage from '../components/NamespacedPage/NamespacedPage';
+import { HttpError } from '../shared/utils/error/http-error';
+
+const NotFoundPage: React.FunctionComponent = () => (
+  <NamespacedPage>
+    <ErrorEmptyState httpError={HttpError.fromCode(404)} />
+  </NamespacedPage>
+);
+
+export default NotFoundPage;

--- a/src/pages/__tests__/EditIntegrationTestPage.spec.tsx
+++ b/src/pages/__tests__/EditIntegrationTestPage.spec.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { useParams } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { configure, screen } from '@testing-library/react';
+import { routerRenderer } from '../../utils/test-utils';
+import EditIntegrationTestPage from '../EditIntegrationTestPage';
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    Link: (props) => <a href={props.to}>{props.children}</a>,
+    useNavigate: () => jest.fn(),
+    useParams: jest.fn(),
+  };
+});
+
+jest.mock('../../components/NamespacedPage/NamespacedPage', () => ({
+  useNamespace: jest.fn(() => 'test'),
+}));
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  useK8sWatchResource: jest.fn(),
+}));
+
+const watchResourceMock = useK8sWatchResource as jest.Mock;
+const useParamsMock = useParams as jest.Mock;
+
+configure({ testIdAttribute: 'data-test' });
+
+describe('EditIntegrationTestPage', () => {
+  it('should show error state if test cannot be loaded', () => {
+    useParamsMock.mockReturnValue({ name: 'int-test' });
+    watchResourceMock.mockReturnValue([[], false, { message: 'Test does not exist', code: 404 }]);
+    routerRenderer(<EditIntegrationTestPage />);
+    screen.getByText('404: Page not found');
+  });
+});


### PR DESCRIPTION
## Fixes 
Fixes [HAC-3050](https://issues.redhat.com/browse/HAC-3050)

## Description
Handle errors at top level pages and display an error state if an error is returned while loading the data.
Created an ErrorState component that handles showing errors consistently, and generically handles 404 errors.

## Type of change
- [x] Bugfix

## Screen shots / Gifs for design review 

![image](https://user-images.githubusercontent.com/11633780/217306492-d112b72b-3f8a-423f-b54f-f880e9709f4f.png)

/cc @MariaLeonova 
