### PR TITLE
show validation error message when invalid component name is detected

### DIFF
--- a/src/shared/components/formik-fields/EditableLabelField.tsx
+++ b/src/shared/components/formik-fields/EditableLabelField.tsx
@@ -18,7 +18,7 @@ const EditableLabelField: React.FC<EditableLabelFieldProps> = ({
   type = TextInputTypes.text,
   ...props
 }) => {
-  const [, { value, error }, { setValue }] = useField({ name, type });
+  const [, { value, error }, { setValue, setTouched }] = useField({ name, type });
   const [editing, setEditing] = React.useState(false);
   const [oldValue, setOldValue] = React.useState('');
   const fieldId = getFieldId(name, 'label-field');
@@ -26,8 +26,9 @@ const EditableLabelField: React.FC<EditableLabelFieldProps> = ({
   React.useEffect(() => {
     if (error && !editing) {
       setEditing(true);
+      setTouched(true);
     }
-  }, [error, editing]);
+  }, [error, editing, setTouched]);
 
   const editIcon = (
     <GrayPencilAltIcon

--- a/src/shared/components/formik-fields/__tests__/EditableLabelField.spec.tsx
+++ b/src/shared/components/formik-fields/__tests__/EditableLabelField.spec.tsx
@@ -97,6 +97,21 @@ describe('EditableLabelField', () => {
     });
   });
 
+  it('should show the validation error message if there are any', async () => {
+    render(
+      <Wrapper
+        initialValues={{ editableLabel: '234-invalid-name' }}
+        initialErrors={{ editableLabel: 'Invalid component name provided' }}
+        onSubmit={jest.fn()}
+      >
+        <EditableLabelField name={fieldName} />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      expect(screen.queryByText('Invalid component name provided')).toBeInTheDocument();
+    });
+  });
+
   it('should show label field with updated value and unmount editable field on input followed by submit button click ', async () => {
     render(
       <Wrapper initialValues={initialValues} onSubmit={jest.fn()}>


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-3376

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Invalid component name error message should be shown if there is any validation error during detection.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

**Before:**

<img width="972" alt="Screenshot 2023-03-10 at 3 01 13 PM" src="https://user-images.githubusercontent.com/9964343/224278911-de744926-ca09-4908-8de4-6336cdf6af1d.png">


**After**:

<img width="945" alt="Screenshot 2023-03-10 at 2 59 03 PM" src="https://user-images.githubusercontent.com/9964343/224278383-95ccd869-325e-4d40-a4e1-468bee81c26f.png">

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->


Try to import the repository: https://github.com/hacbs-release/fbc-test

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

cc: @rottencandy 