### PR TITLE
Force release the namespace.

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -83,7 +83,7 @@ docker run ${COMMON_SETUP} \
     -e CYPRESS_RP_TOKEN=${CYPRESS_RP_HAC} \
     ${TEST_IMAGE} || TEST_RUN=1
 
-bonfire namespace release ${NAMESPACE}
+bonfire namespace release -f ${NAMESPACE}
 
 # teardown_docker
 exit $TEST_RUN


### PR DESCRIPTION
## Fixes 
The bonfire namespace is not released after the tests.

## Description
The bonfire release command without the `-f` flag was waiting for the confirmation and so the namespace was not released after the test run but after the timeout.
Should be done as part of [HAC-3491](https://issues.redhat.com/browse/HAC-3491)
