### PR TITLE
Autofocus on name input field in delete modal

### DIFF
--- a/src/components/modal/DeleteResourceModal.tsx
+++ b/src/components/modal/DeleteResourceModal.tsx
@@ -11,6 +11,7 @@ import {
   ButtonType,
   ButtonVariant,
   Form,
+  FormHelperText,
   ModalVariant,
   Stack,
   StackItem,
@@ -71,7 +72,11 @@ export const DeleteResourceModal: React.FC<DeleteResourceModalProps> = ({
       }) => {
         const input = values.resourceName;
         const isValid = input === resourceName;
-        const helpText = touched && !input ? `${obj.kind} name missing` : undefined;
+        const helpText = (
+          <FormHelperText className="pf-m-warning" isHidden={!(touched && !input)}>
+            {obj.kind} name missing
+          </FormHelperText>
+        );
         const validatedState = touched
           ? !input
             ? ValidatedOptions.warning
@@ -104,6 +109,7 @@ export const DeleteResourceModal: React.FC<DeleteResourceModalProps> = ({
                     helpTextInvalid={`${obj.kind} name does not match`}
                     helpText={helpText}
                     validated={validatedState}
+                    autoFocus
                     required
                   />
                 </StackItem>

--- a/src/components/modal/__tests__/DeleteResourceModal.spec.tsx
+++ b/src/components/modal/__tests__/DeleteResourceModal.spec.tsx
@@ -18,6 +18,7 @@ describe('DeleteResourceModal', () => {
     const obj = { apiVersion: 'v1', kind: 'Application', metadata: { name: 'test' } };
     const onClose = jest.fn();
     render(<DeleteResourceModal obj={obj} model={ApplicationModel} onClose={onClose} />);
+    expect(screen.getByRole('textbox')).toHaveFocus();
     expect(screen.getByText('Delete')).toBeDisabled();
   });
 

--- a/src/shared/components/formik-fields/field-types.ts
+++ b/src/shared/components/formik-fields/field-types.ts
@@ -26,6 +26,7 @@ export interface BaseInputFieldProps extends FieldProps {
   onChange?: (event) => void;
   onBlur?: (event) => void;
   autoComplete?: string;
+  autoFocus?: boolean;
 }
 
 export enum GroupTextType {


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-2744
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
Automatically focus on name input field in delete modal
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

https://user-images.githubusercontent.com/20013884/219417639-b121b28c-5329-4096-aedd-3a32bbfff96d.mp4

<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
Delete a component or application.
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
