### PR TITLE
add sidepanel for task run nodes of pipeline run visualization

### DIFF
--- a/src/components/NamespacedPage/NamespacedPage.scss
+++ b/src/components/NamespacedPage/NamespacedPage.scss
@@ -2,4 +2,18 @@
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
+
+  // TODO work around to https://issues.redhat.com/browse/RHCLOUD-24606
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+
+  .main-layout-container {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    overflow: auto;
+  }
 }

--- a/src/components/NamespacedPage/NamespacedPage.tsx
+++ b/src/components/NamespacedPage/NamespacedPage.tsx
@@ -14,6 +14,14 @@ type NamespacedPageProps = {
 const NamespacedPage: React.FunctionComponent<NamespacedPageProps> = ({ children }) => {
   const { workspacesLoaded } = React.useContext(WorkspaceContext);
 
+  // TODO work around to https://issues.redhat.com/browse/RHCLOUD-24606
+  React.useEffect(() => {
+    const main = document.querySelector<HTMLElement>('main.pf-c-page__main');
+    if (main) {
+      main.style.position = 'relative';
+    }
+  }, []);
+
   if (!workspacesLoaded) {
     return (
       <Bullseye>
@@ -25,7 +33,9 @@ const NamespacedPage: React.FunctionComponent<NamespacedPageProps> = ({ children
   return (
     <ModalProvider>
       <AppBanner />
-      <ErrorBoundary>{children}</ErrorBoundary>
+      <div className="main-layout-container">
+        <ErrorBoundary>{children}</ErrorBoundary>
+      </div>
     </ModalProvider>
   );
 };

--- a/src/components/PipelineRunDetailsView/PipelineRunDetailsView.tsx
+++ b/src/components/PipelineRunDetailsView/PipelineRunDetailsView.tsx
@@ -9,6 +9,7 @@ import { pipelineRunStatus } from '../../utils/pipeline-utils';
 import { useWorkspaceInfo } from '../../utils/workspace-context-utils';
 import DetailsPage from '../ApplicationDetails/DetailsPage';
 import ErrorEmptyState from '../EmptyState/ErrorEmptyState';
+import SidePanelHost from '../SidePanel/SidePanelHost';
 import { StatusIconWithTextLabel } from '../topology/StatusIcon';
 import PipelineRunDetailsTab from './tabs/PipelineRunDetailsTab';
 import PipelineRunLogsTab from './tabs/PipelineRunLogsTab';
@@ -52,83 +53,81 @@ export const PipelineRunDetailsView: React.FC<PipelineRunDetailsViewProps> = ({
 
   const applicationName = pipelineRun.metadata?.labels[PipelineRunLabel.APPLICATION];
   return (
-    <>
-      <React.Fragment>
-        <DetailsPage
-          headTitle={pipelineRunName}
-          breadcrumbs={[
-            ...applicationBreadcrumbs,
-            {
-              path: `/stonesoup/workspaces/${workspace}/applications/${applicationName}/activity/pipelineruns`,
-              name: 'Pipeline runs',
-            },
-            {
-              path: `/stonesoup/workspaces/${workspace}/applications/${applicationName}/pipelineruns/${pipelineRunName}`,
-              name: pipelineRunName,
-            },
-          ]}
-          title={
-            <>
-              <span className="pf-u-mr-sm">{pipelineRunName}</span>
-              <StatusIconWithTextLabel status={plrStatus} />
-            </>
-          }
-          actions={[
-            // Todo: will re enable this after finding the proper solution to rerun post mvp.
-            // {
-            //   key: 'rerun',
-            //   label: 'Rerun',
-            //   onClick: () =>
-            //     pipelineRunRerun(pipelineRun).then((data) => {
-            //       navigate(`/stonesoup/workspaces/${workspace}/applications/${applicationName}/pipelineruns/${data.metadata.name}`);
-            //     }),
-            // },
-            {
-              key: 'stop',
-              label: 'Stop',
-              tooltip: 'Let the running tasks complete, then execute finally tasks',
-              isDisabled: !(plrStatus && plrStatus === 'Running'),
-              onClick: () => pipelineRunStop(pipelineRun),
-            },
-            {
-              key: 'cancel',
-              label: 'Cancel',
-              tooltip: 'Interrupt any executing non finally tasks, then execute finally tasks',
-              isDisabled: !(plrStatus && plrStatus === 'Running'),
-              onClick: () => pipelineRunCancel(pipelineRun),
-            },
-          ]}
-          baseURL={`/stonesoup/workspaces/${workspace}/applications/${applicationName}/pipelineruns/${pipelineRunName}`}
-          tabs={[
-            {
-              key: 'detail',
-              label: 'Details',
-              component: <PipelineRunDetailsTab pipelineRun={pipelineRun} error={error} />,
-            },
-            // {
-            //   key: 'yaml',
-            //   label: 'YAML',
-            //   component: <PipelineRunYamlTab pipelineRun={pipelineRun} />,
-            // },
-            {
-              key: 'taskruns',
-              label: 'Task runs',
-              component: <PipelineRunTaskRunsTab pipelineRun={pipelineRun} />,
-            },
-            {
-              key: 'logs',
-              label: 'Logs',
-              component: <PipelineRunLogsTab pipelineRun={pipelineRun} />,
-            },
-            // {
-            //   key: 'events',
-            //   label: 'Events',
-            //   component: <PipelineRunEventsTab pipelineRun={pipelineRun} />,
-            // },
-          ]}
-        />
-      </React.Fragment>
-    </>
+    <SidePanelHost>
+      <DetailsPage
+        headTitle={pipelineRunName}
+        breadcrumbs={[
+          ...applicationBreadcrumbs,
+          {
+            path: `/stonesoup/workspaces/${workspace}/applications/${applicationName}/activity/pipelineruns`,
+            name: 'Pipeline runs',
+          },
+          {
+            path: `/stonesoup/workspaces/${workspace}/applications/${applicationName}/pipelineruns/${pipelineRunName}`,
+            name: pipelineRunName,
+          },
+        ]}
+        title={
+          <>
+            <span className="pf-u-mr-sm">{pipelineRunName}</span>
+            <StatusIconWithTextLabel status={plrStatus} />
+          </>
+        }
+        actions={[
+          // Todo: will re enable this after finding the proper solution to rerun post mvp.
+          // {
+          //   key: 'rerun',
+          //   label: 'Rerun',
+          //   onClick: () =>
+          //     pipelineRunRerun(pipelineRun).then((data) => {
+          //       navigate(`/stonesoup/workspaces/${workspace}/applications/${applicationName}/pipelineruns/${data.metadata.name}`);
+          //     }),
+          // },
+          {
+            key: 'stop',
+            label: 'Stop',
+            tooltip: 'Let the running tasks complete, then execute finally tasks',
+            isDisabled: !(plrStatus && plrStatus === 'Running'),
+            onClick: () => pipelineRunStop(pipelineRun),
+          },
+          {
+            key: 'cancel',
+            label: 'Cancel',
+            tooltip: 'Interrupt any executing non finally tasks, then execute finally tasks',
+            isDisabled: !(plrStatus && plrStatus === 'Running'),
+            onClick: () => pipelineRunCancel(pipelineRun),
+          },
+        ]}
+        baseURL={`/stonesoup/workspaces/${workspace}/applications/${applicationName}/pipelineruns/${pipelineRunName}`}
+        tabs={[
+          {
+            key: 'detail',
+            label: 'Details',
+            component: <PipelineRunDetailsTab pipelineRun={pipelineRun} error={error} />,
+          },
+          // {
+          //   key: 'yaml',
+          //   label: 'YAML',
+          //   component: <PipelineRunYamlTab pipelineRun={pipelineRun} />,
+          // },
+          {
+            key: 'taskruns',
+            label: 'Task runs',
+            component: <PipelineRunTaskRunsTab pipelineRun={pipelineRun} />,
+          },
+          {
+            key: 'logs',
+            label: 'Logs',
+            component: <PipelineRunLogsTab pipelineRun={pipelineRun} />,
+          },
+          // {
+          //   key: 'events',
+          //   label: 'Events',
+          //   component: <PipelineRunEventsTab pipelineRun={pipelineRun} />,
+          // },
+        ]}
+      />
+    </SidePanelHost>
   );
 };
 

--- a/src/components/PipelineRunDetailsView/PipelineRunSidePanel.tsx
+++ b/src/components/PipelineRunDetailsView/PipelineRunSidePanel.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import {
+  SELECTION_STATE,
+  useVisualizationController,
+  useVisualizationState,
+  GraphElement,
+} from '@patternfly/react-topology';
+import SidePanel from '../SidePanel/SidePanel';
+import TaskRunPanel from './sidepanels/TaskRunPanel';
+import { isTaskRunNode } from './visualization/utils/pipelinerun-graph-utils';
+
+type Props = {
+  scrollIntoView?: (element: GraphElement) => void;
+};
+
+const PipelineRunSidePanel: React.FC<Props> = ({ scrollIntoView }) => {
+  const [[selectedId], setSelectedIds] = useVisualizationState<string[]>(SELECTION_STATE, []);
+  const controller = useVisualizationController();
+
+  const element = React.useMemo(
+    () => (selectedId ? controller.getElementById(selectedId) : null),
+    [controller, selectedId],
+  );
+
+  const panel = isTaskRunNode(element) ? (
+    <TaskRunPanel onClose={() => setSelectedIds([])} taskRunNode={element} />
+  ) : null;
+
+  const isExpanded = !!panel;
+
+  const onExpand = React.useCallback(() => {
+    if (isExpanded && element) {
+      scrollIntoView?.(element);
+    }
+  }, [isExpanded, scrollIntoView, element]);
+
+  React.useEffect(() => {
+    if (isExpanded && element) {
+      scrollIntoView?.(element);
+    }
+    // only run when the element changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [element]);
+
+  return (
+    <SidePanel isExpanded={isExpanded} onExpand={onExpand} isInline>
+      {panel}
+    </SidePanel>
+  );
+};
+
+export default PipelineRunSidePanel;

--- a/src/components/PipelineRunDetailsView/PipelineRunVisualization.tsx
+++ b/src/components/PipelineRunDetailsView/PipelineRunVisualization.tsx
@@ -1,15 +1,28 @@
 import React from 'react';
+import { GraphElement } from '@patternfly/react-topology';
 import { layoutFactory, VisualizationFactory } from '../topology/factories';
 import GraphErrorState from '../topology/factories/GraphErrorState';
 import { pipelineRuncomponentFactory } from './factories';
+import PipelineRunSidePanel from './PipelineRunSidePanel';
 import { getPipelineRunDataModel } from './visualization/utils/pipelinerun-graph-utils';
 
 import './PipelineRunVisualization.scss';
 
 const PipelineRunVisualization = ({ pipelineRun, error }) => {
+  const nodeRef = React.useRef<HTMLDivElement>();
+
   const model = React.useMemo(() => {
     return getPipelineRunDataModel(pipelineRun);
   }, [pipelineRun]);
+
+  const scrollIntoView = React.useCallback(
+    (element: GraphElement) => {
+      nodeRef.current
+        ?.querySelector(`[data-id=${element.getId()}]`)
+        ?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+    },
+    [nodeRef],
+  );
 
   if (error) {
     return <GraphErrorState errors={[error]} />;
@@ -18,12 +31,14 @@ const PipelineRunVisualization = ({ pipelineRun, error }) => {
     return null;
   }
   return (
-    <div className="pipelinerun-graph" data-test="pipelinerun-graph">
+    <div ref={nodeRef} className="pipelinerun-graph" data-test="pipelinerun-graph">
       <VisualizationFactory
         componentFactory={pipelineRuncomponentFactory}
         layoutFactory={layoutFactory}
         model={model}
-      />
+      >
+        <PipelineRunSidePanel scrollIntoView={scrollIntoView} />
+      </VisualizationFactory>
     </div>
   );
 };

--- a/src/components/PipelineRunDetailsView/__tests__/PipelineRunSidePanel.spec.tsx
+++ b/src/components/PipelineRunDetailsView/__tests__/PipelineRunSidePanel.spec.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { useVisualizationController, useVisualizationState } from '@patternfly/react-topology';
+import { render } from '@testing-library/react';
+import SidePanelContext from '../../SidePanel/SidePanelContext';
+import PipelineRunSidePanel from '../PipelineRunSidePanel';
+import { PipelineRunNodeType } from '../visualization/types';
+
+jest.mock('@patternfly/react-topology', () => ({
+  useVisualizationController: jest.fn(() => ({ getElementById: jest.fn() })),
+  useVisualizationState: jest.fn(() => [[], jest.fn()]),
+}));
+
+const useVisualizationControllerMock = useVisualizationController as jest.Mock;
+const useVisualizationStateMock = useVisualizationState as jest.Mock;
+
+describe('PipelineRunSidePanel', () => {
+  it('should render nothing by default', () => {
+    const setPropsFn = jest.fn();
+
+    render(<PipelineRunSidePanel />, {
+      wrapper: ({ children }) => (
+        <SidePanelContext.Provider value={{ setProps: setPropsFn, close: () => {} }}>
+          {children}
+        </SidePanelContext.Provider>
+      ),
+    });
+
+    expect(setPropsFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isExpanded: false,
+        children: null,
+      }),
+    );
+  });
+
+  it('should render nothing if selection is not a task', () => {
+    useVisualizationStateMock.mockImplementationOnce(() => [['testId'], jest.fn()]);
+    useVisualizationControllerMock.mockImplementationOnce(() => ({
+      getElementById: () => ({ getType: () => 'invalid-type' }),
+    }));
+
+    const setPropsFn = jest.fn();
+
+    render(<PipelineRunSidePanel />, {
+      wrapper: ({ children }) => (
+        <SidePanelContext.Provider value={{ setProps: setPropsFn, close: () => {} }}>
+          {children}
+        </SidePanelContext.Provider>
+      ),
+    });
+
+    expect(setPropsFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isExpanded: false,
+        children: null,
+      }),
+    );
+  });
+
+  it('should render panel for task selection', () => {
+    useVisualizationStateMock.mockImplementationOnce(() => [['testId'], jest.fn()]);
+    useVisualizationControllerMock.mockImplementationOnce(() => ({
+      getElementById: () => ({ getType: () => PipelineRunNodeType.TASK_NODE }),
+    }));
+
+    const setPropsFn = jest.fn();
+
+    render(<PipelineRunSidePanel />, {
+      wrapper: ({ children }) => (
+        <SidePanelContext.Provider value={{ setProps: setPropsFn, close: () => {} }}>
+          {children}
+        </SidePanelContext.Provider>
+      ),
+    });
+
+    expect(setPropsFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isExpanded: true,
+      }),
+    );
+  });
+});

--- a/src/components/PipelineRunDetailsView/sidepanels/TaskRunDetails.tsx
+++ b/src/components/PipelineRunDetailsView/sidepanels/TaskRunDetails.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import {
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+} from '@patternfly/react-core';
+import { Timestamp } from '../../../shared/components/timestamp/Timestamp';
+import { PipelineTask } from '../../../types/pipeline';
+import { calculateDuration, runStatus } from '../../../utils/pipeline-utils';
+import RunResultsList from '../tabs/RunResultsList';
+
+type Props = {
+  taskRun: PipelineTask;
+  status: runStatus;
+};
+
+const TaskRunDetails: React.FC<Props> = ({ taskRun, status }) => (
+  <>
+    {status !== runStatus.Skipped ? (
+      <>
+        <DescriptionList columnModifier={{ default: '2Col' }}>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Started</DescriptionListTerm>
+            <DescriptionListDescription>
+              <Timestamp timestamp={taskRun.status?.startTime} />
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Duration</DescriptionListTerm>
+            <DescriptionListDescription>
+              {taskRun.status?.startTime
+                ? calculateDuration(taskRun.status?.startTime, taskRun.status?.completionTime)
+                : '-'}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+        </DescriptionList>
+
+        <DescriptionList className="pf-u-mt-sm">
+          <DescriptionListGroup>
+            <DescriptionListTerm>Description</DescriptionListTerm>
+            <DescriptionListDescription>
+              {taskRun.status?.taskSpec?.description || '-'}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+        </DescriptionList>
+      </>
+    ) : (
+      'This task was skipped.'
+    )}
+    {taskRun.status?.taskResults?.length ? (
+      <>
+        <br />
+        <RunResultsList status={status} results={taskRun.status.taskResults} />
+      </>
+    ) : null}
+  </>
+);
+
+export default TaskRunDetails;

--- a/src/components/PipelineRunDetailsView/sidepanels/TaskRunPanel.scss
+++ b/src/components/PipelineRunDetailsView/sidepanels/TaskRunPanel.scss
@@ -1,0 +1,11 @@
+.task-run-panel {
+  &__tabs {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+
+    & > .pf-c-tab-content {
+      flex-grow: 1;
+    }
+  }
+}

--- a/src/components/PipelineRunDetailsView/sidepanels/TaskRunPanel.tsx
+++ b/src/components/PipelineRunDetailsView/sidepanels/TaskRunPanel.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import {
+  DrawerActions,
+  DrawerCloseButton,
+  DrawerHead,
+  DrawerPanelBody,
+  Tab,
+  Tabs,
+} from '@patternfly/react-core';
+import { ElementModel, GraphElement } from '@patternfly/react-topology';
+import TaskRunLogs from '../../TaskRuns/TaskRunLogs';
+import { StatusIconWithTextLabel } from '../../topology/StatusIcon';
+import { PipelineRunNodeData } from '../visualization/types';
+import TaskRunDetails from './TaskRunDetails';
+
+import './TaskRunPanel.scss';
+
+type Props = {
+  onClose: () => void;
+  taskRunNode: GraphElement<ElementModel, PipelineRunNodeData>;
+};
+
+const TaskRunPanel: React.FC<Props> = ({ taskRunNode, onClose }) => {
+  const taskRun = taskRunNode.getData().task;
+  const { status } = taskRunNode.getData();
+  return (
+    <>
+      <DrawerHead>
+        <span>
+          {taskRun.name} <StatusIconWithTextLabel status={status} />
+        </span>
+        <DrawerActions>
+          <DrawerCloseButton onClick={onClose} />
+        </DrawerActions>
+      </DrawerHead>
+
+      <div className="task-run-panel__tabs">
+        <Tabs defaultActiveKey="details" unmountOnExit className="">
+          <Tab title="Details" eventKey="details">
+            <DrawerPanelBody>
+              <TaskRunDetails taskRun={taskRun} status={status} />
+            </DrawerPanelBody>
+          </Tab>
+          <Tab title="Logs" eventKey="logs">
+            {/* Height hack until we can manage the layout of the main content area in consoledot */}
+            <DrawerPanelBody style={{ maxHeight: 'calc(100vh - 215px)', height: '100%' }}>
+              <TaskRunLogs
+                taskName={taskRun.name}
+                namespace={taskRunNode.getData().namespace}
+                podName={taskRun.status?.podName}
+                status={status}
+              />
+            </DrawerPanelBody>
+          </Tab>
+        </Tabs>
+      </div>
+    </>
+  );
+};
+
+export default TaskRunPanel;

--- a/src/components/PipelineRunDetailsView/sidepanels/TaskRunPanel.tsx
+++ b/src/components/PipelineRunDetailsView/sidepanels/TaskRunPanel.tsx
@@ -42,8 +42,7 @@ const TaskRunPanel: React.FC<Props> = ({ taskRunNode, onClose }) => {
             </DrawerPanelBody>
           </Tab>
           <Tab title="Logs" eventKey="logs">
-            {/* Height hack until we can manage the layout of the main content area in consoledot */}
-            <DrawerPanelBody style={{ maxHeight: 'calc(100vh - 215px)', height: '100%' }}>
+            <DrawerPanelBody style={{ height: '100%' }}>
               <TaskRunLogs
                 taskName={taskRun.name}
                 namespace={taskRunNode.getData().namespace}

--- a/src/components/PipelineRunDetailsView/tabs/RunResultsList.scss
+++ b/src/components/PipelineRunDetailsView/tabs/RunResultsList.scss
@@ -1,0 +1,5 @@
+.run-results-list {
+  &__value {
+    overflow-wrap: anywhere;
+  }
+}

--- a/src/components/PipelineRunDetailsView/tabs/RunResultsList.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/RunResultsList.tsx
@@ -10,6 +10,8 @@ import { TableComposable, Thead, Tbody, Th, Td, Tr } from '@patternfly/react-tab
 import { TektonResultsRun } from '../../../types';
 import { handleURLs } from '../../../utils/render-utils';
 
+import './RunResultsList.scss';
+
 type Props = {
   results: TektonResultsRun[];
   status: string;
@@ -31,8 +33,8 @@ const RunResultsList: React.FC<Props> = ({ results, status }) => (
         <Tbody>
           {results.map(({ name, value }) => (
             <Tr key={`row-${name}`}>
-              <Td>{name}</Td>
-              <Td>{handleURLs(value)}</Td>
+              <Td className="run-results-list__key">{name}</Td>
+              <Td className="run-results-list__value">{handleURLs(value)}</Td>
             </Tr>
           ))}
         </Tbody>

--- a/src/components/PipelineRunDetailsView/visualization/nodes/PipelineRunNode.scss
+++ b/src/components/PipelineRunDetailsView/visualization/nodes/PipelineRunNode.scss
@@ -1,5 +1,5 @@
 .pipelinerun-node {
-  cursor: default;
+  cursor: pointer;
   &__test-status-badge {
     &--failed {
       > rect {

--- a/src/components/PipelineRunDetailsView/visualization/nodes/PipelineRunNode.tsx
+++ b/src/components/PipelineRunDetailsView/visualization/nodes/PipelineRunNode.tsx
@@ -7,6 +7,7 @@ import {
   WhenDecorator,
   WithContextMenuProps,
   WithSelectionProps,
+  withSelection,
 } from '@patternfly/react-topology';
 import { observer } from 'mobx-react';
 import { runStatusToRunStatus } from '../../../topology/utils';
@@ -61,4 +62,4 @@ const PipelineRunNode: React.FunctionComponent<PipelineRunNodeProps> = ({ elemen
   );
 };
 
-export default observer(PipelineRunNode);
+export default withSelection()(observer(PipelineRunNode));

--- a/src/components/PipelineRunDetailsView/visualization/types.ts
+++ b/src/components/PipelineRunDetailsView/visualization/types.ts
@@ -19,6 +19,7 @@ export type StepStatus = {
 export type PipelineRunNodeData = {
   task: PipelineTask;
   status?: runStatus;
+  namespace: string;
   testFailCount?: number;
   testWarnCount?: number;
   whenStatus?: WhenStatus;

--- a/src/components/PipelineRunDetailsView/visualization/utils/pipelinerun-graph-utils.ts
+++ b/src/components/PipelineRunDetailsView/visualization/utils/pipelinerun-graph-utils.ts
@@ -1,7 +1,9 @@
 import {
   DEFAULT_LAYERS,
+  ElementModel,
   getEdgesFromNodes,
   getSpacerNodes,
+  GraphElement,
   ModelKind,
   WhenStatus,
 } from '@patternfly/react-topology';
@@ -348,6 +350,7 @@ const getGraphDataModel = (pipeline: PipelineKind, pipelineRun?: PipelineRunKind
       width: maxWidthForLevel[vertex.level] + NODE_PADDING * 2 + NODE_ICON_WIDTH,
       height: DEFAULT_NODE_HEIGHT,
       data: {
+        namespace: pipelineRun.metadata.namespace,
         status: vertex.data.status?.reason,
         testFailCount: vertex.data.status.testFailCount,
         testWarnCount: vertex.data.status.testWarnCount,
@@ -371,6 +374,7 @@ const getGraphDataModel = (pipeline: PipelineKind, pipelineRun?: PipelineRunKind
     width: getTextWidth(maxFinallyNodeName) + NODE_PADDING * 2 + DEFAULT_FINALLLY_GROUP_PADDING * 2,
     height: DEFAULT_NODE_HEIGHT,
     data: {
+      namespace: pipelineRun.metadata.namespace,
       status: fTask.status.reason,
       whenStatus: taskWhenStatus(fTask),
       task: fTask,
@@ -427,9 +431,8 @@ export const getPipelineRunDataModel = (pipelineRun: PipelineRunKind) => {
   return getGraphDataModel(getPipelineFromPipelineRun(pipelineRun), pipelineRun);
 };
 
-export const getPipelineDataModel = (pipeline: PipelineKind) => {
-  if (!pipeline) {
-    return null;
-  }
-  return getGraphDataModel(pipeline);
-};
+export const isTaskRunNode = (
+  e?: GraphElement,
+): e is GraphElement<ElementModel, PipelineRunNodeData> =>
+  e?.getType() === PipelineRunNodeType.TASK_NODE ||
+  e?.getType() === PipelineRunNodeType.FINALLY_NODE;

--- a/src/components/SidePanel/SidePanel.tsx
+++ b/src/components/SidePanel/SidePanel.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import SidePanelContext, { SidePanelProps } from './SidePanelContext';
+
+const SidePanel: React.FC<SidePanelProps> = ({ isExpanded, isInline, onExpand, children }) => {
+  const { close, setProps } = React.useContext(SidePanelContext);
+
+  React.useEffect(
+    () => () => close(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  React.useEffect(() => {
+    setProps({ isExpanded, isInline, onExpand, children });
+  }, [setProps, isExpanded, isInline, onExpand, children]);
+
+  return null;
+};
+
+export default SidePanel;

--- a/src/components/SidePanel/SidePanelContext.ts
+++ b/src/components/SidePanel/SidePanelContext.ts
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export type SidePanelProps = {
+  isExpanded?: boolean;
+  children?: React.ReactNode;
+  isInline?: boolean;
+  onExpand?: () => void;
+};
+
+export type SidePanelContextValue = {
+  setProps: (props: SidePanelProps) => void;
+  close: () => void;
+};
+
+export default React.createContext<SidePanelContextValue>({
+  setProps: () => {},
+  close: () => {},
+});

--- a/src/components/SidePanel/SidePanelHost.tsx
+++ b/src/components/SidePanel/SidePanelHost.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Drawer, DrawerContent, DrawerPanelContent } from '@patternfly/react-core';
+import SidePanelContext, { SidePanelProps } from './SidePanelContext';
+
+const SidePanelHost: React.FC = ({ children }) => {
+  const [props, setProps] = React.useState<SidePanelProps>({ isExpanded: false, isInline: true });
+  const propsRef = React.useRef(props);
+  propsRef.current = props;
+
+  const close = React.useCallback(() => {
+    setProps({ ...propsRef.current, isExpanded: false });
+  }, []);
+
+  const panelContent = <DrawerPanelContent isResizable>{props.children}</DrawerPanelContent>;
+
+  return (
+    <SidePanelContext.Provider value={{ setProps, close }}>
+      <Drawer isExpanded={props.isExpanded} isInline={props.isInline} onExpand={props.onExpand}>
+        <DrawerContent panelContent={panelContent}>{children}</DrawerContent>
+      </Drawer>
+    </SidePanelContext.Provider>
+  );
+};
+
+export default SidePanelHost;

--- a/src/components/SidePanel/__tests__/SidePanel.spec.tsx
+++ b/src/components/SidePanel/__tests__/SidePanel.spec.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import SidePanel from '../SidePanel';
+import SidePanelContext from '../SidePanelContext';
+
+describe('SidePanel', () => {
+  it('should should render nothing', () => {
+    const setPropsFn = jest.fn();
+    const result = render(<SidePanel />, {
+      wrapper: ({ children }) => (
+        <SidePanelContext.Provider value={{ setProps: setPropsFn, close: () => {} }}>
+          {children}
+        </SidePanelContext.Provider>
+      ),
+    });
+    expect(result.container).toBeEmptyDOMElement();
+  });
+
+  it('should send props to context', () => {
+    const setPropsFn = jest.fn();
+    const onExpandFn = jest.fn();
+    render(
+      <SidePanel isExpanded isInline onExpand={onExpandFn}>
+        test
+      </SidePanel>,
+      {
+        wrapper: ({ children }) => (
+          <SidePanelContext.Provider value={{ setProps: setPropsFn, close: () => {} }}>
+            {children}
+          </SidePanelContext.Provider>
+        ),
+      },
+    );
+    expect(setPropsFn).toBeCalledWith({
+      isExpanded: true,
+      isInline: true,
+      children: 'test',
+      onExpand: onExpandFn,
+    });
+  });
+
+  it('should close on unmount', () => {
+    const setPropsFn = jest.fn();
+    const closeFn = jest.fn();
+    const result = render(<SidePanel isExpanded>test</SidePanel>, {
+      wrapper: ({ children }) => (
+        <SidePanelContext.Provider value={{ setProps: setPropsFn, close: closeFn }}>
+          {children}
+        </SidePanelContext.Provider>
+      ),
+    });
+
+    // unmount SidePanel
+    result.rerender(null);
+
+    expect(closeFn).toBeCalledTimes(1);
+  });
+});

--- a/src/components/SidePanel/__tests__/SidePanelHost.spec.tsx
+++ b/src/components/SidePanel/__tests__/SidePanelHost.spec.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import SidePanel from '../SidePanel';
+import SidePanelHost from '../SidePanelHost';
+
+describe('SidePanelHost', () => {
+  it('should render drawer expanded states', () => {
+    const result = render(<SidePanel>test</SidePanel>, {
+      wrapper: ({ children }) => <SidePanelHost>{children}</SidePanelHost>,
+    });
+
+    expect(result.queryByText('test')).not.toBeInTheDocument();
+
+    result.rerender(<SidePanel isExpanded>test</SidePanel>);
+
+    expect(result.queryByText('test')).toBeInTheDocument();
+  });
+});

--- a/src/components/TaskRuns/TaskRunLogs.tsx
+++ b/src/components/TaskRuns/TaskRunLogs.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { PodGroupVersionKind } from '../../models/pod';
+import LogsWrapperComponent from '../../shared/components/pipeline-run-logs/logs/LogsWrapperComponent';
+import { runStatus } from '../../utils/pipeline-utils';
+
+type Props = {
+  podName: string;
+  taskName: string;
+  namespace: string;
+  status: runStatus;
+};
+
+const TaskRunLogs: React.FC<Props> = ({ taskName, podName, namespace, status }) => {
+  if (status === runStatus.Skipped) {
+    return <div>No logs. This task was skipped.</div>;
+  }
+  if (status === runStatus.Idle) {
+    return <div>Waiting on task to start.</div>;
+  }
+  if (!podName) {
+    return <div>No logs found.</div>;
+  }
+  return (
+    <LogsWrapperComponent
+      resource={{
+        name: podName,
+        groupVersionKind: PodGroupVersionKind,
+        namespace,
+        isList: false,
+      }}
+      taskName={taskName}
+    />
+  );
+};
+
+export default TaskRunLogs;

--- a/src/components/TaskRuns/__tests__/TaskRunLogs.spec.tsx
+++ b/src/components/TaskRuns/__tests__/TaskRunLogs.spec.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import { runStatus } from '../../../utils/pipeline-utils';
+import TaskRunLogs from '../TaskRunLogs';
+
+describe('TaskRunLogs', () => {
+  it('should render no logs found', () => {
+    const result = render(
+      <TaskRunLogs podName={null} namespace="test" taskName="task" status={runStatus.Running} />,
+    );
+    expect(result.queryByText('No logs found.')).toBeInTheDocument();
+  });
+
+  it('should render waiting to start', () => {
+    const result = render(
+      <TaskRunLogs podName={null} namespace="test" taskName="task" status={runStatus.Idle} />,
+    );
+    expect(result.queryByText('Waiting on task to start.')).toBeInTheDocument();
+  });
+
+  it('should render no logs due to Skipped status', () => {
+    const result = render(
+      <TaskRunLogs podName={null} namespace="test" taskName="task" status={runStatus.Skipped} />,
+    );
+    expect(result.queryByText('No logs. This task was skipped.')).toBeInTheDocument();
+  });
+});

--- a/src/components/topology/factories/VisualizationFactory.tsx
+++ b/src/components/topology/factories/VisualizationFactory.tsx
@@ -19,6 +19,7 @@ type VisualizationFactoryProps = {
   componentFactory: ComponentFactory;
   controlBar?: (controller: Controller) => React.ReactNode;
   fullHeight?: boolean;
+  children?: React.ReactElement;
 };
 
 type Size = {
@@ -32,6 +33,7 @@ const VisualizationFactory: React.FC<VisualizationFactoryProps> = ({
   componentFactory,
   controlBar,
   fullHeight = false,
+  children,
 }) => {
   const [controller, setController] = React.useState<Controller>(null);
   const [maxSize, setMaxSize] = React.useState<Size>(null);
@@ -92,6 +94,7 @@ const VisualizationFactory: React.FC<VisualizationFactoryProps> = ({
       <TopologyView controlBar={controlBar ? controlBar(controller) : undefined}>
         <VisualizationSurface />
       </TopologyView>
+      {children}
     </VisualizationProvider>
   );
 

--- a/src/types/task-run.ts
+++ b/src/types/task-run.ts
@@ -9,6 +9,7 @@ import {
   VolumeTypePVC,
   VolumeTypeSecret,
 } from './pipeline-run';
+import { TaskKind } from '.';
 
 export type TaskRunWorkspace = {
   name: string;
@@ -27,6 +28,7 @@ export type TaskRunStatus = {
   startTime?: string;
   steps?: PLRTaskRunStep[];
   taskResults?: TektonResultsRun[];
+  taskSpec?: TaskKind['spec'];
 };
 
 export type TaskRunKind = K8sResourceCommon & {


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-3357

## Description

Adds click interaction for task run nodes of the pipeline run visualization.
Opens a sidepanel with extra information.

The side panel is configured as `inline` which will push the content. The reason for doing this is because it allows us to navigate the visualization and gain access to the right most nodes without having to first close the panel.

When a node is clicked, we scroll it into view to ensure the task node is visible when the panel opens.

Some tasks aren't very interesting, such as skipped tasks. Skipped tasks have no start time or duration or logs.

Known issues:
~~There is a layout issue with consoledot that prevents me from defining two distinct scroll areas: one for the panel and one for the adjacent content. Because of this the panel can scroll off screen. https://issues.redhat.com/browse/RHCLOUD-24606~~
~~This is also causing our logs viewer to scroll the panel down when switching nodes while on the logs tab.~~

Addressed this issue in the second commit. This is a work around to https://issues.redhat.com/browse/RHCLOUD-24606 by setting the main layout to have a `relative` css `position`. By doing this I can then establish a height in the `NamespacedPage` layout. This affects all pages because it establishes a new layout container. We can revisit this once the issue is looked at by the consoledot team.

![image](https://user-images.githubusercontent.com/14068621/225049507-10d64a2a-61e8-40aa-bb23-3860012810ef.png)

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
![image](https://user-images.githubusercontent.com/14068621/223855695-7189a960-63e6-4ddd-ba54-14764a40285f.png)

Success nodes include results:
![image](https://user-images.githubusercontent.com/14068621/223856952-cf423095-5501-4fa2-80fe-19ae0649cb4a.png)

![image](https://user-images.githubusercontent.com/14068621/223855730-6c4cdc5e-0fea-4443-985a-494dafd6eac9.png)

Some tasks have no description.
Skipped tasks have no start time or duration or logs.
![image](https://user-images.githubusercontent.com/14068621/224134392-4fade968-de38-4fe4-acb8-42d451801880.png)
![image](https://user-images.githubusercontent.com/14068621/224134452-426b594a-35ae-43a1-8aac-05387f9848ed.png)

## How to test or reproduce?
Create a build such that there is at least one pipeline run.
Navigate to the pipeline run details page.
Select a node to open the side panel.

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
