### PR TITLE
show full description of samples

### DIFF
--- a/src/components/ImportForm/SampleSection/SampleSection.tsx
+++ b/src/components/ImportForm/SampleSection/SampleSection.tsx
@@ -139,7 +139,6 @@ const SampleSection = ({ onStrategyChange }) => {
                       className="hac-catalog__tile"
                       id={sample.uid}
                       title={sample.name}
-                      description={sample.description}
                       featured={sample.name === selected?.name}
                       data-test={`${sample.type}-${sample.name}`}
                       badges={sample.tags?.map((tag) => (
@@ -175,7 +174,9 @@ const SampleSection = ({ onStrategyChange }) => {
                           Git repository
                         </Button>
                       }
-                    />
+                    >
+                      {sample.description}
+                    </CatalogTile>
                   </GalleryItem>
                 ))}
               </Gallery>


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-3125

## Description
Show the full description content of the sample in the card instead of a single line which cuts the description short.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
before:
![image](https://user-images.githubusercontent.com/14068621/217923605-9e4bc82a-0034-45e1-b8de-ac80891f5dc2.png)

after:
![image](https://user-images.githubusercontent.com/14068621/217923642-00574883-e829-42ee-836c-803def326c17.png)


## How to test or reproduce?
- add a component
- choose to start from a sample

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
