### PR TITLE
Guard workspace route with signup feature flag

### DIFF
--- a/config/remotePlugin.js
+++ b/config/remotePlugin.js
@@ -83,6 +83,9 @@ const routeExtensions = [
         $codeRef: 'WorkspacePage',
       },
     },
+    flags: {
+      required: ['SIGNUP'],
+    },
   },
 
   // Stonesoup overview


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-3201

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Approved users should be able to visit to workspace page, add signup feature flag to protect the route.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix

## Screenshot

<img width="1787" alt="Screenshot 2023-02-21 at 9 27 30 AM" src="https://user-images.githubusercontent.com/9964343/220244074-a1fdc93f-53f7-4804-a8df-dfdde35b7fdd.png">


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

cc: @rohitkrai03 