### PR TITLE
fix details page layout with flex

### DIFF
--- a/src/components/ApplicationDetails/DetailsPage.scss
+++ b/src/components/ApplicationDetails/DetailsPage.scss
@@ -1,10 +1,14 @@
-.app-details__tabs {
-  display: flex;
-  flex-direction: column;
+.app-details {
+  flex-grow: 1;
 
-  &__tabItem {
-    &.isFilled.pf-c-tab-content {
-      flex: 1;
+  &__tabs {
+    display: flex;
+    flex-direction: column;
+
+    &__tabItem {
+      &.isFilled.pf-c-tab-content {
+        flex: 1;
+      }
     }
   }
 }

--- a/src/components/ApplicationDetails/DetailsPage.tsx
+++ b/src/components/ApplicationDetails/DetailsPage.tsx
@@ -139,7 +139,7 @@ const DetailsPage: React.FC<DetailsPageProps> = ({
   );
 
   return (
-    <PageGroup data-test="details">
+    <PageGroup data-test="details" className="app-details">
       <HeadTitle>{`${headTitle} - ${activeTab?.label} | CI/CD`}</HeadTitle>
       <PageSection type="breadcrumb">
         {breadcrumbs && <BreadCrumbs data-test="details__breadcrumbs" breadcrumbs={breadcrumbs} />}


### PR DESCRIPTION

## Description

https://github.com/openshift/hac-dev/pull/465 changed the page layout to work around a consoledot issue but this resulted in the details page for the activity pipelinerun tab not extending the full length


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

before:
![image](https://user-images.githubusercontent.com/14068621/225126455-b8a226fe-ccc5-4118-ba5e-32662171bfe8.png)

after:
![image](https://user-images.githubusercontent.com/14068621/225126549-edbe81ce-f7c4-45c6-bd1d-7ac47e47f864.png)


## How to test or reproduce?
Navigate to application -> activity tab -> pipeline runs tab

<!-- **Test Configuration(s)**: -->

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
