### PR TITLE
remove applications link from application list view

### DIFF
--- a/src/components/ApplicationDetails/__tests__/ApplicationDetails.spec.tsx
+++ b/src/components/ApplicationDetails/__tests__/ApplicationDetails.spec.tsx
@@ -21,7 +21,7 @@ jest.mock('react-router-dom', () => {
   return {
     ...actual,
     Link: (props) => (
-      <a href={props.to} data-test={props.to}>
+      <a href={props.to} data-test={props['data-test']}>
         {props.children}
       </a>
     ),
@@ -160,5 +160,11 @@ describe('ApplicationDetails', () => {
     appDetails = screen.getByTestId('details');
     activeTab = appDetails.querySelector('.pf-c-tabs__item.pf-m-current .pf-c-tabs__item-text');
     expect(activeTab).toHaveTextContent('Environments');
+  });
+
+  it('should contain applications breadcrumb link in the list view', () => {
+    watchResourceMock.mockReturnValueOnce([mockApplication, true]);
+    routerRenderer(<ApplicationDetails applicationName="test" />);
+    expect(screen.queryByTestId('applications-breadcrumb-link')).toBeInTheDocument();
   });
 });

--- a/src/components/ApplicationListView/__tests__/ApplicationListView.spec.tsx
+++ b/src/components/ApplicationListView/__tests__/ApplicationListView.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import '@testing-library/jest-dom';
 import { useFeatureFlag } from '@openshift/dynamic-plugin-sdk';
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
-import { render, screen } from '@testing-library/react';
+import { render, screen, configure } from '@testing-library/react';
 import { ApplicationKind } from '../../../types';
 import { WorkspaceContext } from '../../../utils/workspace-context-utils';
 import ApplicationListView from '../ApplicationListView';
@@ -27,6 +27,8 @@ jest.mock('../../../utils/workspace-context-utils', () => {
     useWorkspaceInfo: jest.fn(() => ({ namespace: 'test-ns', workspace: 'test-ws' })),
   };
 });
+
+configure({ testIdAttribute: 'data-test' });
 
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');
@@ -164,5 +166,12 @@ describe('Application List', () => {
     render(<ApplicationList />);
     screen.getByText('Easily onboard your applications');
     expect(screen.queryByText('Create and manage your applications.')).toBeNull();
+  });
+
+  it('should not contain applications breadcrumb link in the list view', () => {
+    useFeatureFlagMock.mockReturnValue([false]);
+    watchResourceMock.mockReturnValue([applications, true]);
+    render(<ApplicationList />);
+    expect(screen.queryByTestId('applications-breadcrumb-link')).not.toBeInTheDocument();
   });
 });

--- a/src/utils/breadcrumb-utils.tsx
+++ b/src/utils/breadcrumb-utils.tsx
@@ -30,12 +30,17 @@ export const useApplicationBreadcrumbs = (appDisplayName = null, withLink = true
       |
     </span>,
     <BreadcrumbItem key="app-link" component="div">
-      <Link
-        className="pf-c-breadcrumb__link"
-        to={`/stonesoup/workspaces/${workspace}/applications`}
-      >
-        Applications
-      </Link>{' '}
+      {applicationName ? (
+        <Link
+          data-test="applications-breadcrumb-link"
+          className="pf-c-breadcrumb__link"
+          to={`/stonesoup/workspaces/${workspace}/applications`}
+        >
+          Applications
+        </Link>
+      ) : (
+        <span>Applications</span>
+      )}
     </BreadcrumbItem>,
     ...(applicationName
       ? [


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-3248

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Application list view breadcrumb should not contain applications link

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

<img width="1497" alt="Screenshot 2023-02-28 at 11 41 42 AM" src="https://user-images.githubusercontent.com/9964343/221770534-3cac7e83-f075-44af-873c-57812a9a0a96.png">


## Unit tests

```
 Application List
    ✓ should not contain applications breadcrumb link in the list view (25 ms
 ```   
 
 ```
 ApplicationDetails
    ✓ should contain applications breadcrumb link in the list view (841 ms)
 ```
 

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
