### PR TITLE
Add clipboard copy to built container image field

### DIFF
--- a/src/components/Components/ComponentListItem.tsx
+++ b/src/components/Components/ComponentListItem.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  ClipboardCopy,
   DataListAction,
   DataListCell,
   DataListContent,
@@ -170,7 +171,9 @@ export const ComponentListItem: React.FC<ComponentListViewItemProps> = ({
             <DescriptionListGroup>
               <DescriptionListTerm>Built container image</DescriptionListTerm>
               <DescriptionListDescription>
-                <ExternalLink href={`https://${containerImage}`} text={containerImage} />
+                <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied">
+                  {containerImage}
+                </ClipboardCopy>
               </DescriptionListDescription>
             </DescriptionListGroup>
           )}

--- a/src/components/Components/__tests__/ComponentListItem.spec.tsx
+++ b/src/components/Components/__tests__/ComponentListItem.spec.tsx
@@ -98,4 +98,18 @@ describe('ComponentListItem', () => {
     render(<ComponentListItem component={component} routes={[]} />);
     await waitFor(() => expect(screen.queryByText('Component Created')).not.toBeInTheDocument());
   });
+
+  it('should not render Built container image if the containerImage is missing in component status', async () => {
+    const component = { ...componentCRMocks[0], status: undefined };
+    render(<ComponentListItem component={component} routes={[]} />);
+    await waitFor(() =>
+      expect(screen.queryByText('Built container image')).not.toBeInTheDocument(),
+    );
+  });
+
+  it('should render Built container image if the component status contains the containerImage field', async () => {
+    const component = componentCRMocks[0];
+    render(<ComponentListItem component={component} routes={[]} />);
+    await waitFor(() => expect(screen.queryByText('Built container image')).toBeInTheDocument());
+  });
 });


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-2866

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Add clipboard copy feature to build container image field in component list. 

Note:
Container image link that we show today redirects to a 403 page and it isn't useful.[ Slack thread](https://redhat-internal.slack.com/archives/C038DJAP7HR/p1675805885081549?thread_ts=1673452387.689769&cid=C038DJAP7HR)

## Type of change
<!-- Please delete options that are not relevant. -->


- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

![ContainerImage](https://user-images.githubusercontent.com/9964343/218133142-fc44fcd7-8a3b-43dd-988a-40fd95c81e1c.gif)

## Unit tests
```
  ComponentListItem
    ✓ should not render Built container image if the containerImage is missing in component status (13 ms)
    ✓ should render Built container image if the component status contains the containerImage field (17 ms)
 ```   

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
