### PR TITLE
Add environment order in list view

### DIFF
--- a/src/components/Environment/EnvironmentListView.tsx
+++ b/src/components/Environment/EnvironmentListView.tsx
@@ -22,6 +22,7 @@ import {
 import { CubesIcon } from '@patternfly/react-icons/dist/esm/icons';
 import { useSearchParam } from '../../hooks/useSearchParam';
 import { EnvironmentKind } from '../../types';
+import { sortEnvironmentsBasedonParent } from '../../utils/environment-utils';
 import { MVP_FLAG } from '../../utils/flag-utils';
 import FilteredEmptyState from '../EmptyState/FilteredEmptyState';
 import EnvironmentCard from './EnvironmentCard';
@@ -60,7 +61,7 @@ const EnvironmentListView: React.FC<Props> = ({
     // apply filter if present
     result = filter ? result.filter(filter) : result;
 
-    return result;
+    return sortEnvironmentsBasedonParent(result);
   }, [environments, filter, nameFilter]);
 
   const createEnvironmentButton = React.useMemo(() => {
@@ -145,7 +146,7 @@ const EnvironmentListView: React.FC<Props> = ({
           ) : (
             <Grid hasGutter>
               {mvpFeature
-                ? environments.map((env) => (
+                ? filteredEnvironments.map((env) => (
                     <GridItem
                       span={12}
                       md={6}

--- a/src/hacbs/components/Environment/__tests__/EnvironmentListView.spec.tsx
+++ b/src/hacbs/components/Environment/__tests__/EnvironmentListView.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import '@testing-library/jest-dom';
 import { useFeatureFlag } from '@openshift/dynamic-plugin-sdk';
-import { render, screen, configure, cleanup, fireEvent } from '@testing-library/react';
+import { render, screen, configure, cleanup, fireEvent, within } from '@testing-library/react';
 import { getMockWorkflows } from '../../../../components/ApplicationDetails/__data__/WorkflowTestUtils';
 import { EnvironmentType } from '../../../../components/Environment/environment-utils';
 import { useAllEnvironments } from '../../../../hooks/useAllEnvironments';
@@ -102,6 +102,16 @@ describe('EnvironmentListView', () => {
     expect(screen.getAllByTestId('environment-card').length).toBe(
       mockAppEnvWithHealthStatus.length,
     );
+  });
+
+  it('should render environment(s) in order based on parentEnvironments', () => {
+    useAllEnvironmentsMock.mockReturnValue([mockAppEnvWithHealthStatus.slice(0, 3), true]);
+
+    render(<EnvironmentListView validTypes={[EnvironmentType.static]} />);
+    const environmentCards = screen.getAllByTestId('environment-card');
+    within(environmentCards[0]).getByText('Development');
+    within(environmentCards[1]).getByText('Staging');
+    within(environmentCards[2]).getByText('Production');
   });
 
   it('should pre-filter environments by type', () => {


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-3141

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Environment list view should list the environments in order based on the selected parentEnvironment.

## Type of change
<!-- Please delete options that are not relevant. -->


- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

**Before:**

<img width="1467" alt="image" src="https://user-images.githubusercontent.com/9964343/218387294-a29e3c50-6a28-42a7-9f9d-56df01aa12c7.png">



**After:**

<img width="1484" alt="Screenshot 2023-02-13 at 12 00 33 PM" src="https://user-images.githubusercontent.com/9964343/218386905-a0afb15d-27bb-46d0-8133-1c7f130e0fe4.png">


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

Create a list of environment in the order using spec.parentEnvironment fields or via UI by adding ?mvp=false flag in environment page.

## Unit tests

```
  EnvironmentListView
    ✓ should render environment(s) in order based on parentEnvironments (40 ms)
```

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
