### PR TITLE
fix customize pipeline modal for single component

### DIFF
--- a/src/components/ApplicationDetails/component-actions.tsx
+++ b/src/components/ApplicationDetails/component-actions.tsx
@@ -1,7 +1,7 @@
 import { Action } from '../../shared/components/action-menu/types';
 import { ComponentKind } from '../../types';
 import { isPACEnabled, startNewBuild } from '../../utils/component-utils';
-import { createCustomizePipelinesModalLauncher } from '../CustomizedPipeline/CustomizePipelinesModal';
+import { createCustomizeComponentPipelineModalLauncher } from '../CustomizedPipeline/CustomizePipelinesModal';
 import { useModalLauncher } from '../modal/ModalProvider';
 import { componentDeleteModal } from '../modal/resource-modals';
 
@@ -9,7 +9,13 @@ export const useComponentActions = (component: ComponentKind, name: string): Act
   const showModal = useModalLauncher();
   const actions: Action[] = [
     {
-      cta: () => showModal(createCustomizePipelinesModalLauncher([component])),
+      cta: () =>
+        showModal(
+          createCustomizeComponentPipelineModalLauncher(
+            component.metadata.name,
+            component.metadata.namespace,
+          ),
+        ),
       id: 'customize-build-pipeline',
       label: 'Customize build pipeline',
     },

--- a/src/components/Components/ComponentPACStateLabel.tsx
+++ b/src/components/Components/ComponentPACStateLabel.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Label, Tooltip } from '@patternfly/react-core';
 import usePACState, { PACState } from '../../hooks/usePACState';
 import { ComponentKind } from '../../types';
