### PR TITLE
fallback to app metadata.name when displayName is empty

### DIFF
--- a/src/components/ApplicationDetails/ApplicationDetails.tsx
+++ b/src/components/ApplicationDetails/ApplicationDetails.tsx
@@ -63,7 +63,8 @@ const ApplicationDetails: React.FC<HacbsApplicationDetailsProps> = ({ applicatio
     name: applicationName,
     namespace,
   });
-  const appDisplayName = application?.spec?.displayName || applicationName;
+
+  const appDisplayName = application?.spec?.displayName || application?.metadata?.name || '';
 
   if (applicationError) {
     const appError = HttpError.fromCode((applicationError as any).code);

--- a/src/components/ApplicationListView/ApplicationListRow.tsx
+++ b/src/components/ApplicationListView/ApplicationListRow.tsx
@@ -1,22 +1,17 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { pluralize, Skeleton } from '@patternfly/react-core';
 import { useAllApplicationEnvironmentsWithHealthStatus } from '../../hooks/useAllApplicationEnvironmentsWithHealthStatus';
-import { ComponentGroupVersionKind } from '../../models';
+import { useComponents } from '../../hooks/useComponents';
 import ActionMenu from '../../shared/components/action-menu/ActionMenu';
 import { RowFunctionArgs, TableData } from '../../shared/components/table';
 import { Timestamp } from '../../shared/components/timestamp/Timestamp';
-import { ApplicationKind, ComponentKind } from '../../types';
+import { ApplicationKind } from '../../types';
 import { useApplicationActions } from './application-actions';
 import { applicationTableColumnClasses } from './ApplicationListHeader';
 
 const ApplicationListRow: React.FC<RowFunctionArgs<ApplicationKind>> = ({ obj }) => {
-  const [allComponents, loaded] = useK8sWatchResource<ComponentKind[]>({
-    groupVersionKind: ComponentGroupVersionKind,
-    namespace: obj.metadata.namespace,
-    isList: true,
-  });
+  const [components, loaded] = useComponents(obj.metadata.namespace, obj.metadata.name);
 
   const [allEnvironments, environmentsLoaded] = useAllApplicationEnvironmentsWithHealthStatus(
     obj.metadata.name,
@@ -33,13 +28,13 @@ const ApplicationListRow: React.FC<RowFunctionArgs<ApplicationKind>> = ({ obj })
 
   const actions = useApplicationActions(obj);
 
-  const components = allComponents?.filter((c) => c.spec.application === obj.metadata.name) ?? [];
+  const displayName = obj.spec.displayName || obj.metadata.name;
 
   return (
     <>
       <TableData className={applicationTableColumnClasses.name}>
-        <Link to={`/stonesoup/applications/${obj.metadata.name}`} title={obj.spec.displayName}>
-          {obj.spec.displayName}
+        <Link to={`/stonesoup/applications/${obj.metadata.name}`} title={displayName}>
+          {displayName}
         </Link>
       </TableData>
       <TableData className={applicationTableColumnClasses.components}>

--- a/src/components/ApplicationListView/__tests__/ApplicationListRow.spec.tsx
+++ b/src/components/ApplicationListView/__tests__/ApplicationListRow.spec.tsx
@@ -38,7 +38,7 @@ const application: ApplicationKind = {
     uid: '60725777-a545-4c54-bf25-19a3f231aed1',
   },
   spec: {
-    displayName: 'mno-app',
+    displayName: 'mno app display name',
   },
 };
 
@@ -99,7 +99,7 @@ describe('Application List Row', () => {
         mockSnapshotsEnvironmentBindings[0].status.componentDeploymentConditions[0].lastTransitionTime,
       ),
     );
-    expect(getByText(application.metadata.name)).toBeInTheDocument();
+    expect(getByText(application.spec.displayName)).toBeInTheDocument();
     expect(getByText('2 Components')).toBeInTheDocument();
     expect(container).toHaveTextContent(expectedDate.toString());
   });
@@ -124,5 +124,16 @@ describe('Application List Row', () => {
     watchResourceMock.mockReturnValue([[], false]);
     const { getByText } = render(<ApplicationListRow columns={null} obj={application} />);
     expect(getByText('Loading component count')).toBeInTheDocument();
+  });
+
+  it('should render metadata name if there is no display name', () => {
+    watchResourceMock.mockReturnValue([[], false]);
+    const { getByRole } = render(
+      <ApplicationListRow
+        columns={null}
+        obj={{ ...application, spec: { ...application.spec, displayName: '' } }}
+      />,
+    );
+    expect(getByRole('link', { name: application.metadata.name })).toBeInTheDocument();
   });
 });

--- a/src/components/modal/resource-modals.tsx
+++ b/src/components/modal/resource-modals.tsx
@@ -7,12 +7,13 @@ export const applicationDeleteModal = (applicationObj: ApplicationKind) =>
   createDeleteModalLauncher(applicationObj.kind)({
     obj: applicationObj,
     model: ApplicationModel,
-    displayName: applicationObj.spec.displayName,
+    displayName: applicationObj.spec.displayName || applicationObj.metadata.name,
     description: (
       <>
-        The application <strong>{applicationObj.spec.displayName}</strong> will be deleted
-        permanently with all of its components. The deleted application will be promoted manually or
-        automatically based on the deployment strategy of each environment.
+        The application{' '}
+        <strong>{applicationObj.spec.displayName || applicationObj.metadata.name}</strong> will be
+        deleted permanently with all of its components. The deleted application will be promoted
+        manually or automatically based on the deployment strategy of each environment.
       </>
     ),
   });


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-3135

## Description
Fallback to application `metadata.name` when `spec.displayName` does not exist or is an empty string.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
![image](https://user-images.githubusercontent.com/14068621/217678095-c42d9923-eaed-4c75-a1a6-dc9c7d0f3f7f.png)


![image](https://user-images.githubusercontent.com/14068621/217678030-0d7cfec5-6253-4577-9f60-0027a31bf7c5.png)

![image](https://user-images.githubusercontent.com/14068621/217678112-2d769f2b-64e8-4b05-8ff1-cbcbf99061f5.png)

![image](https://user-images.githubusercontent.com/14068621/217678126-313e21f5-7d5f-4313-9c86-b6c8e2890c56.png)


## How to test or reproduce?
Create a new application.
Edit the application yaml and delete the `spec.displayName` or set to an empty string.

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
