### PR TITLE
Show task run test output status on task run nodes

### DIFF
--- a/src/components/ApplicationDetails/tabs/overview/visualization/utils/visualization-utils.ts
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/utils/visualization-utils.ts
@@ -21,6 +21,8 @@ import {
 const STATUS_WIDTH = 24;
 const BADGE_WIDTH = 36;
 
+const DEFAULT_CHAR_WIDTH = 8;
+
 const createGenericNode: NodeCreatorSetup = (type, width?, height?) => (name, data) => ({
   id: name,
   label: data.label,
@@ -100,12 +102,12 @@ export const getTextWidth = (text: string, font: string = '0.875rem RedHatText')
   const canvas = document.createElement('canvas');
   const context = canvas.getContext?.('2d');
   if (!context) {
-    return text.length;
+    return text.length * DEFAULT_CHAR_WIDTH;
   }
   context.font = font;
   const { width } = context.measureText(text);
 
-  return width;
+  return width || text.length * DEFAULT_CHAR_WIDTH;
 };
 
 export const getLabelWidth = (label: string): number =>

--- a/src/components/PipelineRunDetailsView/visualization/nodes/PipelineRunNode.scss
+++ b/src/components/PipelineRunDetailsView/visualization/nodes/PipelineRunNode.scss
@@ -1,3 +1,21 @@
 .pipelinerun-node {
     cursor: default;
+  &__test-status-badge {
+    &--failed {
+      > rect {
+        fill: var(--pf-global--danger-color--100);
+      }
+      > text {
+        fill: var(--pf-global--Color--light-100);
+      }
+    }
+    &--warning {
+      > rect {
+        fill: var(--pf-global--warning-color--100);
+      }
+      > text {
+        fill: var(--pf-global--Color--dark-100);
+      }
+    }
+  }
 }

--- a/src/components/PipelineRunDetailsView/visualization/nodes/PipelineRunNode.tsx
+++ b/src/components/PipelineRunDetailsView/visualization/nodes/PipelineRunNode.tsx
@@ -34,10 +34,18 @@ const PipelineRunNode: React.FunctionComponent<PipelineRunNodeProps> = ({
     return newData;
   }, [data]);
 
-  let status = data.status;
-  if (status === RunStatus.Succeeded && data.testStatus) {
-    status = data.testStatus;
-  }
+  const status =
+    data.status === RunStatus.Succeeded && (data.testFailCount || data.testWarnCount)
+      ? RunStatus.Cancelled
+      : data.status;
+
+  const badge =
+    data.testFailCount || data.testFailCount
+      ? `${data.testFailCount || data.testFailCount}`
+      : undefined;
+  const badgeClassName = data.testFailCount
+    ? 'pipelinerun-node__test-status-badge--failed'
+    : 'pipelinerun-node__test-status-badge--warning';
 
   const hasTaskIcon = !!(data.taskIconClass || data.taskIcon);
   const whenDecorator = data.whenStatus ? (
@@ -60,6 +68,8 @@ const PipelineRunNode: React.FunctionComponent<PipelineRunNodeProps> = ({
       contextMenuOpen={contextMenuOpen}
       {...passedData}
       status={status}
+      badge={badge}
+      badgeClassName={badgeClassName}
       {...rest}
       truncateLength={element.getData()?.label?.length}
     >

--- a/src/components/PipelineRunDetailsView/visualization/nodes/PipelineRunNode.tsx
+++ b/src/components/PipelineRunDetailsView/visualization/nodes/PipelineRunNode.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {
   DEFAULT_WHEN_OFFSET,
   Node,
+  RunStatus,
   TaskNode,
   WhenDecorator,
   WithContextMenuProps,
@@ -33,6 +34,11 @@ const PipelineRunNode: React.FunctionComponent<PipelineRunNodeProps> = ({
     return newData;
   }, [data]);
 
+  let status = data.status;
+  if (status === RunStatus.Succeeded && data.testStatus) {
+    status = data.testStatus;
+  }
+
   const hasTaskIcon = !!(data.taskIconClass || data.taskIcon);
   const whenDecorator = data.whenStatus ? (
     <WhenDecorator
@@ -53,6 +59,7 @@ const PipelineRunNode: React.FunctionComponent<PipelineRunNodeProps> = ({
       onContextMenu={data.showContextMenu ? onContextMenu : undefined}
       contextMenuOpen={contextMenuOpen}
       {...passedData}
+      status={status}
       {...rest}
       truncateLength={element.getData()?.label?.length}
     >

--- a/src/components/PipelineRunDetailsView/visualization/types.ts
+++ b/src/components/PipelineRunDetailsView/visualization/types.ts
@@ -20,6 +20,7 @@ export type PipelineRunNodeData = {
   width?: number;
   height?: number;
   status?: RunStatus;
+  testStatus?: string;
   whenStatus?: string;
 };
 

--- a/src/components/PipelineRunDetailsView/visualization/types.ts
+++ b/src/components/PipelineRunDetailsView/visualization/types.ts
@@ -20,7 +20,8 @@ export type PipelineRunNodeData = {
   width?: number;
   height?: number;
   status?: RunStatus;
-  testStatus?: string;
+  testFailCount?: number;
+  testWarnCount?: number;
   whenStatus?: string;
 };
 

--- a/src/components/PipelineRunDetailsView/visualization/utils/__tests__/pipelinerun-graph-utils.spec.ts
+++ b/src/components/PipelineRunDetailsView/visualization/utils/__tests__/pipelinerun-graph-utils.spec.ts
@@ -115,6 +115,16 @@ describe('pipelinerun-graph-utils: ', () => {
       const { nodes } = getPipelineRunDataModel(testPipelineRun);
       expect(nodes.filter((n) => n.type === NodeType.SPACER_NODE)).toHaveLength(1);
     });
+
+    it('should set test status on nodes', () => {
+      const { nodes } = getPipelineRunDataModel(testPipelineRun);
+      const failedTestNode = nodes.find((n) => n.id === 'task1');
+      expect(failedTestNode.data.testStatus).toEqual(RunStatus.Cancelled);
+      const warningTestNode = nodes.find((n) => n.id === 'task2');
+      expect(warningTestNode.data.testStatus).toEqual(RunStatus.Cancelled);
+      const successTestNode = nodes.find((n) => n.id === 'task3');
+      expect(successTestNode.data.testStatus).toBeUndefined();
+    });
   });
 
   describe('appendStatus', () => {

--- a/src/components/PipelineRunDetailsView/visualization/utils/__tests__/pipelinerun-graph-utils.spec.ts
+++ b/src/components/PipelineRunDetailsView/visualization/utils/__tests__/pipelinerun-graph-utils.spec.ts
@@ -116,14 +116,17 @@ describe('pipelinerun-graph-utils: ', () => {
       expect(nodes.filter((n) => n.type === NodeType.SPACER_NODE)).toHaveLength(1);
     });
 
-    it('should set test status on nodes', () => {
+    it('should set test status counts on nodes', () => {
       const { nodes } = getPipelineRunDataModel(testPipelineRun);
       const failedTestNode = nodes.find((n) => n.id === 'task1');
-      expect(failedTestNode.data.testStatus).toEqual(RunStatus.Cancelled);
+      expect(failedTestNode.data.testFailCount).toEqual(2);
+      expect(failedTestNode.data.testWarnCount).toEqual(0);
       const warningTestNode = nodes.find((n) => n.id === 'task2');
-      expect(warningTestNode.data.testStatus).toEqual(RunStatus.Cancelled);
+      expect(warningTestNode.data.testFailCount).toEqual(0);
+      expect(warningTestNode.data.testWarnCount).toEqual(1);
       const successTestNode = nodes.find((n) => n.id === 'task3');
-      expect(successTestNode.data.testStatus).toBeUndefined();
+      expect(successTestNode.data.testFailCount).toEqual(0);
+      expect(successTestNode.data.testWarnCount).toEqual(0);
     });
   });
 

--- a/src/components/topology/__data__/pipeline-test-data.ts
+++ b/src/components/topology/__data__/pipeline-test-data.ts
@@ -571,9 +571,9 @@ export const testPipelineRun: PipelineRunKind = {
           ],
           taskResults: [
             {
-              name: 'sum',
-              type: 'string',
-              value: '2',
+              name: 'HACBS_TEST_OUTPUT',
+              value:
+                '{"result":"FAILURE","timestamp":"1675992922","note":"For more details please visit the logs in workspace of Tekton tasks.","namespace":"required_checks","successes":2,"failures":2,"warnings":0}',
             },
           ],
           taskSpec: {
@@ -641,9 +641,9 @@ export const testPipelineRun: PipelineRunKind = {
           ],
           taskResults: [
             {
-              name: 'product',
-              type: 'string',
-              value: '1',
+              name: 'HACBS_TEST_OUTPUT',
+              value:
+                '{"result":"WARNING","timestamp":"1675992922","note":"For more details please visit the logs in workspace of Tekton tasks.","namespace":"required_checks","successes":2,"failures":0,"warnings":1}',
             },
           ],
           taskSpec: {
@@ -699,6 +699,13 @@ export const testPipelineRun: PipelineRunKind = {
               waiting: {
                 reason: 'PodInitializing',
               },
+            },
+          ],
+          taskResults: [
+            {
+              name: 'HACBS_TEST_OUTPUT',
+              value:
+                '{"result":"SUCCESS","timestamp":"1675992922","note":"For more details please visit the logs in workspace of Tekton tasks.","namespace":"required_checks","successes":2,"failures":0,"warnings":0}',
             },
           ],
           taskSpec: {


### PR DESCRIPTION
## Fixes 
Fixes [HAC-3200](https://issues.redhat.com/browse/HAC-3200)

## Description
Determines the test status for pipeline run tasks and if the task run is successful, show any test status to indicate the test status issues.

## Type of change
- [x] Feature

## Screenshots

![image](https://user-images.githubusercontent.com/11633780/222455146-5241edc4-0976-4034-8f03-48f676bd5697.png)

