### PR TITLE
add `Detecting runtime` message instead of spinner

### DIFF
--- a/src/components/ImportForm/ReviewSection/RuntimeSelector.tsx
+++ b/src/components/ImportForm/ReviewSection/RuntimeSelector.tsx
@@ -46,7 +46,9 @@ export const RuntimeSelector: React.FC<RuntimeSelectorProps> = ({ detectedCompon
 
   const DetectingRuntime = 'Detecting runtime...';
   const items = React.useMemo(() => {
-    return samples?.map((s) => ({ key: s.uid, value: s.name, icon: <img src={s.icon.url} /> }));
+    return (
+      samples?.map((s) => ({ key: s.uid, value: s.name, icon: <img src={s.icon.url} /> })) || []
+    );
   }, [samples]);
 
   const onChange = (value: string) => {

--- a/src/components/ImportForm/ReviewSection/RuntimeSelector.tsx
+++ b/src/components/ImportForm/ReviewSection/RuntimeSelector.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Spinner } from '@patternfly/react-core';
+import { DropdownToggle, Spinner, Text } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
 import { DropdownField } from '../../../shared';
 import { useComponentDetection } from '../utils/cdq-utils';
@@ -44,6 +44,7 @@ export const RuntimeSelector: React.FC<RuntimeSelectorProps> = ({ detectedCompon
   const [runtimeSource, setRuntimeSource] = React.useState('');
   const [selectedRuntime, setSelectedRuntime] = React.useState(null);
 
+  const DetectingRuntime = 'Detecting runtime...';
   const items = React.useMemo(() => {
     return samples?.map((s) => ({ key: s.uid, value: s.name, icon: <img src={s.icon.url} /> }));
   }, [samples]);
@@ -70,13 +71,44 @@ export const RuntimeSelector: React.FC<RuntimeSelectorProps> = ({ detectedCompon
     revision,
   );
 
+  const detectingRuntimeToggle = React.useCallback(
+    (onToggle) => (
+      <DropdownToggle
+        onToggle={onToggle}
+        isDisabled={detecting || !samplesLoaded}
+        data-test="dropdown-toggle"
+      >
+        {selectedRuntime?.name && selectedRuntime?.name !== DetectingRuntime ? (
+          selectedRuntime.name || 'Select a runtime'
+        ) : (
+          <Text component="p">
+            <Spinner
+              size="md"
+              isSVG
+              aria-label="detecting runtime"
+              style={{ marginRight: 'var(--pf-global--spacer--xs)' }}
+            />
+            {DetectingRuntime}
+          </Text>
+        )}
+      </DropdownToggle>
+    ),
+    [detecting, samplesLoaded, selectedRuntime],
+  );
+
   React.useEffect(() => {
-    if (isDetected && samplesLoaded && !selectedRuntime) {
+    if (
+      isDetected &&
+      samplesLoaded &&
+      (!selectedRuntime || selectedRuntime.name === DetectingRuntime)
+    ) {
       setSelectedRuntime(
         samples?.find(
           (s) => s.attributes.projectType === components[detectedComponentIndex]?.projectType,
         ) || { name: 'Other' },
       );
+    } else if (!selectedRuntime) {
+      setSelectedRuntime({ name: DetectingRuntime });
     }
   }, [components, detectedComponentIndex, isDetected, samples, samplesLoaded, selectedRuntime]);
 
@@ -110,18 +142,16 @@ export const RuntimeSelector: React.FC<RuntimeSelectorProps> = ({ detectedCompon
     setFieldTouched('runtime');
   }, [setFieldTouched]);
 
-  if (!samplesLoaded || detecting) {
-    return <Spinner isSVG size="md" />;
-  }
-
   return (
     <DropdownField
       name="runtime"
       label="Runtime"
       items={items}
+      isDisabled={detecting || !samplesLoaded}
       placeholder="Select a runtime"
       value={selectedRuntime?.name}
       onChange={onChange}
+      dropdownToggle={detectingRuntimeToggle}
     />
   );
 };

--- a/src/components/ImportForm/ReviewSection/__tests__/ReviewComponentCard.spec.tsx
+++ b/src/components/ImportForm/ReviewSection/__tests__/ReviewComponentCard.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { act, screen } from '@testing-library/react';
+import { act, configure, screen } from '@testing-library/react';
 import { formikRenderer } from '../../../../utils/test-utils';
 import { useComponentDetection } from '../../utils/cdq-utils';
 import { useDevfileSamples } from '../../utils/useDevfileSamples';
@@ -11,6 +11,8 @@ jest.mock('../../utils/cdq-utils', () => ({ useComponentDetection: jest.fn() }))
 jest.mock('../../utils/useDevfileSamples', () => ({
   useDevfileSamples: jest.fn(() => []),
 }));
+
+configure({ testIdAttribute: 'data-test' });
 
 const useComponentDetectionMock = useComponentDetection as jest.Mock;
 const useDevfileSamplesMock = useDevfileSamples as jest.Mock;
@@ -43,6 +45,9 @@ const gitRepoComponent = {
 };
 
 describe('ReviewComponentCard', () => {
+  const {
+    componentStub: { componentName },
+  } = gitRepoComponent;
   it('should render git url if component has git repo', () => {
     useComponentDetectionMock.mockReturnValue([]);
     formikRenderer(
@@ -85,7 +90,7 @@ describe('ReviewComponentCard', () => {
       />,
       { isDetected: true, source: { git: {} } },
     );
-    await act(async () => screen.getByRole('button', { expanded: false }).click());
+    await act(async () => screen.getByTestId(`${componentName}-toggle-button`).click());
 
     expect(screen.getByText('Deploy configuration')).toBeInTheDocument();
   });
@@ -100,8 +105,7 @@ describe('ReviewComponentCard', () => {
       />,
       { source: { git: {} } },
     );
-    await act(async () => screen.getByRole('button', { expanded: false }).click());
-
+    await act(async () => screen.getByTestId(`${componentName}-toggle-button`).click());
     expect(screen.queryByText('Deploy configuration')).toBeInTheDocument();
   });
 

--- a/src/components/ImportForm/ReviewSection/__tests__/RuntimeSelector.spec.tsx
+++ b/src/components/ImportForm/ReviewSection/__tests__/RuntimeSelector.spec.tsx
@@ -24,23 +24,34 @@ jest.mock('formik', () => ({
 
 const useComponentDetectionMock = useComponentDetection as jest.Mock;
 const useDevfileSamplesMock = useDevfileSamples as jest.Mock;
+const detectingRuntime = 'Detecting runtime...';
 
 describe('RuntimeSelector', () => {
-  it('should show loading indicator if runtimes are not fetched', () => {
-    useDevfileSamplesMock.mockReturnValue([]);
-    useComponentDetectionMock.mockReturnValue([]);
+  it('should show Detecting runtime in the dropdown during detection phase', () => {
+    useDevfileSamplesMock.mockReturnValue([[], false]);
+    useComponentDetectionMock.mockReturnValue([[], false]);
     formikRenderer(<RuntimeSelector detectedComponentIndex={0} />, { source: { git: {} } });
 
-    expect(screen.getByRole('progressbar')).toBeVisible();
+    expect(screen.getByText(detectingRuntime)).toBeVisible();
   });
 
-  it('should show dropdown if runtimes are fetched', () => {
-    useDevfileSamplesMock.mockReturnValue([[], true]);
-    useComponentDetectionMock.mockReturnValue([]);
-    formikRenderer(<RuntimeSelector detectedComponentIndex={0} />, { source: { git: {} } });
+  it('should show Other when the detected runtime did not match with samples', async () => {
+    useDevfileSamplesMock.mockReturnValue([
+      [{ name: 'Basic Nodejs', attributes: { projectType: 'nodejs' }, icon: {} }],
+      true,
+    ]);
+    useComponentDetectionMock.mockReturnValue([[], false]);
+    formikRenderer(<RuntimeSelector detectedComponentIndex={0} />, {
+      isDetected: true,
+      components: [
+        {
+          projectType: 'quarkus',
+        },
+      ],
+      source: { git: {} },
+    });
 
-    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
-    expect(screen.getByText('Select a runtime')).toBeVisible();
+    await act(() => expect(screen.getByText('Other')).toBeVisible());
   });
 
   it('should show correct message if runtime is automatically detected', () => {
@@ -87,8 +98,8 @@ describe('RuntimeSelector', () => {
       ],
     });
 
-    expect(screen.getByText('Select a runtime')).toBeVisible();
-    await act(async () => screen.getByText('Select a runtime').click());
+    expect(screen.getByText(detectingRuntime)).toBeVisible();
+    await act(async () => screen.getByText(detectingRuntime).click());
 
     useComponentDetectionMock.mockReturnValue([
       { node: { componentStub: { source: { source: { git: {} } } } } },
@@ -133,8 +144,8 @@ describe('RuntimeSelector', () => {
       ],
     });
 
-    expect(screen.getByText('Select a runtime')).toBeVisible();
-    await act(async () => screen.getByText('Select a runtime').click());
+    expect(screen.getByText(detectingRuntime)).toBeVisible();
+    await act(async () => screen.getByText(detectingRuntime).click());
 
     useComponentDetectionMock.mockReturnValue([
       { node: { componentStub: { source: { source: { git: {} } } } } },
@@ -183,8 +194,8 @@ describe('RuntimeSelector', () => {
       ],
     });
 
-    expect(screen.getByText('Select a runtime')).toBeVisible();
-    await act(async () => screen.getByText('Select a runtime').click());
+    expect(screen.getByText(detectingRuntime)).toBeVisible();
+    await act(async () => screen.getByText(detectingRuntime).click());
 
     useComponentDetectionMock.mockReturnValue([
       { node: { componentStub: { source: { source: { git: {} } } } } },

--- a/src/shared/components/dropdown/BasicDropdown.tsx
+++ b/src/shared/components/dropdown/BasicDropdown.tsx
@@ -14,6 +14,7 @@ type BasicDropdownProps = {
   placeholder?: string;
   fullWidth?: boolean;
   disabled?: boolean;
+  dropdownToggle?: (onToggle: (isOpen: boolean) => void) => React.ReactElement;
 };
 
 const BasicDropdown: React.FC<BasicDropdownProps> = ({
@@ -22,6 +23,7 @@ const BasicDropdown: React.FC<BasicDropdownProps> = ({
   onChange,
   placeholder,
   disabled,
+  dropdownToggle,
 }) => {
   const [dropdownOpen, setDropdownOpen] = React.useState<boolean>(false);
   const onToggle = (isOpen: boolean) => setDropdownOpen(isOpen);
@@ -29,6 +31,19 @@ const BasicDropdown: React.FC<BasicDropdownProps> = ({
     onChange && onChange(event.currentTarget.textContent);
     setDropdownOpen(false);
   };
+
+  const dropdownToggleComponent = React.useMemo(
+    () =>
+      dropdownToggle ? (
+        dropdownToggle(onToggle)
+      ) : (
+        <DropdownToggle onToggle={onToggle} isDisabled={disabled} data-test="dropdown-toggle">
+          {selected || placeholder}
+        </DropdownToggle>
+      ),
+    [dropdownToggle, selected, placeholder, disabled],
+  );
+
   const dropdownItems = React.useMemo(
     () =>
       items.map((item) => {
@@ -44,11 +59,7 @@ const BasicDropdown: React.FC<BasicDropdownProps> = ({
   return (
     <Dropdown
       onSelect={onSelect}
-      toggle={
-        <DropdownToggle onToggle={onToggle} isDisabled={disabled} data-test="dropdown-toggle">
-          {selected || placeholder}
-        </DropdownToggle>
-      }
+      toggle={dropdownToggleComponent}
       isOpen={dropdownOpen}
       dropdownItems={dropdownItems}
       autoFocus={false}

--- a/src/shared/components/formik-fields/DropdownField.tsx
+++ b/src/shared/components/formik-fields/DropdownField.tsx
@@ -15,6 +15,7 @@ const DropdownField: React.FC<DropdownFieldProps> = ({
   fullWidth,
   validateOnChange = false,
   value,
+  isDisabled,
   ...props
 }) => {
   const [field, { touched, error }] = useField(name);
@@ -34,6 +35,7 @@ const DropdownField: React.FC<DropdownFieldProps> = ({
     >
       <BasicDropdown
         {...props}
+        disabled={isDisabled}
         items={items}
         selected={value ?? field.value}
         fullWidth={fullWidth}

--- a/src/shared/components/formik-fields/field-types.ts
+++ b/src/shared/components/formik-fields/field-types.ts
@@ -69,6 +69,7 @@ export interface DropdownFieldProps extends FieldProps {
   validateOnChange?: boolean;
   autocompleteFilter?: (text: string, item: object, key?: string) => boolean;
   onChange?: (value: string) => void;
+  dropdownToggle?: (onToggle: (isOpen: boolean) => void) => React.ReactElement;
 }
 
 export type FormSelectFieldOption<T = any> = {


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-2909

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Replace the runtime detection spinner with disabled dropdown with `Detecting runtime...` message.

## Type of change
<!-- Please delete options that are not relevant. -->


- [x] Bugfix

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

**Detecting phase screenshot:**

![detecting_spinner](https://user-images.githubusercontent.com/9964343/222658245-3786d6f8-2ede-4dad-ae67-9dec994ed932.gif)


**Detection full video:**

![detecting_runtime_spinner](https://user-images.githubusercontent.com/9964343/222658274-a7818f14-b38d-4997-a1c5-110675aa76f9.gif)

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

/cc @christianvogt 
