### PR TITLE
Update application health status to only use SEB

### DIFF
--- a/src/utils/__tests__/environment-utils.spec.ts
+++ b/src/utils/__tests__/environment-utils.spec.ts
@@ -1,13 +1,8 @@
 import { RunStatus } from '@patternfly/react-topology';
 import { mockSnapshotsEnvironmentBindings } from '../../components/ApplicationDetails/__data__';
 import { EnvironmentKind } from '../../types';
+import { GitOpsDeploymentHealthStatus } from '../../types/gitops-deployment';
 import {
-  GitOpsDeploymentHealthStatus,
-  GitOpsDeploymentKind,
-  GitOpsDeploymentStrategy,
-} from '../../types/gitops-deployment';
-import {
-  getApplicationGitopsStatus,
   getComponentDeploymentRunStatus,
   getComponentDeploymentStatus,
   sortEnvironmentsBasedonParent,
@@ -178,54 +173,6 @@ describe('environment-utils', () => {
     it('should return Succeeded status for healthy application', () => {
       const degradedApplication = mockSnapshotsEnvironmentBindings[2];
       expect(getComponentDeploymentRunStatus(degradedApplication)).toBe(RunStatus.Failed);
-    });
-  });
-
-  describe('getApplicationGitopsStatus', () => {
-    const getGitOpsMockCr = (status: GitOpsDeploymentHealthStatus) =>
-      ({
-        spec: { type: GitOpsDeploymentStrategy.automated, source: { path: '', repoUrl: '' } },
-        status: { health: { status } },
-      } as GitOpsDeploymentKind);
-
-    it('should return Pending status for SEB without status', () => {
-      const missingApplication = { ...mockSnapshotsEnvironmentBindings[0], status: undefined };
-      expect(
-        getApplicationGitopsStatus(
-          missingApplication,
-          getGitOpsMockCr(GitOpsDeploymentHealthStatus.Healthy),
-        ),
-      ).toBe(RunStatus.Pending);
-    });
-
-    it('should return Succeeded status for healthy application', () => {
-      const healthyApplication = mockSnapshotsEnvironmentBindings[0];
-      expect(
-        getApplicationGitopsStatus(
-          healthyApplication,
-          getGitOpsMockCr(GitOpsDeploymentHealthStatus.Healthy),
-        ),
-      ).toBe(RunStatus.Succeeded);
-    });
-
-    it('should return Failed status for healthy application', () => {
-      const healthyApplication = mockSnapshotsEnvironmentBindings[0];
-      expect(
-        getApplicationGitopsStatus(
-          healthyApplication,
-          getGitOpsMockCr(GitOpsDeploymentHealthStatus.Degraded),
-        ),
-      ).toBe(RunStatus.Failed);
-    });
-
-    it('should return Running status for healthy application', () => {
-      const healthyApplication = mockSnapshotsEnvironmentBindings[0];
-      expect(
-        getApplicationGitopsStatus(
-          healthyApplication,
-          getGitOpsMockCr(GitOpsDeploymentHealthStatus.Progressing),
-        ),
-      ).toBe(RunStatus.Running);
     });
   });
 });

--- a/src/utils/environment-utils.ts
+++ b/src/utils/environment-utils.ts
@@ -1,7 +1,7 @@
 import { RunStatus } from '@patternfly/react-topology';
 import { EnvironmentKind } from '../types';
 import { SnapshotEnvironmentBinding } from '../types/coreBuildService';
-import { GitOpsDeploymentHealthStatus, GitOpsDeploymentKind } from '../types/gitops-deployment';
+import { GitOpsDeploymentHealthStatus } from '../types/gitops-deployment';
 
 export enum EnvironmentDeploymentStrategy {
   AppStudioAutomated = 'Automatic',
@@ -114,27 +114,6 @@ export const getComponentDeploymentRunStatus = (
   snapshotEnvironmentBinding: SnapshotEnvironmentBinding,
 ): RunStatus => {
   const status = getComponentDeploymentStatus(snapshotEnvironmentBinding);
-
-  switch (status) {
-    case GitOpsDeploymentHealthStatus.Healthy:
-      return RunStatus.Succeeded;
-    case GitOpsDeploymentHealthStatus.Progressing:
-      return RunStatus.Running;
-    case GitOpsDeploymentHealthStatus.Degraded:
-      return RunStatus.Failed;
-    default:
-      return RunStatus.Pending;
-  }
-};
-
-export const getApplicationGitopsStatus = (
-  snapshotEnvironmentBinding: SnapshotEnvironmentBinding,
-  gitOpsDeployment: GitOpsDeploymentKind,
-) => {
-  let status = getComponentDeploymentStatus(snapshotEnvironmentBinding);
-  if (status === GitOpsDeploymentHealthStatus.Healthy) {
-    status = gitOpsDeployment?.status?.health?.status;
-  }
 
   switch (status) {
     case GitOpsDeploymentHealthStatus.Healthy:


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
- https://issues.redhat.com/browse/HAC-3144

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- Update `useApplicationHealth` hook to only use status from `SnapshotEnvironmentBinding`.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
<img width="1535" alt="Screenshot 2023-02-13 at 9 53 49 PM" src="https://user-images.githubusercontent.com/6041994/218513936-a7ebc558-363e-4a05-ab2d-4bf53a1ddf84.png">




## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