-import { createCustomizePipelinesModalLauncher } from '../CustomizedPipeline/CustomizePipelinesModal';
+import { createCustomizeComponentPipelineModalLauncher } from '../CustomizedPipeline/CustomizePipelinesModal';
 import { useModalLauncher } from '../modal/ModalProvider';
 
 type Props = {
@@ -20,8 +20,14 @@ const ComponentPACStateLabel: React.FC<Props> = ({ component, onStateChange }) =
   }, [pacState]);
 
   const customizePipeline = React.useCallback(
-    () => showModal(createCustomizePipelinesModalLauncher([component])),
-    [showModal, component],
+    () =>
+      showModal(
+        createCustomizeComponentPipelineModalLauncher(
+          component.metadata.name,
+          component.metadata.namespace,
+        ),
+      ),
+    [showModal, component.metadata.name, component.metadata.namespace],
   );
 
   switch (pacState) {

--- a/src/components/CustomizedPipeline/CustomizeAllPipelines.tsx
+++ b/src/components/CustomizedPipeline/CustomizeAllPipelines.tsx
@@ -32,9 +32,7 @@ const CustomizeAllPipelines: React.FC<Props> = ({
 
   if (loaded) {
     if (components.length > 0) {
-      return (
-        <CustomizePipeline components={filteredComponents} loading={!loaded} onClose={onClose} />
-      );
+      return <CustomizePipeline components={filteredComponents} onClose={onClose} />;
     }
 
     return (

--- a/src/components/CustomizedPipeline/CustomizeComponentPipeline.tsx
+++ b/src/components/CustomizedPipeline/CustomizeComponentPipeline.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { ComponentGroupVersionKind } from '../../models';
+import { ComponentKind } from '../../types';
+import { ComponentProps } from '../modal/createModalLauncher';
+import CustomizePipeline from './CustomizePipelines';
+
+type Props = ComponentProps & {
+  namespace: string;
+  name: string;
+};
+
+const CustomizeComponentPipeline: React.FC<Props> = ({ namespace, name, onClose }) => {
+  const [watchedComponent, loaded] = useK8sWatchResource<ComponentKind>({
+    groupVersionKind: ComponentGroupVersionKind,
+    namespace,
+    name,
+    isList: false,
+  });
+  if (loaded && watchedComponent) {
+    return <CustomizePipeline components={[watchedComponent]} onClose={onClose} />;
+  }
+  return null;
+};
+
+export default CustomizeComponentPipeline;

--- a/src/components/CustomizedPipeline/CustomizePipelines.tsx
+++ b/src/components/CustomizedPipeline/CustomizePipelines.tsx
@@ -25,7 +25,6 @@ import { ComponentProps } from '../modal/createModalLauncher';
 
 type Props = ComponentProps & {
   components: ComponentKind[];
-  loading?: boolean;
 };
 
 const Row: React.FC<{
@@ -124,12 +123,13 @@ const Row: React.FC<{
   );
 };
 
-const CustomizePipeline: React.FC<Props> = ({ components, onClose, loading }) => {
+const CustomizePipeline: React.FC<Props> = ({ components, onClose }) => {
   const [showRequestedAlert, setShowRequestedAlert] = React.useState(false);
 
-  const sortedComponents = !loading
-    ? [...components].sort((a, b) => a.metadata.name.localeCompare(b.metadata.name))
-    : [];
+  const sortedComponents = React.useMemo(
+    () => [...components].sort((a, b) => a.metadata.name.localeCompare(b.metadata.name)),
+    [components],
+  );
 
   const [componentState, setComponentState] = React.useState<{ [name: string]: PACState }>({});
 
@@ -244,14 +244,14 @@ const CustomizePipeline: React.FC<Props> = ({ components, onClose, loading }) =>
             variant={AlertVariant.warning}
             title="Sending pull request is taking more time than expected"
             className="pf-u-mt-lg"
+            actionLinks={
+              <ExternalLink href="https://github.com/apps/appstudio-staging-ci" showIcon>
+                Start the flow
+              </ExternalLink>
+            }
           >
             You may need to install the GitHub application and grant permissions to the component
             repository.
-            <br />
-            <br />
-            <ExternalLink href="https://github.com/apps/appstudio-staging-ci" showIcon>
-              Start the flow
-            </ExternalLink>
           </Alert>
         ) : undefined}
       </ModalBoxBody>

--- a/src/components/CustomizedPipeline/CustomizePipelinesModal.tsx
+++ b/src/components/CustomizedPipeline/CustomizePipelinesModal.tsx
@@ -2,7 +2,7 @@ import { ModalVariant } from '@patternfly/react-core';
 import { ComponentKind } from '../../types';
 import { createModalLauncher } from '../modal/createModalLauncher';
 import CustomizeAllPipelines from './CustomizeAllPipelines';
-import CustomizePipelines from './CustomizePipelines';
+import CustomizeComponentPipeline from './CustomizeComponentPipeline';
 
 export const createCustomizeAllPipelinesModalLauncher = (
   applicationName: string,
@@ -11,14 +11,14 @@ export const createCustomizeAllPipelinesModalLauncher = (
   onClose?: () => void,
 ) =>
   createModalLauncher(CustomizeAllPipelines, {
-    'data-testid': `customized-all-pipelines-modal`,
+    'data-testid': 'customized-all-pipelines-modal',
     variant: ModalVariant.large,
     hasNoBodyWrapper: true,
   })({ applicationName, namespace, filter, onClose });
 
-export const createCustomizePipelinesModalLauncher = (components?: ComponentKind[]) =>
-  createModalLauncher(CustomizePipelines, {
-    'data-testid': `customized-pipelines-modal`,
+export const createCustomizeComponentPipelineModalLauncher = (name: string, namespace: string) =>
+  createModalLauncher(CustomizeComponentPipeline, {
+    'data-testid': 'customized-pipelines-modal',
     variant: ModalVariant.large,
     hasNoBodyWrapper: true,
-  })({ components });
+  })({ name, namespace });

--- a/src/components/CustomizedPipeline/__tests__/CustomizeComponentPipeline.spec.tsx
+++ b/src/components/CustomizedPipeline/__tests__/CustomizeComponentPipeline.spec.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { render } from '@testing-library/react';
+import { ComponentKind } from '../../../types';
+import CustomizeComponentPipeline from '../CustomizeComponentPipeline';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  useK8sWatchResource: jest.fn(() => [[], true]),
+}));
+
+const useK8sWatchResourceMock = useK8sWatchResource as jest.Mock;
+
+const mockComponent = {
+  metadata: {
+    name: `my-component`,
+  },
+  spec: {
+    source: {
+      git: {
+        url: 'https://github.com/org/test',
+      },
+    },
+  },
+} as any as ComponentKind;
+
+describe('CustomizeAllPipelines', () => {
+  it('should render nothing while loading', () => {
+    useK8sWatchResourceMock.mockReturnValueOnce([{}, false]);
+    const result = render(<CustomizeComponentPipeline name="my-component" namespace="test" />);
+    expect(result.baseElement.textContent).toBe('');
+  });
+
+  it('should render modal with components table', () => {
+    useK8sWatchResourceMock.mockReturnValueOnce([mockComponent, true]);
+    const result = render(<CustomizeComponentPipeline name="my-component" namespace="test" />);
+    expect(result.getByTestId('component-row', { exact: false })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-3140

## Description
When the customize pipeline modal is opened for a single component using the kebab menu item of a row in the component list view, the state of the component is not updated as the state changes.

The reason this happens is because the component instance passed to the modal is stale.

Reworked the logic to pass 

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
No change in visuals

## How to test or reproduce?
- Create a component with default build
- from the components tab, select `customize build pipeline` from the component row kebab
- Click on `send pull request`
- observe the state never updates before this change
- after this change the state should update as the user goes through the flow


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
