### PR TITLE
fix cursor style while hovering on pipelinerun and commit node

### DIFF
--- a/src/components/ApplicationDetails/tabs/overview/visualization/nodes/CommitWorkflowNode.tsx
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/nodes/CommitWorkflowNode.tsx
@@ -19,7 +19,7 @@ const CommitWorkflowNode: React.FC<CommitWorkflowNodeProps> = ({ element }) => {
     <TaskNode
       truncateLength={element.getData().label?.length}
       element={element}
-      className={css('workload-node', { 'm-disabled': isDisabled })}
+      className={css('commit-node', { 'm-disabled': isDisabled })}
       taskIcon={getWorkflowNodeIcon(workflowType)}
       taskIconTooltip={getTooltipText(workflowType)}
       status={statusToRunStatus(status)}

--- a/src/components/ApplicationDetails/tabs/overview/visualization/nodes/WorkflowNode.scss
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/nodes/WorkflowNode.scss
@@ -1,4 +1,4 @@
-.workload-node {
+.workload-node, .commit-node {
   cursor: pointer;
   &.m-disabled {
     > .pf-topology-pipelines__pill-background {
@@ -13,4 +13,7 @@
       padding: 0;
     }
   }
+}
+.commit-node {
+  cursor: default;
 }

--- a/src/components/PipelineRunDetailsView/visualization/nodes/PipelineRunNode.scss
+++ b/src/components/PipelineRunDetailsView/visualization/nodes/PipelineRunNode.scss
@@ -1,0 +1,3 @@
+.pipelinerun-node {
+    cursor: default;
+}

--- a/src/components/PipelineRunDetailsView/visualization/nodes/PipelineRunNode.tsx
+++ b/src/components/PipelineRunDetailsView/visualization/nodes/PipelineRunNode.tsx
@@ -9,6 +9,8 @@ import {
 } from '@patternfly/react-topology';
 import { observer } from 'mobx-react';
 
+import './PipelineRunNode.scss';
+
 type PipelineRunNodeProps = {
   element: Node;
 } & WithContextMenuProps &
@@ -46,6 +48,7 @@ const PipelineRunNode: React.FunctionComponent<PipelineRunNodeProps> = ({
 
   return (
     <TaskNode
+      className="pipelinerun-node"
       element={element}
       onContextMenu={data.showContextMenu ? onContextMenu : undefined}
       contextMenuOpen={contextMenuOpen}


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-3126

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

On hovering over the pipeline run/commit nodes, the cursor pointer is applied but there isn't any interaction on the node yet.
We have a story to address the pipeline run and commit node interactions in the backlog, so removing the cursor pointer style until we implement the interactions.

[slack thread](https://redhat-internal.slack.com/archives/C038DJAP7HR/p1675862260167559?thread_ts=1675806083.101539&cid=C038DJAP7HR) 

## Type of change
<!-- Please delete options that are not relevant. -->


- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

https://user-images.githubusercontent.com/9964343/217618070-b9495c8c-c5cb-4667-b672-410c294ff3e6.mp4


https://user-images.githubusercontent.com/9964343/217618052-eb222faf-39b5-4882-b9d8-fc998dd3e77d.mp4


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->


