### PR TITLE
Support tekton minimal status configuration

### DIFF
--- a/src/components/LogViewer/BuildLogViewer.tsx
+++ b/src/components/LogViewer/BuildLogViewer.tsx
@@ -24,7 +24,7 @@ export const BuildLogViewer: React.FC<BuildLogViewerProps> = ({ component }) => 
     PipelineRunType.BUILD,
   );
   const [taskRuns, tloaded] = useTaskRuns(
-    component.metadata.namespace,
+    pipelineRun?.metadata?.namespace,
     pipelineRun?.metadata?.name,
   );
 

--- a/src/components/LogViewer/BuildLogViewer.tsx
+++ b/src/components/LogViewer/BuildLogViewer.tsx
@@ -3,6 +3,7 @@ import { ModalVariant, Stack, StackItem } from '@patternfly/react-core';
 import dayjs from 'dayjs';
 import { PipelineRunType } from '../../consts/pipelinerun';
 import { useComponentPipelineRun } from '../../hooks';
+import { useTaskRuns } from '../../hooks/useTaskRuns';
 import PipelineRunLogs from '../../shared/components/pipeline-run-logs/PipelineRunLogs';
 import { EmptyBox, LoadingBox } from '../../shared/components/status-box/StatusBox';
 import { ComponentKind } from '../../types';
@@ -22,8 +23,12 @@ export const BuildLogViewer: React.FC<BuildLogViewerProps> = ({ component }) => 
     component.metadata.namespace,
     PipelineRunType.BUILD,
   );
+  const [taskRuns, tloaded] = useTaskRuns(
+    component.metadata.namespace,
+    pipelineRun?.metadata?.name,
+  );
 
-  if (loaded && !pipelineRun) {
+  if (loaded && tloaded && !pipelineRun) {
     return <EmptyBox label="pipeline runs" />;
   }
 
@@ -45,7 +50,11 @@ export const BuildLogViewer: React.FC<BuildLogViewerProps> = ({ component }) => 
         )}
       </StackItem>
       <StackItem isFilled>
-        {pipelineRun ? <PipelineRunLogs obj={pipelineRun} /> : <LoadingBox />}
+        {pipelineRun && taskRuns && tloaded ? (
+          <PipelineRunLogs obj={pipelineRun} taskRuns={taskRuns} />
+        ) : (
+          <LoadingBox />
+        )}
       </StackItem>
     </Stack>
   );

--- a/src/components/PipelineRunDetailsView/PipelineRunVisualization.tsx
+++ b/src/components/PipelineRunDetailsView/PipelineRunVisualization.tsx
@@ -8,12 +8,12 @@ import { getPipelineRunDataModel } from './visualization/utils/pipelinerun-graph
 
 import './PipelineRunVisualization.scss';
 
