### PR TITLE
increase timeout for build log test

### DIFF
--- a/integration-tests/tests/create-application-from-public-git-source.spec.ts
+++ b/integration-tests/tests/create-application-from-public-git-source.spec.ts
@@ -84,7 +84,7 @@ describe('Create Component from Public Git Source', { tags: ['@PR-check', '@publ
       applicationDetailPage.openBuildLog(componentPage.componentName);
 
       // Workaround for https://issues.redhat.com/browse/HAC-3071
-      cy.get('li[class*="pipeline-run-logs__navitem"]', {timeout: 40000}).should("include.text", "clone-repository");
+      cy.get('li[class*="pipeline-run-logs__navitem"]', {timeout: 60000}).should("include.text", "clone-repository");
 
       applicationDetailPage.checkBuildLog("appstudio-init", 'Determine if Image Already Exists');
       applicationDetailPage.closeBuildLog();


### PR DESCRIPTION
seems to fail on occasion just before the logs load