### PR TITLE
fix crash when import a private Git Repository

### DIFF
--- a/src/components/Environment/EditStrategyModal.tsx
+++ b/src/components/Environment/EditStrategyModal.tsx
@@ -31,7 +31,7 @@ type DeleteResourceModalProps = ComponentProps & {
 };
 
 export const EditStrategyModal: React.FC<DeleteResourceModalProps> = ({ obj, onClose }) => {
-  const [error, setError] = React.useState();
+  const [error, setError] = React.useState<string>();
   const initialStrategy = dropdownItems.find((i) => i.key === obj.spec.deploymentStrategy).value;
 
   const updateEnvironment = async (values: FormikValues) => {
@@ -47,7 +47,7 @@ export const EditStrategyModal: React.FC<DeleteResourceModalProps> = ({ obj, onC
       });
       onClose({ submitClicked: true });
     } catch (e) {
-      setError(e);
+      setError(e.message || e.toString());
     }
   };
 

--- a/src/components/ImportForm/SourceSection/AuthTokenModal.tsx
+++ b/src/components/ImportForm/SourceSection/AuthTokenModal.tsx
@@ -24,7 +24,7 @@ type AuthTokenModalProps = ComponentProps & {
 };
 
 export const AuthTokenModal: React.FC<AuthTokenModalProps> = ({ onClose, uploadUrl }) => {
-  const [error, setError] = React.useState();
+  const [error, setError] = React.useState<string>();
   const { uploadToken } = useSpiAPI();
 
   const submitToken = React.useCallback(
@@ -33,7 +33,7 @@ export const AuthTokenModal: React.FC<AuthTokenModalProps> = ({ onClose, uploadU
         await uploadToken(uploadUrl, values.username, values.token);
         onClose();
       } catch (e) {
-        setError(e);
+        setError(e.message || e.toString());
       }
     },
     [uploadUrl, onClose, uploadToken],

--- a/src/components/modal/DeleteResourceModal.tsx
+++ b/src/components/modal/DeleteResourceModal.tsx
@@ -39,7 +39,7 @@ export const DeleteResourceModal: React.FC<DeleteResourceModalProps> = ({
   isEntryNotRequired = false,
   description,
 }) => {
-  const [error, setError] = React.useState();
+  const [error, setError] = React.useState<string>();
   const resourceName = displayName || obj.metadata.name;
   const deleteResource = async () => {
     try {
@@ -51,7 +51,7 @@ export const DeleteResourceModal: React.FC<DeleteResourceModalProps> = ({
         },
       });
     } catch (e) {
-      setError(e);
+      setError(e.message || e.toString());
     }
     onClose({ submitClicked: true });
   };


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/HAC-3029

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This issue only presents itself in production because the error is due to CORS.

If the network request to SPI fails, the UI was setting the error object into the state. We then try to render the error object which causes react to blow up. The solution is to extract the error message and set a string to the error state.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
No change.

## How to test or reproduce?
- go to create a component
- enter any git url that's unreachable
- manually enter a token
- press connect

You will need to force an error to occur in the network request to SPI in order to reproduce this.

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
