### PR TITLE
update overview page layout and actions

### DIFF
--- a/integration-tests/support/pageObjects/global-po.ts
+++ b/integration-tests/support/pageObjects/global-po.ts
@@ -7,8 +7,6 @@ export const alertTitle = '.pf-c-alert__title';
 
 export const consentButton = '[id="truste-consent-button"]';
 
-export const overviewCreateAppButton = 'a[data-test="go-to-applications-page"]';
-
 export const loginPO = {
   usernameForm: '.pf-c-login__main',
   username: '#rh-username-verification-form',

--- a/integration-tests/utils/Login.ts
+++ b/integration-tests/utils/Login.ts
@@ -1,5 +1,4 @@
-import { overviewCreateAppButton } from './../support/pageObjects/global-po';
-import { pageTitles } from '../support/constants/PageTitle';
+import { NavItem, pageTitles } from '../support/constants/PageTitle';
 import { loginPO, kcLoginPO } from '../support/pageObjects/global-po';
 import { Common } from './Common';
 
@@ -30,7 +29,7 @@ export class Login {
 
   private static waitForApps() {
     Common.waitForLoad();
-    cy.get(overviewCreateAppButton).click();
+    Common.navigateTo(NavItem.applications);
     Common.verifyPageTitle(pageTitles.applications);
     Common.waitForLoad();
     cy.testA11y(`${pageTitles.applications} page`);

--- a/src/components/Overview/AboutSection.tsx
+++ b/src/components/Overview/AboutSection.tsx
@@ -37,7 +37,7 @@ const TechnologyTile: React.FC<TechnologyTileProps> = ({ name, logo }) => (
 
 const AboutSection: React.FC = () => (
   <Grid hasGutter>
-    <GridItem span={8}>
+    <GridItem sm={12} lg={8}>
       <Card isLarge>
         <CardTitle>About</CardTitle>
         <CardBody style={{ paddingLeft: '16px' }}>
@@ -79,7 +79,7 @@ const AboutSection: React.FC = () => (
         </CardBody>
       </Card>
     </GridItem>
-    <GridItem span={4}>
+    <GridItem sm={12} lg={4}>
       <Stack hasGutter>
         <StackItem>
           <Card isLarge>

--- a/src/components/Overview/InfoBanner.tsx
+++ b/src/components/Overview/InfoBanner.tsx
@@ -20,6 +20,7 @@ const InfoBanner = () => (
       <Flex
         justifyContent={{ default: 'justifyContentSpaceEvenly' }}
         flexWrap={{ default: 'nowrap' }}
+        direction={{ default: 'column', sm: 'row' }}
       >
         <FlexItem flex={{ default: 'flex_1' }}>
           <Card isPlain isCompact>

--- a/src/components/Overview/IntroBanner.scss
+++ b/src/components/Overview/IntroBanner.scss
@@ -9,4 +9,13 @@
     background-color: var(--pf-global--BackgroundColor--dark-100);
     background-size: cover;
   }
+
+  &__cta {
+    margin-top: var(--pf-global--spacer--sm);
+    margin-right: var(--pf-global--spacer--md);
+
+    & + &__cta {
+      margin-right: none;
+    }
+  }
 }


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-3128
https://issues.redhat.com/browse/HAC-3130

## Description
Makes overview page responsive.
Changes the `+ Create an application` action to go to the import wizard instead of the application list view.
Add action `View my applications` to go to the application list view. This action will only appear if the user has at least one application.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
![image](https://user-images.githubusercontent.com/14068621/217670801-928ba729-49b7-4744-9cef-033e876258bb.png)

![image](https://user-images.githubusercontent.com/14068621/217670889-cbd9ebb2-817f-4b95-8449-8cbf11aca6d5.png)
![image](https://user-images.githubusercontent.com/14068621/217670917-62a4be67-38ea-41e8-8c2f-fe58925e2de1.png)


## How to test or reproduce?
Visit the overview page with 0 or more applications.

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
