### PR TITLE
remove validation errors when switching back from samples to import  flow

### DIFF
--- a/src/components/ImportForm/SourceSection/SourceSection.tsx
+++ b/src/components/ImportForm/SourceSection/SourceSection.tsx
@@ -42,6 +42,7 @@ export const SourceSection: React.FC<SourceSectionProps> = ({ onStrategyChange }
   const {
     values: { secret: authSecret },
     setFieldValue,
+    setFieldTouched,
   } = useFormikContext<ImportFormValues>();
 
   const [sourceUrl, setSourceUrl] = React.useState('');
@@ -139,8 +140,9 @@ export const SourceSection: React.FC<SourceSectionProps> = ({ onStrategyChange }
 
   const handleStrategyChange = React.useCallback(() => {
     setFieldValue('source.git.url', '');
+    setFieldTouched('source.git.url', false);
     onStrategyChange(ImportStrategy.SAMPLE);
-  }, [onStrategyChange, setFieldValue]);
+  }, [onStrategyChange, setFieldValue, setFieldTouched]);
 
   const description =
     'To add components to your application, provide a link to your GitHub repo or start with a code sample.';


### PR DESCRIPTION

## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-2992

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When switching to samples flow we are resetting the `source.git.url` to empty, but the fieldTouched property is not reset causing the validation message to show up when switching back to import from code flow. 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:
![before_fix](https://user-images.githubusercontent.com/9964343/222119520-eedf0a30-d3a5-40e0-b7ce-8086234fbd1f.gif)


After:
![fix_validation_issue](https://user-images.githubusercontent.com/9964343/222118983-2bad7513-34c7-48c0-b61a-07111a3a5b8a.gif)

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

1. In Add component page, click on the Git url and move to `Start with a Sample` flow
2. Switch back to `Import from your code` flow from samples page.

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
