### PR TITLE
Fix environment UI crashing issue

### DIFF
--- a/src/components/ApplicationListView/ApplicationListRow.tsx
+++ b/src/components/ApplicationListView/ApplicationListRow.tsx
@@ -22,7 +22,7 @@ const ApplicationListRow: React.FC<RowFunctionArgs<ApplicationKind>> = ({ obj })
       environmentsLoaded
         ? allEnvironments?.sort?.(
             (a, b) => new Date(b.lastDeploy).getTime() - new Date(a.lastDeploy).getTime(),
-          )?.[0].lastDeploy
+          )?.[0]?.lastDeploy
         : '-',
     [environmentsLoaded, allEnvironments],
   );

--- a/src/hooks/__data__/mock-data.ts
+++ b/src/hooks/__data__/mock-data.ts
@@ -1,4 +1,258 @@
+import { EnvironmentKind } from '../../types';
+import { SnapshotEnvironmentBinding } from '../../types/coreBuildService';
 import { RouteKind } from '../../types/routes';
+
+export const mockEnvironments: EnvironmentKind[] = [
+  {
+    kind: 'Environment',
+    apiVersion: 'appstudio.redhat.com/v1alpha1',
+    metadata: {
+      name: 'prod',
+      namespace: 'test',
+    },
+    spec: {
+      displayName: 'Prod',
+      deploymentStrategy: 'Manual',
+      type: 'poc',
+    },
+  },
+];
+
+const baseSnapshotEnvironmentBinding: SnapshotEnvironmentBinding = {
+  apiVersion: 'appstudio.redhat.com/v1alpha1',
+  kind: 'SnapshotEnvironmentBinding',
+  metadata: {
+    creationTimestamp: '2023-02-21T05:10:22Z',
+    generateName: 'test-app-prod-binding-',
+    labels: {
+      'appstudio.application': 'test-app',
+      'appstudio.environment': 'prod',
+    },
+    name: 'test-app-prod-binding-dxbcz',
+    namespace: 'test-ns',
+    uid: '30341053-fe45-4bc3-824a-075af3b6ba23',
+  },
+  spec: {
+    application: 'test-app',
+    components: [
+      {
+        configuration: {
+          env: [],
+          replicas: 1,
+        },
+        name: 'test-app-devfile-sample-dlod-sample',
+      },
+    ],
+    environment: 'prod',
+    snapshot: 'test-app-dmmr7',
+  },
+};
+export enum SEB_STATUS {
+  SUCCEEDED = 'Succeeded',
+  RUNNING = 'Running',
+  MISSING = 'Missing',
+  PARTIAL = 'Partial',
+  DEGRADED = 'Degraded',
+}
+
+export const mockSnapshotEnvironmentBindings: {
+  [key in SEB_STATUS]: SnapshotEnvironmentBinding[];
+} = {
+  [SEB_STATUS.MISSING]: [{ ...baseSnapshotEnvironmentBinding }],
+  [SEB_STATUS.PARTIAL]: [
+    {
+      ...baseSnapshotEnvironmentBinding,
+      status: {
+        bindingConditions: [
+          {
+            lastTransitionTime: '2023-02-21T05:10:23Z',
+            message:
+              "Can not Reconcile Binding 'test-app-development-binding-dxbcz', since GitOps Repo Conditions status is false.",
+            reason: 'ErrorOccurred',
+            status: 'True',
+            type: 'ErrorOccurred',
+          },
+        ],
+        gitopsRepoConditions: [
+          {
+            lastTransitionTime: '2023-02-21T05:10:23Z',
+            message:
+              'GitOps repository sync failed: failed to push remote to repository "https://<TOKEN>@github.com/ch007m/test-app-nmNw5-identify-count" "fatal: could not read Password for \'https://<TOKEN>@github.com\': No such device or address\\n": exit status 128',
+            reason: 'GenerateError',
+            status: 'False',
+            type: 'GitOpsResourcesGenerated',
+          },
+        ],
+      },
+    },
+  ],
+  [SEB_STATUS.SUCCEEDED]: [
+    {
+      ...baseSnapshotEnvironmentBinding,
+      status: {
+        bindingConditions: [
+          {
+            lastTransitionTime: '2023-02-21T05:26:52Z',
+            message:
+              "SnapshotEventBinding Component status is required to generate GitOps deployment, waiting for the Application Service controller to finish reconciling binding 'my-app-development-binding-w8plb'",
+            reason: 'ErrorOccurred',
+            status: 'True',
+            type: 'ErrorOccurred',
+          },
+        ],
+        componentDeploymentConditions: [
+          {
+            lastTransitionTime: '2023-02-21T05:27:25Z',
+            message: '1 of 1 components deployed',
+            reason: 'CommitsSynced',
+            status: 'True',
+            type: 'AllComponentsDeployed',
+          },
+        ],
+        components: [
+          {
+            gitopsRepository: {
+              branch: 'main',
+              commitID: 'd99ca37ecdb9213a14123ff775f21f44f16d8c96',
+              generatedResources: ['deployment-patch.yaml'],
+              path: 'components/devfile-sample-guhp/overlays/development',
+              url: 'https://github.com/redhat-appstudio-appdata/my-app-ls2Qa-assess-press',
+            },
+            name: 'devfile-sample-guhp',
+          },
+        ],
+        gitopsDeployments: [
+          {
+            componentName: 'devfile-sample-guhp',
+            gitopsDeployment:
+              'my-app-development-binding-w8plb-my-app-development-devfile-sample-guhp',
+          },
+        ],
+        gitopsRepoConditions: [
+          {
+            lastTransitionTime: '2023-02-21T05:26:53Z',
+            message: 'GitOps repository sync successful',
+            reason: 'OK',
+            status: 'True',
+            type: 'GitOpsResourcesGenerated',
+          },
+        ],
+      },
+    },
+  ],
+  [SEB_STATUS.RUNNING]: [
+    {
+      ...baseSnapshotEnvironmentBinding,
+      status: {
+        components: [
+          {
+            gitopsRepository: {
+              branch: 'main',
+              commitID: '95598ffacde7586c92a1eecf7c813080b8a9a1c8\n',
+              generatedResources: ['deployment-patch.yaml'],
+              path: 'components/test-nodeapp/overlays/production',
+              url: 'https://github.com/HACbs-ui-org/test-application-jephilli-define-laugh',
+            },
+            name: 'test-nodeapp',
+          },
+        ],
+        bindingConditions: [
+          {
+            lastTransitionTime: '2023-01-24T09:31:03Z',
+            message:
+              'SnapshotEventBinding Component status is required to generate GitOps deployment, waiting for the Application Service controller to finish reconciling',
+            binding: 'test-app-2-development-binding-w7f2z',
+            reason: 'ErrorOccurred',
+            status: 'True',
+            type: 'ErrorOccurred',
+          },
+        ],
+
+        componentDeploymentConditions: [
+          {
+            lastTransitionTime: '2023-01-24T09:31:34Z',
+            message: '1 of 1 components deployed',
+            reason: 'CommitsUnsynced',
+            status: 'False',
+            type: 'AllComponentsDeployed',
+          },
+        ],
+        gitopsDeployments: [
+          {
+            componentName: 'test-nodeapp',
+            gitopsDeployment:
+              'test-application-development-binding-8h9wl-test-application-development-test-nodeapp',
+          },
+        ],
+        gitopsRepoConditions: [
+          {
+            lastTransitionTime: '2022-11-09T17:33:47Z',
+            message: 'GitOps repository sync successful',
+            reason: 'OK',
+            status: 'True',
+            type: 'GitOpsResourcesGenerated',
+          },
+        ],
+      },
+    },
+  ],
+  [SEB_STATUS.DEGRADED]: [
+    {
+      ...baseSnapshotEnvironmentBinding,
+      status: {
+        components: [
+          {
+            gitopsRepository: {
+              branch: 'main',
+              commitID: '95598ffacde7586c92a1eecf7c813080b8a9a1c8\n',
+              generatedResources: ['deployment-patch.yaml'],
+              path: 'components/test-nodeapp/overlays/production',
+              url: 'https://github.com/HACbs-ui-org/test-application-jephilli-define-laugh',
+            },
+            name: 'test-nodeapp',
+          },
+        ],
+        bindingConditions: [
+          {
+            lastTransitionTime: '2023-01-24T09:31:03Z',
+            message:
+              'SnapshotEventBinding Component status is required to generate GitOps deployment, waiting for the Application Service controller to finish reconciling',
+            binding: 'test-app-2-development-binding-w7f2z',
+            reason: 'ErrorOccurred',
+            status: 'True',
+            type: 'ErrorOccurred',
+          },
+        ],
+
+        componentDeploymentConditions: [
+          {
+            lastTransitionTime: '2023-01-24T09:31:34Z',
+            message: '1 of 1 components deployed',
+            reason: 'CommitsUnsynced',
+            status: 'False',
+            type: 'ErrorOccurred',
+          },
+        ],
+        gitopsDeployments: [
+          {
+            componentName: 'test-nodeapp',
+            gitopsDeployment:
+              'test-application-development-binding-8h9wl-test-application-development-test-nodeapp',
+          },
+        ],
+        gitopsRepoConditions: [
+          {
+            lastTransitionTime: '2022-11-09T17:33:47Z',
+            message: 'GitOps repository sync successful',
+            reason: 'OK',
+            status: 'True',
+            type: 'GitOpsResourcesGenerated',
+          },
+        ],
+      },
+    },
+  ],
+};
 
 export const mockRoutes: RouteKind[] = [
   {

--- a/src/hooks/__tests__/useAllApplicationEnvironmentsWithHealthstatus.spec.ts
+++ b/src/hooks/__tests__/useAllApplicationEnvironmentsWithHealthstatus.spec.ts
@@ -1,0 +1,131 @@
+import { renderHook } from '@testing-library/react-hooks';
+import {
+  mockEnvironments,
+  mockSnapshotEnvironmentBindings,
+  SEB_STATUS,
+} from '../__data__/mock-data';
+import { useAllApplicationEnvironmentsWithHealthStatus } from '../useAllApplicationEnvironmentsWithHealthStatus';
+import { useAllEnvironments } from '../useAllEnvironments';
+import { useReleases } from '../useReleases';
+import { useSnapshotsEnvironmentBindings } from '../useSnapshotsEnvironmentBindings';
+
+jest.mock('../useAllEnvironments', () => {
+  return {
+    useAllEnvironments: jest.fn(),
+  };
+});
+jest.mock('../useReleases', () => {
+  return {
+    useReleases: jest.fn(),
+  };
+});
+
+jest.mock('../useSnapshotsEnvironmentBindings', () => {
+  return {
+    useSnapshotsEnvironmentBindings: jest.fn(),
+  };
+});
+
+describe('useAllApplicationEnvironmentsWithHealthStatus', () => {
+  const mockUseSnapshotsEnvironmentBindings = useSnapshotsEnvironmentBindings as jest.Mock;
+  const mockUseAllEnvironments = useAllEnvironments as jest.Mock;
+  const mockuseReleases = useReleases as jest.Mock;
+
+  beforeEach(() => {
+    mockUseAllEnvironments.mockReturnValue([mockEnvironments, true]);
+    mockuseReleases.mockReturnValue([[], true]);
+  });
+
+  it('should return empty array if some resources are not loaded', async () => {
+    mockUseAllEnvironments.mockReturnValue([[], false]);
+    mockUseSnapshotsEnvironmentBindings.mockReturnValue([[], true]);
+    const { result } = renderHook(() =>
+      useAllApplicationEnvironmentsWithHealthStatus('new-application'),
+    );
+    const [envsWithStatus, loaded] = result.current;
+
+    expect(loaded).toEqual(false);
+    expect(envsWithStatus.length).toEqual(0);
+  });
+
+  it('should return default status for managed environment', async () => {
+    mockUseAllEnvironments.mockReturnValue([
+      [{ ...mockEnvironments[0], spec: { ...mockEnvironments[0].spec, tags: ['managed'] } }],
+      true,
+    ]),
+      mockUseSnapshotsEnvironmentBindings.mockReturnValue([[], true]);
+    const { result } = renderHook(() =>
+      useAllApplicationEnvironmentsWithHealthStatus('new-application'),
+    );
+    const [envsWithStatus, loaded] = result.current;
+
+    expect(loaded).toEqual(true);
+    expect(envsWithStatus.length).toEqual(1);
+  });
+
+  it('should return Missing status', async () => {
+    mockUseSnapshotsEnvironmentBindings.mockReturnValue([[], true]);
+    const { result } = renderHook(() =>
+      useAllApplicationEnvironmentsWithHealthStatus('new-application'),
+    );
+    const [envsWithStatus, loaded] = result.current;
+
+    expect(loaded).toEqual(true);
+    expect(envsWithStatus.length).toEqual(1);
+    expect(envsWithStatus[0].healthStatus).toBe('Missing');
+    expect(envsWithStatus[0].lastDeploy).toBeUndefined();
+  });
+
+  it('should return Progressing status', async () => {
+    mockUseSnapshotsEnvironmentBindings.mockReturnValue([
+      mockSnapshotEnvironmentBindings[SEB_STATUS.RUNNING],
+      true,
+    ]);
+    const { result } = renderHook(() =>
+      useAllApplicationEnvironmentsWithHealthStatus('new-application'),
+    );
+    const [envsWithStatus] = result.current;
+
+    expect(envsWithStatus[0].healthStatus).toBe('Progressing');
+  });
+
+  it('should return Healthy status', async () => {
+    mockUseSnapshotsEnvironmentBindings.mockReturnValue([
+      mockSnapshotEnvironmentBindings[SEB_STATUS.SUCCEEDED],
+      true,
+    ]);
+    const { result } = renderHook(() =>
+      useAllApplicationEnvironmentsWithHealthStatus('new-application'),
+    );
+    const [envsWithStatus] = result.current;
+
+    expect(envsWithStatus[0].healthStatus).toBe('Healthy');
+  });
+
+  it('should return Degraded status', async () => {
+    mockUseSnapshotsEnvironmentBindings.mockReturnValue([
+      mockSnapshotEnvironmentBindings[SEB_STATUS.DEGRADED],
+      true,
+    ]);
+    const { result } = renderHook(() =>
+      useAllApplicationEnvironmentsWithHealthStatus('new-application'),
+    );
+    const [envsWithStatus] = result.current;
+
+    expect(envsWithStatus[0].healthStatus).toBe('Degraded');
+  });
+
+  it('should return default values for partial status', async () => {
+    mockUseSnapshotsEnvironmentBindings.mockReturnValue([
+      mockSnapshotEnvironmentBindings[SEB_STATUS.PARTIAL],
+      true,
+    ]);
+    const { result } = renderHook(() =>
+      useAllApplicationEnvironmentsWithHealthStatus('new-application'),
+    );
+    const [envsWithStatus] = result.current;
+
+    expect(envsWithStatus[0].healthStatus).toBe('Progressing');
+    expect(envsWithStatus[0].lastDeploy).toBeUndefined();
+  });
+});

--- a/src/hooks/useAllApplicationEnvironmentsWithHealthStatus.ts
+++ b/src/hooks/useAllApplicationEnvironmentsWithHealthStatus.ts
@@ -53,7 +53,8 @@ export const useAllApplicationEnvironmentsWithHealthStatus = (
         ...environment,
         healthStatus: getComponentDeploymentStatus(snapshotsEnvironmentBinding),
         lastDeploy:
-          snapshotsEnvironmentBinding?.status?.componentDeploymentConditions[0]?.lastTransitionTime,
+          snapshotsEnvironmentBinding?.status?.componentDeploymentConditions?.[0]
+            ?.lastTransitionTime,
       };
     });
   }, [allLoaded, snapshotsEnvironmentBindings, environments, releases]);

