### PR TITLE
context directory should not be passed when runtime is changed

### DIFF
--- a/src/components/ImportForm/ReviewSection/RuntimeSelector.tsx
+++ b/src/components/ImportForm/ReviewSection/RuntimeSelector.tsx
@@ -66,7 +66,7 @@ export const RuntimeSelector: React.FC<RuntimeSelectorProps> = ({ detectedCompon
     runtimeSource,
     application,
     secret,
-    context,
+    sourceUrl !== runtimeSource ? undefined : context,
     revision,
   );
 

--- a/src/components/ImportForm/ReviewSection/__tests__/RuntimeSelector.spec.tsx
+++ b/src/components/ImportForm/ReviewSection/__tests__/RuntimeSelector.spec.tsx
@@ -107,4 +107,100 @@ describe('RuntimeSelector', () => {
     expect(setFieldValueMock).toHaveBeenCalledWith('detectionFailed', false);
     expect(setFieldValueMock).toHaveBeenCalledWith('isDetected', true);
   });
+
+  it('should set the context directory when the provided repo is matching with sample runtime repo', async () => {
+    useDevfileSamplesMock.mockReturnValue([
+      [
+        {
+          name: 'Basic Nodejs',
+          attributes: {
+            projectType: 'nodejs',
+            git: { remotes: { origin: 'https://github.com/sclorg/nodejs-ex' } },
+          },
+          icon: {},
+        },
+      ],
+      true,
+    ]);
+    useComponentDetectionMock.mockReturnValue([]);
+    formikRenderer(<RuntimeSelector detectedComponentIndex={0} />, {
+      source: { git: { url: 'https://github.com/sclorg/nodejs-ex', context: '/testDirectory' } },
+      isDetected: false,
+      components: [
+        {
+          projectType: 'nodejs',
+        },
+      ],
+    });
+
+    expect(screen.getByText('Select a runtime')).toBeVisible();
+    await act(async () => screen.getByText('Select a runtime').click());
+
+    useComponentDetectionMock.mockReturnValue([
+      { node: { componentStub: { source: { source: { git: {} } } } } },
+      true,
+    ]);
+    await act(async () => screen.getByText('Basic Nodejs').click());
+
+    expect(screen.getByText('Basic Nodejs')).toBeVisible();
+    expect(useComponentDetectionMock).toHaveBeenLastCalledWith(
+      'https://github.com/sclorg/nodejs-ex',
+      undefined,
+      undefined,
+      '/testDirectory',
+      undefined,
+    );
+    expect(setFieldValueMock).toHaveBeenCalledWith('detectionFailed', false);
+    expect(setFieldValueMock).toHaveBeenCalledWith('isDetected', true);
+  });
+
+  it('should not set the context directory when the runtime is changed', async () => {
+    useDevfileSamplesMock.mockReturnValue([
+      [
+        {
+          name: 'Basic Quarkus',
+          attributes: {
+            projectType: 'quarkus',
+            git: {
+              remotes: {
+                origin: 'https://github.com/devfile-samples/devfile-sample-code-with-quarkus',
+              },
+            },
+          },
+          icon: {},
+        },
+      ],
+      true,
+    ]);
+    useComponentDetectionMock.mockReturnValue([]);
+    formikRenderer(<RuntimeSelector detectedComponentIndex={0} />, {
+      source: { git: { url: 'https://github.com/sclorg/nodejs-ex', context: '/testDirectory' } },
+      isDetected: false,
+      components: [
+        {
+          projectType: 'nodejs',
+        },
+      ],
+    });
+
+    expect(screen.getByText('Select a runtime')).toBeVisible();
+    await act(async () => screen.getByText('Select a runtime').click());
+
+    useComponentDetectionMock.mockReturnValue([
+      { node: { componentStub: { source: { source: { git: {} } } } } },
+      true,
+    ]);
+    await act(async () => screen.getByText('Basic Quarkus').click());
+
+    expect(screen.getByText('Basic Quarkus')).toBeVisible();
+    expect(useComponentDetectionMock).toHaveBeenLastCalledWith(
+      'https://github.com/devfile-samples/devfile-sample-code-with-quarkus',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(setFieldValueMock).toHaveBeenCalledWith('detectionFailed', false);
+    expect(setFieldValueMock).toHaveBeenCalledWith('isDetected', true);
+  });
 });


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-3203

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Create button is not enabled again after switching the runtime from Other to Basic Quarkus when context directory is set in the first step.



## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


https://user-images.githubusercontent.com/9964343/220329109-9eb71a6f-e0e8-4b1e-82d5-f718fe133e7a.mov



## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

1. use https://github.com/RedHat-EMEA-SSA-Team/end-to-end-developer-workshop repo while creating components and set the context directory to `/labs`.

2. Switch the detected runtime of a component from `Other` to  `Basic Quarkus` component.

<!-- **Test Configuration(s)**: -->

## Unit tests:

```
  RuntimeSelector
    ✓ should set the context directory when the provided repo is matching with sample runtime repo (59 ms)
    ✓ should not set the context directory when the runtime is changed (48 ms)
```
## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

cc: @rohitkrai03 