### PR TITLE
Pin back RedhatInsights frontend-builder-common to fix PR check

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -10,7 +10,7 @@ export APP_ROOT=$(pwd)
 export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
 export NODE_BUILD_VERSION=14
 IMAGE="quay.io/cloudservices/hac-dev-frontend"
-COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
+COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/990db3673ececc8b13f53610dc560ecb4615d494
 
 # --------------------------------------------
 # Options that must be configured by app owner


### PR DESCRIPTION
It seems the cutover to Caddy had broken our PR check. See: https://github.com/RedHatInsights/insights-frontend-builder-common/commit/e8332b4624ff467105160083afbba40e797a5949.

That commit pulls in https://gitlab.cee.redhat.com/insights-platform/frontend-build-container/-/merge_requests/23 which defaults PR checks to use Caddy over NGINX. HAC dev does not yet use caddy (it broke things when we merged it last time)

In order to unblock all other PRs, we either need to:

- merge @karelhala's PR to enable caddy support in HAC dev: https://github.com/openshift/hac-dev/pull/404
- merge this PR