-const PipelineRunVisualization = ({ pipelineRun, error }) => {
+const PipelineRunVisualization = ({ pipelineRun, error, taskRuns }) => {
   const nodeRef = React.useRef<HTMLDivElement>();
 
   const model = React.useMemo(() => {
-    return getPipelineRunDataModel(pipelineRun);
-  }, [pipelineRun]);
+    return getPipelineRunDataModel(pipelineRun, taskRuns);
+  }, [pipelineRun, taskRuns]);
 
   const scrollIntoView = React.useCallback(
     (element: GraphElement) => {

--- a/src/components/PipelineRunDetailsView/__tests__/PipelineVisualization.spec.tsx
+++ b/src/components/PipelineRunDetailsView/__tests__/PipelineVisualization.spec.tsx
@@ -30,19 +30,20 @@ beforeEach(() => {
 
 describe('PipelineRunVisualization', () => {
   it('should not render the pipelinerun graph', () => {
-    render(<PipelineRunVisualization pipelineRun={null} error={null} />);
+    render(<PipelineRunVisualization pipelineRun={null} taskRuns={[]} error={null} />);
     expect(screen.queryByTestId('pipelinerun-graph')).not.toBeInTheDocument();
   });
 
   it('should not render the pipelinerun graph if the pipelinerun status is not available yet', () => {
     const plrWithoutStatus = { ...testPipelineRun, status: undefined };
-    render(<PipelineRunVisualization pipelineRun={plrWithoutStatus} error={null} />);
+    render(<PipelineRunVisualization pipelineRun={plrWithoutStatus} taskRuns={[]} error={null} />);
     expect(screen.queryByTestId('pipelinerun-graph')).not.toBeInTheDocument();
   });
 
   it('should surface the api error message', () => {
     render(
       <PipelineRunVisualization
+        taskRuns={[]}
         pipelineRun={null}
         error={new CustomError('Model does not exist')}
       />,
@@ -51,7 +52,7 @@ describe('PipelineRunVisualization', () => {
   });
 
   it('should render the pipelinerun graph', () => {
-    render(<PipelineRunVisualization pipelineRun={testPipelineRun} error={null} />);
+    render(<PipelineRunVisualization pipelineRun={testPipelineRun} taskRuns={[]} error={null} />);
     screen.getByTestId('pipelinerun-graph');
   });
 });

--- a/src/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
@@ -19,7 +19,7 @@ import ExternalLink from '../../../shared/components/links/ExternalLink';
 import { ErrorDetailsWithStaticLog } from '../../../shared/components/pipeline-run-logs/logs/log-snippet-types';
 import { getPLRLogSnippet } from '../../../shared/components/pipeline-run-logs/logs/pipelineRunLogSnippet';
 import { Timestamp } from '../../../shared/components/timestamp/Timestamp';
-import { PipelineRunKind } from '../../../types';
+import { PipelineRunKind, TaskRunKind } from '../../../types';
 import { getCommitShortName } from '../../../utils/commits-utils';
 import { calculateDuration, pipelineRunStatus } from '../../../utils/pipeline-utils';
 import { useWorkspaceInfo } from '../../../utils/workspace-context-utils';
@@ -31,12 +31,18 @@ import { getSourceUrl } from '../utils/pipelinerun-utils';
 import RunResultsList from './RunResultsList';
 
 type PipelineRunDetailsTabProps = {
+  taskRuns: TaskRunKind[];
   pipelineRun: PipelineRunKind;
   error: unknown;
 };
-const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({ pipelineRun, error }) => {
+const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({
+  pipelineRun,
+  error,
+  taskRuns,
+}) => {
   const { workspace } = useWorkspaceInfo();
-  const pipelineRunFailed = (getPLRLogSnippet(pipelineRun) || {}) as ErrorDetailsWithStaticLog;
+  const pipelineRunFailed = (getPLRLogSnippet(pipelineRun, taskRuns) ||
+    {}) as ErrorDetailsWithStaticLog;
   const duration = calculateDuration(
     typeof pipelineRun.status?.startTime === 'string' ? pipelineRun.status?.startTime : '',
     typeof pipelineRun.status?.completionTime === 'string'
@@ -55,7 +61,7 @@ const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({ pipelineR
       <Title headingLevel="h4" className="pf-c-title pf-u-mt-lg pf-u-mb-lg" size="lg">
         Pipeline run details
       </Title>
-      <PipelineRunVisualization pipelineRun={pipelineRun} error={error} />
+      <PipelineRunVisualization pipelineRun={pipelineRun} error={error} taskRuns={taskRuns} />
       {!error && (
         <Flex>
           <Flex flex={{ default: 'flex_3' }}>

--- a/src/components/PipelineRunDetailsView/tabs/PipelineRunLogsTab.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/PipelineRunLogsTab.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import { PipelineRunLogs } from '../../../shared';
-import { PipelineRunKind } from '../../../types';
+import { PipelineRunKind, TaskRunKind } from '../../../types';
 
 type PipelineRunLogsTabProps = {
   pipelineRun: PipelineRunKind;
+  taskRuns: TaskRunKind[];
 };
 
-const PipelineRunLogsTab: React.FC<PipelineRunLogsTabProps> = ({ pipelineRun }) => (
-  <PipelineRunLogs obj={pipelineRun} />
+const PipelineRunLogsTab: React.FC<PipelineRunLogsTabProps> = ({ pipelineRun, taskRuns }) => (
+  <PipelineRunLogs obj={pipelineRun} taskRuns={taskRuns} />
 );
 
 export default PipelineRunLogsTab;

--- a/src/components/PipelineRunDetailsView/tabs/PipelineRunTaskRunsTab.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/PipelineRunTaskRunsTab.tsx
@@ -1,17 +1,14 @@
 import * as React from 'react';
-import { PipelineRunKind } from '../../../types';
+import { TaskRunKind } from '../../../types';
 import TaskRunListView from '../../TaskRunListView/TaskRunListView';
 
 type PipelineRunTaskRunsTabProps = {
-  pipelineRun: PipelineRunKind;
+  taskRuns: TaskRunKind[];
+  loaded: boolean;
 };
 
-const PipelineRunTaskRunsTab: React.FC<PipelineRunTaskRunsTabProps> = ({ pipelineRun }) =>
-  pipelineRun && Object.keys(pipelineRun).length ? (
-    <TaskRunListView
-      pipelineName={pipelineRun.metadata.name}
-      namespace={pipelineRun.metadata.namespace}
-    />
-  ) : null;
+const PipelineRunTaskRunsTab: React.FC<PipelineRunTaskRunsTabProps> = ({ taskRuns, loaded }) => (
+  <TaskRunListView taskRuns={taskRuns} loaded={loaded} />
+);
 
 export default PipelineRunTaskRunsTab;

--- a/src/components/PipelineRunDetailsView/tabs/__tests__/PipelineRunDetailsTab.spec.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/__tests__/PipelineRunDetailsTab.spec.tsx
@@ -5,6 +5,7 @@ import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { configure, render, screen } from '@testing-library/react';
 import { PipelineRunLabel } from '../../../../consts/pipelinerun';
 import { CustomError } from '../../../../shared/utils/error/custom-error';
+import { PipelineRunKind, TaskRunKind, TektonResourceLabel } from '../../../../types';
 import { sampleBuildPipelines } from '../../../ApplicationDetails/tabs/overview/visualization/hooks/__data__/workflow-data';
 import { pipelineWithCommits } from '../../../Commits/__data__/pipeline-with-commits';
 import { testPipelineRun } from '../../../topology/__data__/pipeline-test-data';
@@ -37,46 +38,93 @@ beforeEach(() => {
     return createElement(tagName);
   };
 });
-
+const getTaskRunsFromPLR = (plr: PipelineRunKind): TaskRunKind[] =>
+  Object.keys(plr.status.taskRuns).map((trName) => ({
+    apiVersion: 'v1alpha1',
+    kind: 'TaskRun',
+    metadata: {
+      labels: {
+        [TektonResourceLabel.pipelineTask]: plr.status.taskRuns[trName].pipelineTaskName,
+      },
+      name: trName,
+    },
+    spec: {},
+    status: plr.status.taskRuns[trName].status,
+  }));
 describe('PipelineRunDetailsTab', () => {
   it('should render the pipelinerun details tab', () => {
     watchResourceMock.mockReturnValue([[], true]);
-    render(<PipelineRunDetailsTab pipelineRun={sampleBuildPipelines[0]} error={null} />, {
-      wrapper: BrowserRouter,
-    });
+    render(
+      <PipelineRunDetailsTab
+        pipelineRun={sampleBuildPipelines[0]}
+        taskRuns={getTaskRunsFromPLR(sampleBuildPipelines[0])}
+        error={null}
+      />,
+      {
+        wrapper: BrowserRouter,
+      },
+    );
     screen.getByText('Pipeline run details');
   });
 
   it('should render the pipelinerun component reference', () => {
     watchResourceMock.mockReturnValue([[], true]);
-    render(<PipelineRunDetailsTab pipelineRun={sampleBuildPipelines[0]} error={null} />, {
-      wrapper: BrowserRouter,
-    });
+    render(
+      <PipelineRunDetailsTab
+        pipelineRun={sampleBuildPipelines[0]}
+        taskRuns={getTaskRunsFromPLR(sampleBuildPipelines[0])}
+        error={null}
+      />,
+      {
+        wrapper: BrowserRouter,
+      },
+    );
     expect(screen.getByRole('link', { name: /1-nodejs/ })).toBeInTheDocument();
   });
 
   it('should not render the pipelinerun visualization if the status field is missing', () => {
     watchResourceMock.mockReturnValue([[], true]);
-    render(<PipelineRunDetailsTab pipelineRun={sampleBuildPipelines[1]} error={null} />, {
-      wrapper: BrowserRouter,
-    });
+    render(
+      <PipelineRunDetailsTab
+        pipelineRun={sampleBuildPipelines[1]}
+        taskRuns={getTaskRunsFromPLR(testPipelineRun)}
+        error={null}
+      />,
+      {
+        wrapper: BrowserRouter,
+      },
+    );
     expect(screen.queryByTestId('pipelinerun-graph')).not.toBeInTheDocument();
   });
 
   it('should render the pipelinerun visualization', () => {
     watchResourceMock.mockReturnValue([[], true]);
-    render(<PipelineRunDetailsTab pipelineRun={testPipelineRun} error={null} />, {
-      wrapper: BrowserRouter,
-    });
+    render(
+      <PipelineRunDetailsTab
+        pipelineRun={testPipelineRun}
+        taskRuns={getTaskRunsFromPLR(testPipelineRun)}
+        error={null}
+      />,
+      {
+        wrapper: BrowserRouter,
+      },
+    );
     screen.getByTestId('pipelinerun-graph');
   });
 
   it('should not render the error fields for the succeeded pipelinerun', () => {
     watchResourceMock.mockReturnValue([[], true]);
 
-    render(<PipelineRunDetailsTab pipelineRun={testPipelineRun} error={null} />, {
-      wrapper: BrowserRouter,
-    });
+    render(
+      <PipelineRunDetailsTab
+        pipelineRun={testPipelineRun}
+        taskRuns={getTaskRunsFromPLR(testPipelineRun)}
+        error={null}
+      />,
+      {
+        wrapper: BrowserRouter,
+      },
+    );
     expect(screen.queryByText('Message')).not.toBeInTheDocument();
     expect(screen.queryByText('Log snippet')).not.toBeInTheDocument();
   });
@@ -98,9 +146,16 @@ describe('PipelineRunDetailsTab', () => {
         ],
       },
     };
-    render(<PipelineRunDetailsTab pipelineRun={failedPipelineRun} error={null} />, {
-      wrapper: BrowserRouter,
-    });
+    render(
+      <PipelineRunDetailsTab
+        pipelineRun={failedPipelineRun}
+        taskRuns={getTaskRunsFromPLR(failedPipelineRun)}
+        error={null}
+      />,
+      {
+        wrapper: BrowserRouter,
+      },
+    );
     screen.getByText('Message');
     screen.getByText('Log snippet');
   });
@@ -110,6 +165,7 @@ describe('PipelineRunDetailsTab', () => {
     render(
       <PipelineRunDetailsTab
         pipelineRun={testPipelineRun}
+        taskRuns={getTaskRunsFromPLR(testPipelineRun)}
         error={new CustomError('Model not found')}
       />,
       {
@@ -121,33 +177,61 @@ describe('PipelineRunDetailsTab', () => {
 
   it('should render the component link', () => {
     watchResourceMock.mockReturnValue([[], true]);
-    render(<PipelineRunDetailsTab pipelineRun={testPipelineRun} error={null} />, {
-      wrapper: BrowserRouter,
-    });
+    render(
+      <PipelineRunDetailsTab
+        pipelineRun={testPipelineRun}
+        taskRuns={getTaskRunsFromPLR(testPipelineRun)}
+        error={null}
+      />,
+      {
+        wrapper: BrowserRouter,
+      },
+    );
     screen.getByText('Component');
   });
 
   it('should not render the commit link for simple pipelinerun', () => {
     watchResourceMock.mockReturnValue([[], true]);
-    render(<PipelineRunDetailsTab pipelineRun={testPipelineRun} error={null} />, {
-      wrapper: BrowserRouter,
-    });
+    render(
+      <PipelineRunDetailsTab
+        pipelineRun={testPipelineRun}
+        taskRuns={getTaskRunsFromPLR(testPipelineRun)}
+        error={null}
+      />,
+      {
+        wrapper: BrowserRouter,
+      },
+    );
     expect(screen.queryByText('Commit')).not.toBeInTheDocument();
   });
 
   it('should render the commit link for pac pipelinerun', () => {
     watchResourceMock.mockReturnValue([[], true]);
-    render(<PipelineRunDetailsTab pipelineRun={pipelineWithCommits[0]} error={null} />, {
-      wrapper: BrowserRouter,
-    });
+    render(
+      <PipelineRunDetailsTab
+        pipelineRun={pipelineWithCommits[0]}
+        taskRuns={getTaskRunsFromPLR(testPipelineRun)}
+        error={null}
+      />,
+      {
+        wrapper: BrowserRouter,
+      },
+    );
     screen.getByText('Commit');
   });
 
   it('should render the source Url for advanced pipelinerun', () => {
     watchResourceMock.mockReturnValue([[], true]);
-    render(<PipelineRunDetailsTab pipelineRun={pipelineWithCommits[0]} error={null} />, {
-      wrapper: BrowserRouter,
-    });
+    render(
+      <PipelineRunDetailsTab
+        pipelineRun={pipelineWithCommits[0]}
+        taskRuns={getTaskRunsFromPLR(testPipelineRun)}
+        error={null}
+      />,
+      {
+        wrapper: BrowserRouter,
+      },
+    );
     screen.getByText('Source');
   });
 
@@ -164,18 +248,32 @@ describe('PipelineRunDetailsTab', () => {
         },
       },
     };
-    render(<PipelineRunDetailsTab pipelineRun={simplePipelineRun} error={null} />, {
-      wrapper: BrowserRouter,
-    });
+    render(
+      <PipelineRunDetailsTab
+        pipelineRun={simplePipelineRun}
+        taskRuns={getTaskRunsFromPLR(testPipelineRun)}
+        error={null}
+      />,
+      {
+        wrapper: BrowserRouter,
+      },
+    );
     screen.getByText('Source');
   });
 
   it('should not render the source section for a pipelinerun without any source', () => {
     watchResourceMock.mockReturnValue([[], true]);
 
-    render(<PipelineRunDetailsTab pipelineRun={testPipelineRun} error={null} />, {
-      wrapper: BrowserRouter,
-    });
+    render(
+      <PipelineRunDetailsTab
+        pipelineRun={testPipelineRun}
+        taskRuns={getTaskRunsFromPLR(testPipelineRun)}
+        error={null}
+      />,
+      {
+        wrapper: BrowserRouter,
+      },
+    );
     expect(screen.queryByText('Source')).not.toBeInTheDocument();
   });
 
@@ -191,18 +289,32 @@ describe('PipelineRunDetailsTab', () => {
         },
       },
     };
-    render(<PipelineRunDetailsTab pipelineRun={simplePipelineRun} error={null} />, {
-      wrapper: BrowserRouter,
-    });
+    render(
+      <PipelineRunDetailsTab
+        pipelineRun={simplePipelineRun}
+        taskRuns={getTaskRunsFromPLR(simplePipelineRun)}
+        error={null}
+      />,
+      {
+        wrapper: BrowserRouter,
+      },
+    );
     expect(screen.queryByText('Download SBOM')).toBeInTheDocument();
   });
 
   it('should not render the download SBOM section for a pipelinerun without any image annotation', () => {
     watchResourceMock.mockReturnValue([[], true]);
 
-    render(<PipelineRunDetailsTab pipelineRun={testPipelineRun} error={null} />, {
-      wrapper: BrowserRouter,
-    });
+    render(
+      <PipelineRunDetailsTab
+        pipelineRun={testPipelineRun}
+        taskRuns={getTaskRunsFromPLR(testPipelineRun)}
+        error={null}
+      />,
+      {
+        wrapper: BrowserRouter,
+      },
+    );
     expect(screen.queryByText('Download SBOM')).not.toBeInTheDocument();
   });
 });

--- a/src/components/PipelineRunDetailsView/tabs/__tests__/PipelineRunTaskRunsTab.spec.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/__tests__/PipelineRunTaskRunsTab.spec.tsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom';
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { ByRoleOptions, configure, render, screen } from '@testing-library/react';
 import { useSearchParam } from '../../../../hooks/useSearchParam';
+import { TektonResourceLabel } from '../../../../types';
 import { testTaskRuns } from '../../../TaskRunListView/__data__/mock-TaskRun-data';
 import { testPipelineRun } from '../../../topology/__data__/pipeline-test-data';
 import PipelineRunTaskRunsTab from '../PipelineRunTaskRunsTab';
@@ -16,29 +17,51 @@ jest.mock('../../../../hooks/useSearchParam', () => ({
   useSearchParam: jest.fn(),
 }));
 
+jest.mock('react-i18next', () => ({
+  useTranslation: jest.fn(() => ({ t: (x) => x })),
+}));
+
 const mockUseK8sWatchResource = useK8sWatchResource as jest.Mock;
 const mockUseSearchParam = useSearchParam as jest.Mock;
 
 configure({ testIdAttribute: 'data-test' });
 
 describe('PipelineRunTaskRunsTab', () => {
-  it('should not render the TaskRun table if pipelinerun is missing', () => {
+  it('should not render the TaskRun table if taskruns are missing', () => {
     mockUseSearchParam.mockReturnValueOnce(['']);
-    render(<PipelineRunTaskRunsTab pipelineRun={null} />);
+    render(<PipelineRunTaskRunsTab taskRuns={[]} loaded={false} />);
     expect(screen.queryByRole('grid')).not.toBeInTheDocument();
   });
 
   it('should render TaskRun empty state', () => {
     mockUseK8sWatchResource.mockReturnValue([[], true]);
     mockUseSearchParam.mockReturnValueOnce(['']);
-    render(<PipelineRunTaskRunsTab pipelineRun={testPipelineRun} />);
+    render(<PipelineRunTaskRunsTab taskRuns={[]} loaded={true} />);
     screen.getByTestId('taskrun-empty-state');
   });
 
   it('should render TaskRun table', () => {
     mockUseK8sWatchResource.mockReturnValue([[testTaskRuns[0]], true]);
     mockUseSearchParam.mockReturnValueOnce(['']);
-    render(<PipelineRunTaskRunsTab pipelineRun={testPipelineRun} />);
-    screen.queryByRole('grid', { label: 'TaskRun List' } as ByRoleOptions);
+    render(
+      <PipelineRunTaskRunsTab
+        taskRuns={Object.values(testPipelineRun.status.taskRuns).map((tr) => ({
+          apiVersion: 'v1alpha1',
+          kind: 'TaskRun',
+          metadata: {
+            labels: {
+              [TektonResourceLabel.pipelineTask]: tr.pipelineTaskName,
+            },
+          },
+          spec: {},
+          status: tr.status,
+        }))}
+        loaded={true}
+      />,
+    );
+    screen.getByTestId('taskrun-list-toolbar');
+    expect(
+      screen.queryByRole('grid', { ['aria-label']: 'TaskRun List' } as ByRoleOptions),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/PipelineRunDetailsView/visualization/utils/pipelinerun-graph-utils.ts
+++ b/src/components/PipelineRunDetailsView/visualization/utils/pipelinerun-graph-utils.ts
@@ -164,7 +164,7 @@ export const appendStatus = (
 
   return tasks.map((task) => {
     if (!pipelineRun?.status) {
-      return merge(task, { status: { reason: runStatus.Skipped } });
+      return merge(task, { status: { reason: runStatus.Pending } });
     }
     if (!taskRuns || taskRuns.length === 0) {
       return merge({}, task, { status: { reason: overallPipelineRunStatus } });
@@ -180,9 +180,6 @@ export const appendStatus = (
       status: { ...taskStatus, reason: runStatus.Pending },
     });
 
-    if (!pipelineRun?.status || !pipelineRun?.status?.taskRuns) {
-      return mTask;
-    }
     // append task duration
     if (mTask.status.completionTime && mTask.status.startTime) {
       const date =

--- a/src/components/TaskRunListView/TaskRunListView.tsx
+++ b/src/components/TaskRunListView/TaskRunListView.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import {
   Bullseye,
   EmptyState,
@@ -13,25 +12,14 @@ import {
 } from '@patternfly/react-core';
 import { useSearchParam } from '../../hooks/useSearchParam';
 import { Table } from '../../shared';
-import { TaskRunGroupVersionKind, TaskRunKind } from '../../types';
+import { TaskRunKind } from '../../types';
 import FilteredEmptyState from '../EmptyState/FilteredEmptyState';
 import { TaskRunListHeader } from './TaskRunListHeader';
 import TaskRunListRow from './TaskRunListRow';
 
-type Props = { pipelineName: string; namespace: string };
+type Props = { taskRuns: TaskRunKind[]; loaded: boolean };
 
-const TaskRunListView: React.FC<Props> = ({ pipelineName, namespace }) => {
-  const [taskRuns, loaded] = useK8sWatchResource<TaskRunKind[]>({
-    groupVersionKind: TaskRunGroupVersionKind,
-    namespace,
-    isList: true,
-    selector: {
-      matchLabels: {
-        'tekton.dev/pipelineRun': pipelineName,
-      },
-    },
-  });
-
+const TaskRunListView: React.FC<Props> = ({ taskRuns, loaded }) => {
   const [nameFilter, setNameFilter] = useSearchParam('name', '');
 
   const sortedTaskRuns = React.useMemo(

--- a/src/components/TaskRunListView/__tests__/TaskRunListView.spec.tsx
+++ b/src/components/TaskRunListView/__tests__/TaskRunListView.spec.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { render, configure, screen } from '@testing-library/react';
 import { useSearchParam } from '../../../hooks/useSearchParam';
 import { testTaskRuns } from '../__data__/mock-TaskRun-data';
@@ -10,7 +9,6 @@ jest.mock('react-i18next', () => ({
 }));
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
-  useK8sWatchResource: jest.fn(),
   getActiveWorkspace: jest.fn(() => 'test-ws'),
 }));
 
@@ -20,36 +18,31 @@ jest.mock('../../../hooks/useSearchParam', () => ({
 
 configure({ testIdAttribute: 'data-test' });
 
-const useK8sWatchResourceMock = useK8sWatchResource as jest.Mock;
 const mockUseSearchParam = useSearchParam as jest.Mock;
 
 describe('TaskRunListView', () => {
   it('should render progress indicator while loading', async () => {
-    useK8sWatchResourceMock.mockReturnValue([undefined, false, undefined]);
     mockUseSearchParam.mockReturnValueOnce(['']);
-    const wrapper = render(<TaskRunListView pipelineName="test-pipeline" namespace="test-ns" />);
+    const wrapper = render(<TaskRunListView taskRuns={[]} loaded={false} />);
     expect(await wrapper.findByRole('progressbar')).toBeTruthy();
   });
 
   it('should render empty state when no TaskRuns present', () => {
-    useK8sWatchResourceMock.mockReturnValue([[], true, undefined]);
     mockUseSearchParam.mockReturnValueOnce(['']);
-    const wrapper = render(<TaskRunListView pipelineName="test-pipeline" namespace="test-ns" />);
+    const wrapper = render(<TaskRunListView taskRuns={[]} loaded={false} />);
     expect(wrapper.findByText('No TaskRuns found')).toBeTruthy();
   });
 
   it('should render table', () => {
-    useK8sWatchResourceMock.mockReturnValue([testTaskRuns, true, undefined]);
     mockUseSearchParam.mockReturnValueOnce(['']);
-    const wrapper = render(<TaskRunListView pipelineName="test-pipeline" namespace="test-ns" />);
+    const wrapper = render(<TaskRunListView taskRuns={testTaskRuns} loaded={true} />);
     const table = wrapper.container.getElementsByTagName('table');
     expect(table).toHaveLength(1);
   });
 
   it('should render filter toolbar', () => {
-    useK8sWatchResourceMock.mockReturnValue([testTaskRuns, true, undefined]);
     mockUseSearchParam.mockReturnValueOnce(['']);
-    const wrapper = render(<TaskRunListView pipelineName="test-pipeline" namespace="test-ns" />);
+    const wrapper = render(<TaskRunListView taskRuns={testTaskRuns} loaded={true} />);
     screen.getByTestId('taskrun-list-toolbar');
     expect(wrapper.container.getElementsByTagName('table')).toHaveLength(1);
     expect(wrapper.container.getElementsByTagName('tr')).toHaveLength(1);

--- a/src/hooks/useTaskRuns.ts
+++ b/src/hooks/useTaskRuns.ts
@@ -1,0 +1,17 @@
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { TaskRunGroupVersionKind, TaskRunKind, TektonResourceLabel } from '../types';
+
+export const useTaskRuns = (
+  namespace: string,
+  pipelineRunName: string,
+): [TaskRunKind[], boolean, unknown] =>
+  useK8sWatchResource<TaskRunKind[]>({
+    groupVersionKind: TaskRunGroupVersionKind,
+    namespace,
+    selector: {
+      matchLabels: {
+        [TektonResourceLabel.pipelinerun]: pipelineRunName,
+      },
+    },
+    isList: true,
+  });

--- a/src/shared/components/pipeline-run-logs/logs/pipelineRunLogSnippet.ts
+++ b/src/shared/components/pipeline-run-logs/logs/pipelineRunLogSnippet.ts
@@ -1,9 +1,18 @@
-import { Condition, PipelineRunKind, PLRTaskRunData, PLRTaskRunStep } from '../../../../types';
+import {
+  Condition,
+  PipelineRunKind,
+  PLRTaskRunData,
+  PLRTaskRunStep,
+  TaskRunKind,
+} from '../../../../types';
 import { pipelineRunStatus } from '../../../../utils/pipeline-utils';
 import { CombinedErrorDetails } from './log-snippet-types';
 import { taskRunSnippetMessage } from './log-snippet-utils';
 
-export const getPLRLogSnippet = (pipelineRun: PipelineRunKind): CombinedErrorDetails => {
+export const getPLRLogSnippet = (
+  pipelineRun: PipelineRunKind,
+  taskRuns: TaskRunKind[],
+): CombinedErrorDetails => {
   if (!pipelineRun?.status) {
     // Lack information to pull from the Pipeline Run
     return null;
@@ -22,8 +31,8 @@ export const getPLRLogSnippet = (pipelineRun: PipelineRunKind): CombinedErrorDet
     return null;
   }
 
-  const taskRuns: PLRTaskRunData[] = Object.values(pipelineRun.status.taskRuns || {});
-  const failedTaskRuns = taskRuns.filter((taskRun) =>
+  const tRuns: PLRTaskRunData[] = Object.values(taskRuns || pipelineRun.status.taskRuns || {});
+  const failedTaskRuns = tRuns.filter((taskRun) =>
     taskRun?.status?.conditions?.find(
       (condition) => condition.type === 'Succeeded' && condition.status === 'False',
     ),


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-3352

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

when embedded-status configuration is set to minimal, which will remove the `status.taskruns` from the `pipelineruns.status`. This PR fetches the taskruns separately instead of reading from `pipelinerun.status.taskruns`

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

No UI changes


Pipelinerun/Taskrun/logs should work as before.

https://user-images.githubusercontent.com/9964343/224714069-4579d68b-ffdd-44e8-a1e9-2dda642866d1.mov






## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

cc: @christianvogt 
