### PR TITLE
Do not propagate task status up to pipeline run

### DIFF
--- a/src/utils/pipeline-utils.ts
+++ b/src/utils/pipeline-utils.ts
@@ -26,22 +26,6 @@ export enum runStatus {
   Unknown = 'Unknown',
 }
 
-const statusSeverities = [
-  [runStatus.Succeeded],
-  [
-    runStatus['In Progress'],
-    runStatus.Idle,
-    runStatus.Pending,
-    runStatus.Running,
-    runStatus.PipelineNotStarted,
-    runStatus.NeedsMerge,
-    runStatus.Unknown,
-  ],
-  [runStatus.Skipped],
-  [runStatus.Cancelled, runStatus.Cancelling],
-  [runStatus.Failed, runStatus.FailedToStart],
-];
-
 export enum SucceedConditionReason {
   PipelineRunStopped = 'StoppedRunFinally',
   PipelineRunCancelled = 'CancelledRunFinally',
@@ -250,28 +234,8 @@ export const taskRunStatus = (taskRun: TaskRunKind | PLRTaskRunData): runStatus 
   return status === runStatus.Succeeded ? taskResultsStatus(taskRun.status.taskResults) : status;
 };
 
-const worstStatus = (status1: runStatus, status2: runStatus): runStatus => {
-  const index1 = statusSeverities.findIndex((severities) => severities.includes(status1));
-  const index2 = statusSeverities.findIndex((severities) => severities.includes(status2));
-  return index1 >= index2 ? status1 : status2;
-};
-
-export const pipelineRunStatus = (pipelineRun: PipelineRunKind): runStatus => {
-  if (!pipelineRun?.status?.conditions?.length) {
-    return runStatus.Pending;
-  }
-
-  let status = conditionsRunStatus(pipelineRun.status.conditions, pipelineRun.spec.status);
-  if (status === runStatus.Succeeded && pipelineRun.status?.taskRuns) {
-    Object.keys(pipelineRun.status?.taskRuns).forEach((taskName) => {
-      const resultStatus = taskResultsStatus(
-        pipelineRun.status.taskRuns[taskName].status?.taskResults,
-      );
-      status = worstStatus(status, resultStatus);
-    });
-  }
-  return status;
-};
+export const pipelineRunStatus = (pipelineRun: PipelineRunKind): runStatus =>
+  conditionsRunStatus(pipelineRun?.status?.conditions, pipelineRun?.spec?.status);
 
 export const pipelineRunStatusToGitOpsStatus = (status: string): GitOpsDeploymentHealthStatus => {
   switch (status) {


### PR DESCRIPTION
## Fixes 
Fix for showing correct pipeline status. Do not propagate task run status up to pipeline run status (introduced in https://github.com/openshift/hac-dev/pull/468).


## Description
https://github.com/openshift/hac-dev/pull/468 mistakenly propagated the task run status up to the overall pipeline run status. Remove this propagation.

## Type of change
- [x] Bugfix

## Screen shots / Gifs for design review 

Before:
![image](https://user-images.githubusercontent.com/11633780/225007390-aea33058-ee78-4778-8776-ce5f6653b272.png)


After:

![image](https://user-images.githubusercontent.com/11633780/225007529-34c8c651-7557-401d-94b6-468899c7f99b.png)


## How to test or reproduce?
View a successful pipeline run that has HACBS_TEST_OUTPUT failures in task runs.

/cc @karthikjeeyar @rohitkrai03 