### PR TITLE
fix quay image link in integration details page

### DIFF
--- a/src/components/IntegrationTest/tabs/IntegrationTestOverviewTab.tsx
+++ b/src/components/IntegrationTest/tabs/IntegrationTestOverviewTab.tsx
@@ -25,6 +25,9 @@ const IntegrationTestOverviewTab: React.FC<IntegrationTestOverviewTabProps> = ({
   const { workspace } = useWorkspaceInfo();
   const optionalReleaseLabel =
     integrationTest.metadata.labels?.[IntegrationTestLabels.OPTIONAL] === 'true';
+  const quayImageLink = /(http(s?)):\/\//i.test(integrationTest.spec.bundle)
+    ? integrationTest.spec.bundle
+    : `https://${integrationTest.spec.bundle}`;
 
   return (
     <>
@@ -85,9 +88,7 @@ const IntegrationTestOverviewTab: React.FC<IntegrationTestOverviewTabProps> = ({
               <DescriptionListGroup>
                 <DescriptionListTerm>Image bundle</DescriptionListTerm>
                 <DescriptionListDescription>
-                  <ExternalLink href={integrationTest.spec.bundle}>
-                    {integrationTest.spec.bundle}
-                  </ExternalLink>
+                  <ExternalLink href={quayImageLink}>{integrationTest.spec.bundle}</ExternalLink>
                 </DescriptionListDescription>
               </DescriptionListGroup>
               <DescriptionListGroup>

--- a/src/components/IntegrationTest/tabs/__tests__/IntegrationTestOverviewTab.spec.tsx
+++ b/src/components/IntegrationTest/tabs/__tests__/IntegrationTestOverviewTab.spec.tsx
@@ -19,7 +19,7 @@ describe('IntegrationTestOverviewTab', () => {
     screen.getByText('pipeline-1'); // pipeline-to-run
     screen.getByText('Optional'); // optional for release
     expect(screen.getAllByRole('link')[0].getAttribute('href')).toBe(
-      'quay.io/test-rep/test-bundle:test-1',
+      'https://quay.io/test-rep/test-bundle:test-1',
     ); // image bundle
     expect(screen.getAllByRole('link')[1].getAttribute('href')).toBe(
       '/stonesoup/workspaces/test-ws/applications/test-app',
@@ -33,10 +33,33 @@ describe('IntegrationTestOverviewTab', () => {
     screen.getByText('pipeline-2'); // pipeline-to-run
     screen.getByText('Mandatory'); // optional for release
     expect(screen.getAllByRole('link')[0].getAttribute('href')).toBe(
-      'quay.io/test-rep/test-bundle:test-2',
+      'https://quay.io/test-rep/test-bundle:test-2',
     ); // image bundle
     expect(screen.getAllByRole('link')[1].getAttribute('href')).toBe(
       '/stonesoup/workspaces/test-ws/applications/test-app',
     ); // application link
+  });
+
+  it('should use the image url from the spec', () => {
+    render(
+      <IntegrationTestOverviewTab
+        integrationTest={{
+          ...MockIntegrationTests[1],
+          spec: {
+            ...MockIntegrationTests[1].spec,
+            bundle: `http://quay.io/test-rep/test-bundle:test-2`,
+          },
+        }}
+      />,
+    );
+    expect(screen.getAllByRole('link')[0].getAttribute('href')).toBe(
+      'http://quay.io/test-rep/test-bundle:test-2',
+    );
+  });
+  it('should append https to the bundle url if it is not present in the spec', () => {
+    render(<IntegrationTestOverviewTab integrationTest={MockIntegrationTests[1]} />);
+    expect(screen.getAllByRole('link')[0].getAttribute('href')).toBe(
+      'https://quay.io/test-rep/test-bundle:test-2',
+    );
   });
 });


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-2811

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

After creating an integration test through the UI, if I view its detail page and click on the provided image bundle link, it tries to access that while staying within console and shows me a 404.

## Type of change
<!-- Please delete options that are not relevant. -->


- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


Before:

![Screenshot 2023-01-06 at 3 20 00 PM](https://user-images.githubusercontent.com/9964343/219626130-6d931b8b-6c78-4cf1-9890-082c4cbeee48.png)


After:

https://user-images.githubusercontent.com/9964343/219626083-e16acd59-833d-42ae-8d7a-9ba2d4af09db.mov


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

Add an integration test and visit the integration test details page. (use ?mvp=false flag to enable integration tests tab)

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
