### PR TITLE
Don't complete form on editable label enter key

### DIFF
--- a/src/shared/components/formik-fields/EditableLabelField.tsx
+++ b/src/shared/components/formik-fields/EditableLabelField.tsx
@@ -38,12 +38,19 @@ const EditableLabelField: React.FC<EditableLabelFieldProps> = ({
     />
   );
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      setEditing(false);
+      e.preventDefault();
+    }
+  };
+
   return (
     <FormGroup fieldId={fieldId} {...props} label={label} labelIcon={editing ? null : editIcon}>
       {editing ? (
         <Flex>
           <FlexItem>
-            <InputField name={name} dataTest="editable-label-input" />
+            <InputField name={name} dataTest="editable-label-input" onKeyDown={handleKeyDown} />
           </FlexItem>
           <FlexItem>
             <ActionGroupWithIcons

--- a/src/shared/components/formik-fields/__tests__/EditableLabelField.spec.tsx
+++ b/src/shared/components/formik-fields/__tests__/EditableLabelField.spec.tsx
@@ -145,6 +145,29 @@ describe('EditableLabelField', () => {
     });
   });
 
+  it('should show label field with updated value and unmount editable field on input and enter press, form should not be submitted', async () => {
+    render(
+      <Wrapper initialValues={initialValues} onSubmit={jest.fn()}>
+        <EditableLabelField name={fieldName} />
+      </Wrapper>,
+    );
+    fireEvent.click(screen.getByTestId('pencil-icon'));
+    await waitFor(() => {
+      const inputField = screen.getByTestId('editable-label-input').querySelector('input');
+      fireEvent.input(inputField, { target: { value: 'new field value' } });
+      fireEvent.keyDown(inputField, { key: 'Enter', code: 'Enter', charCode: 13 });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('editable-label-input')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('check-icon')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('close-icon')).not.toBeInTheDocument();
+      expect(screen.queryByText('field value')).not.toBeInTheDocument();
+      expect(screen.getByText('new field value')).toBeInTheDocument();
+      expect(screen.getByTestId('pencil-icon')).toBeInTheDocument();
+    });
+  });
+
   it('should set the component name field to editable mode and show the inline error message', async () => {
     render(
       <Wrapper

--- a/src/shared/components/formik-fields/field-types.ts
+++ b/src/shared/components/formik-fields/field-types.ts
@@ -27,6 +27,7 @@ export interface BaseInputFieldProps extends FieldProps {
   onBlur?: (event) => void;
   autoComplete?: string;
   autoFocus?: boolean;
+  onKeyDown?: (event) => void;
 }
 
 export enum GroupTextType {


### PR DESCRIPTION
## Fixes 
Fixes [HAC-2120](https://issues.redhat.com/browse/HAC-2120)

## Description
Don't submit form on an enter key press in the editable label field. The edit should be saved but the form should not be submitted.

## Type of change
- [x] Bugfix

/cc @karthikjeeyar @christianvogt 
