### PR TITLE
workaround svg scrollIntoView for Firefox

### DIFF
--- a/src/components/PipelineRunDetailsView/PipelineRunSidePanel.tsx
+++ b/src/components/PipelineRunDetailsView/PipelineRunSidePanel.tsx
@@ -3,44 +3,49 @@ import {
   SELECTION_STATE,
   useVisualizationController,
   useVisualizationState,
-  GraphElement,
+  Node,
 } from '@patternfly/react-topology';
 import SidePanel from '../SidePanel/SidePanel';
 import TaskRunPanel from './sidepanels/TaskRunPanel';
 import { isTaskRunNode } from './visualization/utils/pipelinerun-graph-utils';
 
 type Props = {
-  scrollIntoView?: (element: GraphElement) => void;
+  scrollIntoView?: (node: Node) => void;
 };
 
 const PipelineRunSidePanel: React.FC<Props> = ({ scrollIntoView }) => {
   const [[selectedId], setSelectedIds] = useVisualizationState<string[]>(SELECTION_STATE, []);
   const controller = useVisualizationController();
 
-  const element = React.useMemo(
-    () => (selectedId ? controller.getElementById(selectedId) : null),
-    [controller, selectedId],
-  );
+  const taskRunNode = React.useMemo(() => {
+    if (selectedId) {
+      const element = controller.getElementById(selectedId);
+      if (isTaskRunNode(element)) {
+        return element;
+      }
+    }
+    return null;
+  }, [controller, selectedId]);
 
-  const panel = isTaskRunNode(element) ? (
-    <TaskRunPanel onClose={() => setSelectedIds([])} taskRunNode={element} />
+  const panel = taskRunNode ? (
+    <TaskRunPanel onClose={() => setSelectedIds([])} taskRunNode={taskRunNode} />
   ) : null;
 
   const isExpanded = !!panel;
 
   const onExpand = React.useCallback(() => {
-    if (isExpanded && element) {
-      scrollIntoView?.(element);
+    if (isExpanded && taskRunNode) {
+      scrollIntoView?.(taskRunNode);
     }
-  }, [isExpanded, scrollIntoView, element]);
+  }, [isExpanded, scrollIntoView, taskRunNode]);
 
   React.useEffect(() => {
-    if (isExpanded && element) {
-      scrollIntoView?.(element);
+    if (isExpanded && taskRunNode) {
+      scrollIntoView?.(taskRunNode);
     }
-    // only run when the element changes
+    // only run when the node changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [element]);
+  }, [taskRunNode]);
 
   return (
     <SidePanel isExpanded={isExpanded} onExpand={onExpand} isInline>

--- a/src/components/PipelineRunDetailsView/PipelineRunVisualization.tsx
+++ b/src/components/PipelineRunDetailsView/PipelineRunVisualization.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
-import { GraphElement } from '@patternfly/react-topology';
+import { Node } from '@patternfly/react-topology';
 import { layoutFactory, VisualizationFactory } from '../topology/factories';
 import GraphErrorState from '../topology/factories/GraphErrorState';
 import { pipelineRuncomponentFactory } from './factories';
 import PipelineRunSidePanel from './PipelineRunSidePanel';
-import { getPipelineRunDataModel } from './visualization/utils/pipelinerun-graph-utils';
+import {
+  getPipelineRunDataModel,
+  scrollNodeIntoView,
+} from './visualization/utils/pipelinerun-graph-utils';
 
 import './PipelineRunVisualization.scss';
 
@@ -16,10 +19,10 @@ const PipelineRunVisualization = ({ pipelineRun, error, taskRuns }) => {
   }, [pipelineRun, taskRuns]);
 
   const scrollIntoView = React.useCallback(
-    (element: GraphElement) => {
-      nodeRef.current
-        ?.querySelector(`[data-id=${element.getId()}]`)
-        ?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+    (node: Node) => {
+      if (nodeRef.current) {
+        scrollNodeIntoView(node, nodeRef.current);
+      }
     },
     [nodeRef],
   );

--- a/src/components/PipelineRunDetailsView/__tests__/PipelineRunSidePanel.spec.tsx
+++ b/src/components/PipelineRunDetailsView/__tests__/PipelineRunSidePanel.spec.tsx
@@ -59,14 +59,16 @@ describe('PipelineRunSidePanel', () => {
   });
 
   it('should render panel for task selection', () => {
+    const scrollIntoViewFn = jest.fn();
+    const testNode = { getType: () => PipelineRunNodeType.TASK_NODE };
     useVisualizationStateMock.mockImplementationOnce(() => [['testId'], jest.fn()]);
     useVisualizationControllerMock.mockImplementationOnce(() => ({
-      getElementById: () => ({ getType: () => PipelineRunNodeType.TASK_NODE }),
+      getElementById: () => testNode,
     }));
 
     const setPropsFn = jest.fn();
 
-    render(<PipelineRunSidePanel />, {
+    render(<PipelineRunSidePanel scrollIntoView={scrollIntoViewFn} />, {
       wrapper: ({ children }) => (
         <SidePanelContext.Provider value={{ setProps: setPropsFn, close: () => {} }}>
           {children}
@@ -79,5 +81,6 @@ describe('PipelineRunSidePanel', () => {
         isExpanded: true,
       }),
     );
+    expect(scrollIntoViewFn).toHaveBeenCalledWith(testNode);
   });
 });

--- a/src/components/PipelineRunDetailsView/visualization/utils/pipelinerun-graph-utils.ts
+++ b/src/components/PipelineRunDetailsView/visualization/utils/pipelinerun-graph-utils.ts
@@ -5,6 +5,7 @@ import {
   getSpacerNodes,
   GraphElement,
   ModelKind,
+  Node,
   WhenStatus,
 } from '@patternfly/react-topology';
 import { uniq } from 'lodash-es';
@@ -431,8 +432,29 @@ export const getPipelineRunDataModel = (pipelineRun: PipelineRunKind, taskRuns: 
   return getGraphDataModel(getPipelineFromPipelineRun(pipelineRun), pipelineRun, taskRuns);
 };
 
-export const isTaskRunNode = (
-  e?: GraphElement,
-): e is GraphElement<ElementModel, PipelineRunNodeData> =>
+export const isTaskRunNode = (e?: GraphElement): e is Node<ElementModel, PipelineRunNodeData> =>
   e?.getType() === PipelineRunNodeType.TASK_NODE ||
   e?.getType() === PipelineRunNodeType.FINALLY_NODE;
+
+export const scrollNodeIntoView = (node: Node, scrollPane: HTMLElement) => {
+  const targetNode = scrollPane.querySelector(`[data-id=${node.getId()}]`);
+  if (targetNode) {
+    if (scrollPane.ownerDocument.defaultView.navigator.userAgent.search('Firefox') !== -1) {
+      // Fix for firefox which does not take into consideration the full SVG node size with #scrollIntoView
+      let left: number = null;
+      const nodeBounds = node.getBounds();
+      const scrollLeftEdge = nodeBounds.x;
+      const scrollRightEdge = nodeBounds.x + nodeBounds.width - scrollPane.offsetWidth;
+      if (scrollPane.scrollLeft < scrollRightEdge) {
+        left = scrollRightEdge;
+      } else if (scrollPane.scrollLeft > scrollLeftEdge) {
+        left = scrollLeftEdge;
+      }
+      if (left != null) {
+        scrollPane.scrollTo({ left, behavior: 'smooth' });
+      }
+    } else {
+      targetNode.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+    }
+  }
+};


### PR DESCRIPTION
## Fixes 
https://github.com/openshift/hac-dev/pull/465#issuecomment-1469904086

## Description
`scrollIntoView` acts funny for Firefox. It doesn't seem to take into consideration the width of the SVG node.

Implemented a custom solution just for Firefox :(


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
Select task nodes in the pipeline run visualization that is not fully visible when the side panel is open.


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
