### PR TITLE
extend samples background to bottom of wizard

### DIFF
--- a/src/components/ImportForm/ImportForm.scss
+++ b/src/components/ImportForm/ImportForm.scss
@@ -1,0 +1,11 @@
+.import-form {
+  .pf-c-wizard__main {
+    display: flex;
+    flex-direction: column;
+  }
+  .pf-c-wizard__main-body {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+  }
+}

--- a/src/components/ImportForm/ImportForm.tsx
+++ b/src/components/ImportForm/ImportForm.tsx
@@ -9,6 +9,8 @@ import { createResources } from './utils/submit-utils';
 import { ImportFormValues, ImportStrategy } from './utils/types';
 import { useImportSteps } from './utils/useImportSteps';
 
+import './ImportForm.scss';
+
 type ImportFormProps = {
   applicationName?: string;
 };
@@ -72,7 +74,12 @@ const ImportForm: React.FunctionComponent<ImportFormProps> = ({ applicationName 
   };
 
   return (
-    <PageSection isFilled type={PageSectionTypes.wizard} variant={PageSectionVariants.light}>
+    <PageSection
+      isFilled
+      type={PageSectionTypes.wizard}
+      variant={PageSectionVariants.light}
+      className="import-form"
+    >
       <FormikWizard
         onSubmit={handleSubmit}
         onReset={handleReset}

--- a/src/components/ImportForm/SampleSection/SampleSection.tsx
+++ b/src/components/ImportForm/SampleSection/SampleSection.tsx
@@ -78,7 +78,7 @@ const SampleSection = ({ onStrategyChange }) => {
   return (
     <>
       <HeadTitle>Import - Select sample | CI/CD</HeadTitle>
-      <PageSection variant="light" isFilled>
+      <PageSection variant="light">
         <TextContent>
           <Text component={TextVariants.h2}>
             Select a sample{' '}


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-3098

## Description
Update styles to make the wizard content extend to the bottom so that the grey background of the samples isn't cut short.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
before:
![image](https://user-images.githubusercontent.com/14068621/217932611-d2c0ee8f-aecb-46c2-920f-613f664ee019.png)


after:
![image](https://user-images.githubusercontent.com/14068621/217932201-06db5658-c764-43eb-912c-f6baac44d2e6.png)

![image](https://user-images.githubusercontent.com/14068621/217932404-22fb0bf7-c48e-4a75-87c9-0d2e5243934a.png)

## How to test or reproduce?
- create a new component from samples

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
