### PR TITLE
Show `Build starting` for component status when pipeline run does not exist

### DIFF
--- a/src/components/Components/BuildStatusColumn.tsx
+++ b/src/components/Components/BuildStatusColumn.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { Button, Flex, FlexItem } from '@patternfly/react-core';
 import { useLatestPipelineRunForComponent } from '../../hooks/usePipelineRunsForApplication';
-import { pipelineRunFilterReducer } from '../../shared';
+import { pipelineRunFilterReducer, runStatus } from '../../shared';
 import { ComponentKind } from '../../types';
 import { getBuildStatusIcon } from '../../utils/gitops-utils';
+import { useWorkspaceInfo } from '../../utils/workspace-context-utils';
 import { useBuildLogViewerModal } from '../LogViewer/BuildLogViewer';
 
 type BuildStatusComponentProps = {
@@ -11,14 +12,15 @@ type BuildStatusComponentProps = {
 };
 
 const BuildStatusColumn: React.FC<BuildStatusComponentProps> = ({ component }) => {
-  const pipelineRun = useLatestPipelineRunForComponent(component);
-  const status = pipelineRunFilterReducer(pipelineRun);
+  const { namespace } = useWorkspaceInfo();
+  const [pipelineRun, pipelineRunLoaded] = useLatestPipelineRunForComponent(namespace, component);
+  const status = pipelineRun ? pipelineRunFilterReducer(pipelineRun) : runStatus.PipelineNotStarted;
   const buildLogsModal = useBuildLogViewerModal(component);
   const isContainerImage = !component.spec.source?.git?.url;
 
   return (
     <Flex direction={{ default: 'column' }}>
-      {pipelineRun && (
+      {pipelineRunLoaded && (
         <FlexItem align={{ default: 'alignRight' }}>
           {getBuildStatusIcon(status)} Build {status}
         </FlexItem>

--- a/src/components/Components/__tests__/ComponentListItem.spec.tsx
+++ b/src/components/Components/__tests__/ComponentListItem.spec.tsx
@@ -34,7 +34,7 @@ describe('ComponentListItem', () => {
   const mockLatestPipelineRunForComponent = useLatestPipelineRunForComponent as jest.Mock;
 
   beforeEach(() => {
-    mockLatestPipelineRunForComponent.mockReturnValue(mockPipelineRuns[0]);
+    mockLatestPipelineRunForComponent.mockReturnValue([mockPipelineRuns[0], true]);
     useK8sWatchResourceMock.mockReturnValue([[mockPipelineRuns[2]], true]);
   });
 
@@ -65,7 +65,7 @@ describe('ComponentListItem', () => {
   });
 
   it('should render View Build logs action item', async () => {
-    mockLatestPipelineRunForComponent.mockReturnValue(mockPipelineRuns[1]);
+    mockLatestPipelineRunForComponent.mockReturnValue([mockPipelineRuns[1], true]);
     render(
       <BrowserRouter>
         <ComponentListItem component={componentCRMocks[0]} routes={[]} />

--- a/src/components/Components/__tests__/ComponentListView.spec.tsx
+++ b/src/components/Components/__tests__/ComponentListView.spec.tsx
@@ -55,7 +55,7 @@ jest.mock('react-router-dom', () => {
 });
 
 jest.mock('../../../hooks/usePipelineRunsForApplication', () => ({
-  useLatestPipelineRunForComponent: () => mockPipelineRuns[0],
+  useLatestPipelineRunForComponent: () => [mockPipelineRuns[0], true],
 }));
 
 jest.mock('../../../utils/component-utils', () => {

--- a/src/shared/components/pipeline-run-logs/utils.ts
+++ b/src/shared/components/pipeline-run-logs/utils.ts
@@ -135,7 +135,7 @@ export enum runStatus {
   Running = 'Running',
   'In Progress' = 'In Progress',
   FailedToStart = 'FailedToStart',
-  PipelineNotStarted = 'PipelineNotStarted',
+  PipelineNotStarted = 'Starting',
   Skipped = 'Skipped',
   Cancelled = 'Cancelled',
   Cancelling = 'Cancelling',


### PR DESCRIPTION
## Fixes 
Fixes [HAC-2344](https://issues.redhat.com/browse/HAC-2344)

## Description
When the Pipelinerun has not been started yet, display the component status as `Build Starting`

## Type of change
- [x] Bugfix

/cc @karthikjeeyar @christianvogt 