### PR TITLE
Fix for SearchInput used in toolbar

### DIFF
--- a/src/components/Commits/CommitsListView.tsx
+++ b/src/components/Commits/CommitsListView.tsx
@@ -151,7 +151,6 @@ const CommitsListView: React.FC<CommitsListViewProps> = ({
                           placeholder="Filter by name..."
                           onChange={(e, name) => onNameInput(name)}
                           value={nameFilter}
-                          onClear={onClearFilters}
                         />
                       </ToolbarItem>
                       <ToolbarItem>

--- a/src/components/Components/ComponentListView.tsx
+++ b/src/components/Components/ComponentListView.tsx
@@ -190,7 +190,6 @@ const ComponentListView: React.FC<ComponentListViewProps> = ({ applicationName }
                       placeholder="Filter by name..."
                       onChange={(e, name) => setNameFilter(name)}
                       value={nameFilter}
-                      onClear={() => setNameFilter('')}
                     />
                   </ToolbarItem>
                   <ToolbarItem>

--- a/src/components/Environment/EnvironmentListView.tsx
+++ b/src/components/Environment/EnvironmentListView.tsx
@@ -139,7 +139,6 @@ const EnvironmentListView: React.FC<Props> = ({
                       placeholder="Filter by name..."
                       value={nameFilter}
                       onChange={(e, name) => setNameFilter(name)}
-                      onClear={() => unsetNameFilter()}
                     />
                   </ToolbarItem>
                 </>

--- a/src/components/ImportForm/SampleSection/SampleSection.tsx
+++ b/src/components/ImportForm/SampleSection/SampleSection.tsx
@@ -116,7 +116,6 @@ const SampleSection = ({ onStrategyChange }) => {
                   value={filter}
                   onChange={(e, name) => setFilter(name)}
                   placeholder="Filter by keyword..."
-                  onClear={() => setFilter('')}
                 />
               </ToolbarItem>
               <ToolbarItem alignment={{ default: 'alignRight' }}>

--- a/src/components/PipelineRunListView/PipelineRunsListView.tsx
+++ b/src/components/PipelineRunListView/PipelineRunsListView.tsx
@@ -117,7 +117,6 @@ const PipelineRunsListView: React.FC<PipelineRunsListViewProps> = ({ application
                 placeholder="Filter by name..."
                 onChange={(e, name) => onNameInput(name)}
                 value={nameFilter}
-                onClear={() => setNameFilter('')}
               />
             </ToolbarItem>
             <ToolbarItem>

--- a/src/components/TaskRunListView/TaskRunListView.tsx
+++ b/src/components/TaskRunListView/TaskRunListView.tsx
@@ -87,7 +87,6 @@ const TaskRunListView: React.FC<Props> = ({ pipelineName, namespace }) => {
                 placeholder="Filter by name..."
                 onChange={(e, name) => onNameInput(name)}
                 value={nameFilter}
-                onClear={() => setNameFilter('')}
               />
             </ToolbarItem>
           </ToolbarGroup>


### PR DESCRIPTION
## Fixes 
Fixes an issue where the search input on the toolbars shows two clear buttons (`x`).

## Description
PF latest adds a clear button on a SearchInput when `onClear` is set. Remove the `onClear` setting and rely on the toolbar clear button for clearing the text.

## Type of change
- [x] Bugfix

/cc @karthikjeeyar 