### PR TITLE
Remove status from component node of lifecycle vis

### DIFF
--- a/integration-tests/support/pageObjects/createApplication-po.ts
+++ b/integration-tests/support/pageObjects/createApplication-po.ts
@@ -67,6 +67,7 @@ export const applicationDetailPagePO = {
   route: (param: string) => `[data-test-id="${param}-route"]`,
   graphNode: 'g[data-kind="node"]',
   pipelineStatusSuccess: 'g[class="pf-topology-pipelines__pill-status pf-m-success"]',
+  pipelineNode: 'g[class="pf-topology__pipelines__task-node workload-node"]',
 };
 
 export const componentsListPagePO = {

--- a/integration-tests/support/pages/ApplicationDetailPage.ts
+++ b/integration-tests/support/pages/ApplicationDetailPage.ts
@@ -57,9 +57,14 @@ export class ApplicationDetailPage {
     cy.get(buildLogModalContentPO.failedPipelineRunLogs).should('not.exist');
   }
 
-  verifyGraphNodes(nodeText: string) {
+  verifyGraphNodes(nodeText: string, success = true) {
     cy.contains(applicationDetailPagePO.graphNode, nodeText).within(() => {
-      cy.get(applicationDetailPagePO.pipelineStatusSuccess, { timeout: 60000 })
+      cy.get(
+        success
+          ? applicationDetailPagePO.pipelineStatusSuccess
+          : applicationDetailPagePO.pipelineNode,
+        { timeout: 60000 },
+      )
         .scrollIntoView()
         .should('be.visible');
     });

--- a/integration-tests/tests/basic-happy-path.spec.ts
+++ b/integration-tests/tests/basic-happy-path.spec.ts
@@ -128,7 +128,7 @@ describe('Basic Happy Path', { tags: ['@PR-check', '@publicRepo'] }, () => {
 
     it('Validate the graph views for the created application', () => {
       Applications.goToOverviewTab();
-      applicationDetailPage.verifyGraphNodes('Components');
+      applicationDetailPage.verifyGraphNodes('Components', false);
       applicationDetailPage.verifyGraphNodes('Builds');
       applicationDetailPage.verifyGraphNodes('Static environments');
     });


### PR DESCRIPTION
## Fixes 
Fixes [HAC-2915](https://issues.redhat.com/browse/HAC-2915)

## Description
Removes status indicator for component nodes in the overview lifecycle visualization

## Type of change
- [x] Bugfix

## Screen shots / Gifs for design review 
![image](https://user-images.githubusercontent.com/11633780/224340608-21f3d159-583e-41ea-a1b0-90a338bbf841.png)


![image](https://user-images.githubusercontent.com/11633780/224340545-da3d86c9-8361-4468-b8e6-91714e9166f4.png)

/cc @karthikjeeyar @christianvogt 