### PR TITLE
support pac-provision error state

### DIFF
--- a/src/components/Components/BuildStatusColumn.tsx
+++ b/src/components/Components/BuildStatusColumn.tsx
@@ -1,61 +1,22 @@
 import * as React from 'react';
-import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
-import {
-  Button,
-  ButtonVariant,
-  DataListCell,
-  Flex,
-  FlexItem,
-  Popover,
-  Text,
-  TextContent,
-} from '@patternfly/react-core';
-import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
-import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens/dist/js/global_warning_color_100';
-import { PipelineRunLabel, PipelineRunType } from '../../consts/pipelinerun';
+import { Button, Flex, FlexItem } from '@patternfly/react-core';
 import { useLatestPipelineRunForComponent } from '../../hooks/usePipelineRunsForApplication';
-import { PipelineRunGroupVersionKind } from '../../models';
 import { pipelineRunFilterReducer } from '../../shared';
-import ExternalLink from '../../shared/components/links/ExternalLink';
-import { ComponentKind, PipelineRunKind } from '../../types';
-import { useURLForComponentPRs, isPACEnabled } from '../../utils/component-utils';
+import { ComponentKind } from '../../types';
 import { getBuildStatusIcon } from '../../utils/gitops-utils';
 import { useBuildLogViewerModal } from '../LogViewer/BuildLogViewer';
 
 type BuildStatusComponentProps = {
   component: ComponentKind;
-  allComponents: ComponentKind[];
 };
 