--- a/src/types/coreBuildService.ts
+++ b/src/types/coreBuildService.ts
@@ -132,13 +132,13 @@ export type SnapshotEnvironmentBinding = K8sResourceCommon & {
     snapshot: string;
   };
   status?: {
-    bindingConditions: Condition[];
-    componentDeploymentConditions: Condition[];
-    components: {
+    bindingConditions?: Condition[];
+    componentDeploymentConditions?: Condition[];
+    components?: {
       gitopsRepository: GitopsRepository;
       name: string;
     }[];
-    gitopsDeployments: GitopsDeployment[];
-    gitopsRepoConditions: Condition[];
+    gitopsDeployments?: GitopsDeployment[];
+    gitopsRepoConditions?: Condition[];
   };
 };


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-3202

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Environment page is breaking when the component creation fails with Gitops error then the SnapshotEnvironmentBinding's status is missing `ComponentDeploymentConditions` field. 

Note:
This is not happening in staging, development clusters. This issue was noticed when deploying frontend + backend components in quicklab clusters.


## Type of change
<!-- Please delete options that are not relevant. -->


- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->



## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

This issue was noticed when deploying frontend + backend components in quicklab clusters.

https://github.com/ch007m/my-stonesoup/blob/main/howto-play.md#install-the-frontend

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

## Unit tests

```
  useAllApplicationEnvironmentsWithHealthStatus
    ✓ should return empty array if some resources are not loaded (12 ms)
    ✓ should return default status for managed environment (3 ms)
    ✓ should return Missing status (2 ms)
    ✓ should return Progressing status (2 ms)
    ✓ should return Healthy status (2 ms)
    ✓ should return Degraded status (2 ms)
    ✓ should return default values for partial status (2 ms)
```    

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

cc: @rohitkrai03 