-const BuildStatusColumn: React.FC<BuildStatusComponentProps> = ({ component, allComponents }) => {
-  const hasPAC = isPACEnabled(component);
-  const prURL = useURLForComponentPRs(allComponents);
-
-  const [pipelineBuildRuns, pipelineRunsLoaded] = useK8sWatchResource<PipelineRunKind[]>(
-    hasPAC
-      ? {
-          groupVersionKind: PipelineRunGroupVersionKind,
-          isList: true,
-          namespace: component.metadata.namespace,
-          selector: {
-            matchLabels: {
-              [PipelineRunLabel.PIPELINE_TYPE]: PipelineRunType.BUILD,
-              [PipelineRunLabel.COMPONENT]: component.metadata.name,
-            },
-          },
-          limit: 1,
-        }
-      : null,
-  );
-
+const BuildStatusColumn: React.FC<BuildStatusComponentProps> = ({ component }) => {
   const pipelineRun = useLatestPipelineRunForComponent(component);
   const status = pipelineRunFilterReducer(pipelineRun);
   const buildLogsModal = useBuildLogViewerModal(component);
   const isContainerImage = !component.spec.source?.git?.url;
 
-  const merged = pipelineRunsLoaded && pipelineBuildRuns?.length;
-
-  return merged || !(pipelineRunsLoaded && hasPAC) ? (
+  return (
     <Flex direction={{ default: 'column' }}>
       {pipelineRun && (
         <FlexItem align={{ default: 'alignRight' }}>
@@ -75,37 +36,6 @@ const BuildStatusColumn: React.FC<BuildStatusComponentProps> = ({ component, all
         </FlexItem>
       )}
     </Flex>
-  ) : (
-    <DataListCell alignRight>
-      <Flex justifyContent={{ default: 'justifyContentFlexEnd' }}>
-        <Popover
-          position="left"
-          bodyContent={(hide) => (
-            <div data-test="component-list-item-unmerged-popover">
-              <TextContent>
-                <Text component="h2">Merge build PR</Text>
-                <Text component="p">
-                  On creating a new component, a pull request is created to merge the build pipeline
-                  that was created for this component. Components cannot be built until the PR is
-                  merged.
-                </Text>
-              </TextContent>
-              <Text component="p" className="pf-u-mt-md">
-                <Flex>
-                  <FlexItem onClick={hide}>
-                    <ExternalLink href={prURL} text="View all pull requests." />
-                  </FlexItem>
-                </Flex>
-              </Text>
-            </div>
-          )}
-        >
-          <Button variant={ButtonVariant.link} isInline>
-            <ExclamationTriangleIcon color={warningColor.value} /> Merge build PR
-          </Button>
-        </Popover>
-      </Flex>
-    </DataListCell>
   );
 };
 

--- a/src/components/Components/ComponentListItem.tsx
+++ b/src/components/Components/ComponentListItem.tsx
@@ -45,14 +45,9 @@ const getConditionStatus = (condition: ResourceStatusCondition) => {
 export type ComponentListViewItemProps = {
   component: ComponentKind;
   routes: RouteKind[];
-  allComponents?: ComponentKind[];
 };
 
-export const ComponentListItem: React.FC<ComponentListViewItemProps> = ({
-  component,
-  routes,
-  allComponents,
-}) => {
+export const ComponentListItem: React.FC<ComponentListViewItemProps> = ({ component, routes }) => {
   const [expanded, setExpanded] = React.useState(false);
   const { replicas, targetPort, resources } = component.spec;
   const name = component.metadata.name;
@@ -82,15 +77,7 @@ export const ComponentListItem: React.FC<ComponentListViewItemProps> = ({
                     <b>{name}</b>
                   </FlexItem>
                   <FlexItem>
-                    <ComponentPACStateLabel
-                      component={component}
-                      // onStateChange={(pacState) =>
-                      //   setComponentState((prevState) => ({
-                      //     ...prevState,
-                      //     [component.metadata.name]: pacState,
-                      //   }))
-                      // }
-                    />
+                    <ComponentPACStateLabel component={component} />
                   </FlexItem>
                 </Flex>
                 <FlexItem>
@@ -115,7 +102,7 @@ export const ComponentListItem: React.FC<ComponentListViewItemProps> = ({
               </DataListCell>
             ) : null,
             <DataListCell key="status" alignRight>
-              <BuildStatusColumn component={component} allComponents={allComponents} />
+              <BuildStatusColumn component={component} />
             </DataListCell>,
           ]}
         />

--- a/src/components/Components/ComponentListView.tsx
+++ b/src/components/Components/ComponentListView.tsx
@@ -229,7 +229,6 @@ const ComponentListView: React.FC<ComponentListViewProps> = ({ applicationName }
                         key={component.metadata.uid}
                         component={component}
                         routes={routes}
-                        allComponents={components}
                       />
                     ))}
                   </>

--- a/src/components/Components/ComponentPACStateLabel.tsx
+++ b/src/components/Components/ComponentPACStateLabel.tsx
@@ -89,6 +89,20 @@ const ComponentPACStateLabel: React.FC<Props> = ({ component, onStateChange }) =
           </Label>
         </Tooltip>
       );
+
+    case PACState.error:
+      return (
+        <Tooltip content="Install the GitHub application and grant permissions to the component repository.">
+          <Label
+            color="gold"
+            onClick={customizePipeline}
+            aria-role="button"
+            style={{ cursor: 'pointer' }}
+          >
+            Install GitHub app
+          </Label>
+        </Tooltip>
+      );
     default:
       return null;
   }

--- a/src/components/Components/__tests__/BuildStatusColumn.spec.tsx
+++ b/src/components/Components/__tests__/BuildStatusColumn.spec.tsx
@@ -29,7 +29,7 @@ describe('BuildStatusColumn', () => {
     useK8sWatchResourceMock.mockReturnValue([mockPipelineRuns, true]);
     render(
       <BrowserRouter>
-        <BuildStatusColumn component={componentCRMocks[0]} allComponents={componentCRMocks} />
+        <BuildStatusColumn component={componentCRMocks[0]} />
       </BrowserRouter>,
     );
     await waitFor(() => screen.getByText('Build Succeeded'));
@@ -39,7 +39,7 @@ describe('BuildStatusColumn', () => {
     useK8sWatchResourceMock.mockReturnValue([[mockPipelineRuns[2]], true]);
     render(
       <BrowserRouter>
-        <BuildStatusColumn component={componentCRMocks[1]} allComponents={componentCRMocks} />
+        <BuildStatusColumn component={componentCRMocks[1]} />
       </BrowserRouter>,
     );
     await waitFor(() => screen.getByText('Build Failed'));
@@ -50,27 +50,17 @@ describe('BuildStatusColumn', () => {
     useK8sWatchResourceMock.mockReturnValue([[], false]);
     render(
       <BrowserRouter>
-        <BuildStatusColumn component={componentCRMocks[1]} allComponents={componentCRMocks} />
+        <BuildStatusColumn component={componentCRMocks[1]} />
       </BrowserRouter>,
     );
     expect(screen.queryByText('Merge build PR')).not.toBeInTheDocument();
-  });
-
-  it('should render needs merge status', async () => {
-    useK8sWatchResourceMock.mockReturnValue([[], true]);
-    render(
-      <BrowserRouter>
-        <BuildStatusColumn component={componentCRMocks[1]} allComponents={componentCRMocks} />
-      </BrowserRouter>,
-    );
-    await waitFor(() => screen.getByText('Merge build PR'));
   });
 
   it('should not render View Build logs action item for components without build pipelinerun', async () => {
     useK8sWatchResourceMock.mockReturnValue([[], true]);
     render(
       <BrowserRouter>
-        <BuildStatusColumn component={componentCRMocks[0]} allComponents={componentCRMocks} />
+        <BuildStatusColumn component={componentCRMocks[0]} />
       </BrowserRouter>,
     );
     expect(screen.queryByText('View logs')).not.toBeInTheDocument();
@@ -80,7 +70,7 @@ describe('BuildStatusColumn', () => {
     useK8sWatchResourceMock.mockReturnValue([[mockPipelineRuns], true]);
     render(
       <BrowserRouter>
-        <BuildStatusColumn component={componentCRMocks[0]} allComponents={componentCRMocks} />
+        <BuildStatusColumn component={componentCRMocks[0]} />
       </BrowserRouter>,
     );
     await waitFor(() => screen.getByText('View logs'));

--- a/src/components/CustomizedPipeline/__tests__/CustomizePipeline.spec.tsx
+++ b/src/components/CustomizedPipeline/__tests__/CustomizePipeline.spec.tsx
@@ -20,7 +20,10 @@ const useK8sWatchResourceMock = useK8sWatchResource as jest.Mock;
 const k8sPatchResourceMock = k8sPatchResource as jest.Mock;
 
 let componentCount = 1;
-const createComponent = (pacValue?: 'done' | 'request', sample?: boolean): ComponentKind =>
+const createComponent = (
+  pacValue?: 'done' | 'request' | 'error',
+  sample?: boolean,
+): ComponentKind =>
   ({
     metadata: {
       name: `my-component-${componentCount++}`,
@@ -81,6 +84,26 @@ describe('CustomizePipeline', () => {
       <CustomizePipeline components={[createComponent('done')]} onClose={() => {}} />,
     );
     const button = result.queryByRole('link', { name: 'Edit pipeline in GitHub' });
+    expect(button).toBeInTheDocument();
+  });
+
+  it('should render resend pull request', () => {
+    useK8sWatchResourceMock.mockReturnValue([[{}], true]);
+    const result = render(
+      <CustomizePipeline components={[createComponent('error')]} onClose={() => {}} />,
+    );
+    const button = result.getByRole('button', { name: 'Resend pull request' });
+    expect(button).toBeInTheDocument();
+  });
+
+  it('should render install GitHub app alert', () => {
+    useK8sWatchResourceMock.mockReturnValue([[{}], true]);
+    const result = render(
+      <CustomizePipeline components={[createComponent('error')]} onClose={() => {}} />,
+    );
+    const link = result.getByRole('link', { name: /Install GitHub Application/ });
+    expect(link).toBeInTheDocument();
+    const button = result.getByRole('button', { name: 'Cancel' });
     expect(button).toBeInTheDocument();
   });
 

--- a/src/hooks/__tests__/usePACState.spec.ts
+++ b/src/hooks/__tests__/usePACState.spec.ts
@@ -1,6 +1,6 @@
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { ComponentKind } from '../../types';
-import { PAC_ANNOTATION, SAMPLE_ANNOTATION } from '../../utils/component-utils';
+import { PACProvision, PAC_ANNOTATION, SAMPLE_ANNOTATION } from '../../utils/component-utils';
 import usePACState, { PACState } from '../usePACState';
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
@@ -9,7 +9,7 @@ jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
 
 const useK8sWatchResourceMock = useK8sWatchResource as jest.Mock;
 
-const createComponent = (pacValue?: 'done' | 'request'): ComponentKind =>
+const createComponent = (pacValue?: PACProvision): ComponentKind =>
   ({
     metadata: {
       name: 'my-component',
@@ -39,25 +39,31 @@ describe('usePACState', () => {
   });
 
   it('should identify requested state', () => {
-    const component = createComponent('request');
+    const component = createComponent(PACProvision.request);
     expect(usePACState(component)).toBe(PACState.requested);
   });
 
   it('should identify pending state', () => {
     useK8sWatchResourceMock.mockReturnValueOnce([[], true]);
-    const component = createComponent('done');
+    const component = createComponent(PACProvision.done);
     expect(usePACState(component)).toBe(PACState.pending);
   });
 
   it('should identify ready state', () => {
     useK8sWatchResourceMock.mockReturnValueOnce([[{}], true]);
-    const component = createComponent('done');
+    const component = createComponent(PACProvision.done);
     expect(usePACState(component)).toBe(PACState.ready);
   });
 
   it('should identify loading state', () => {
     useK8sWatchResourceMock.mockReturnValueOnce([[], false]);
-    const component = createComponent('done');
+    const component = createComponent(PACProvision.done);
     expect(usePACState(component)).toBe(PACState.loading);
+  });
+
+  it('should identify error state', () => {
+    useK8sWatchResourceMock.mockReturnValueOnce([[], false]);
+    const component = createComponent(PACProvision.error);
+    expect(usePACState(component)).toBe(PACState.error);
   });
 });

--- a/src/utils/component-utils.ts
+++ b/src/utils/component-utils.ts
@@ -16,6 +16,7 @@ export const INITIAL_BUILD_ANNOTATION = 'appstudio.openshift.io/component-initia
 export enum PACProvision {
   done = 'done',
   request = 'request',
+  error = 'error',
 }
 
 export const getPACProvision = (component: ComponentKind): PACProvision | undefined => {
@@ -38,7 +39,23 @@ export const enablePAC = (component: ComponentKind) => {
       {
         op: 'add',
         path: `/metadata/annotations/${PAC_ANNOTATION.replace('/', '~1')}`,
-        value: 'request',
+        value: PACProvision.request,
+      },
+    ],
+  });
+};
+
+export const disablePAC = (component: ComponentKind) => {
+  k8sPatchResource({
+    model: ComponentModel,
+    queryOptions: {
+      name: component.metadata.name,
+      ns: component.metadata.namespace,
+    },
+    patches: [
+      {
+        op: 'remove',
+        path: `/metadata/annotations/${PAC_ANNOTATION.replace('/', '~1')}`,
       },
     ],
   });


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-3175

## Description

A third state `error` has been added. This state is now used whenever we set to `request` but the github app isn't installed. Previously it would remain in the `request` state and therefore the UI would assume that if the transition to `done` doesn't happen within a few seconds, that the github app may not be installed and so we would inform the user to go do so. Once installed the value would transition to `done` and pac would have been configured.

When in the `error` state, inform the user that the github app must be installed. Also provide the user with a means to resend the pull request.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
Failed to send pull request:
![image](https://user-images.githubusercontent.com/14068621/221983963-e84dbbac-d6a5-4ce5-9d82-ff929d433b89.png)

Component list when the pull request failed to send
![image](https://user-images.githubusercontent.com/14068621/221984032-3c5a1a00-23fd-451c-ab0f-c8507a2b3463.png)

## How to test or reproduce?

- Create a component where the repo doesn't have the github app installed.
- choose to `Customize build pipeline`
- click `Send pull request`

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
