### PR TITLE
Start new build action from pipeline run details page

### DIFF
--- a/src/components/PipelineRunDetailsView/sidepanels/TaskRunPanel.scss
+++ b/src/components/PipelineRunDetailsView/sidepanels/TaskRunPanel.scss
@@ -1,4 +1,7 @@
 .task-run-panel {
+  &__head {
+    flex-shrink: 0;
+  }
   &__tabs {
     flex-grow: 1;
     display: flex;

--- a/src/components/PipelineRunDetailsView/sidepanels/TaskRunPanel.tsx
+++ b/src/components/PipelineRunDetailsView/sidepanels/TaskRunPanel.tsx
@@ -25,14 +25,16 @@ const TaskRunPanel: React.FC<Props> = ({ taskRunNode, onClose }) => {
   const { status } = taskRunNode.getData();
   return (
     <>
-      <DrawerHead>
-        <span>
-          {taskRun.name} <StatusIconWithTextLabel status={status} />
-        </span>
-        <DrawerActions>
-          <DrawerCloseButton onClick={onClose} />
-        </DrawerActions>
-      </DrawerHead>
+      <div className="task-run-panel__head">
+        <DrawerHead>
+          <span>
+            {taskRun.name} <StatusIconWithTextLabel status={status} />
+          </span>
+          <DrawerActions>
+            <DrawerCloseButton onClick={onClose} />
+          </DrawerActions>
+        </DrawerHead>
+      </div>
 
       <div className="task-run-panel__tabs">
         <Tabs defaultActiveKey="details" unmountOnExit className="">

--- a/src/components/PipelineRunDetailsView/sidepanels/__tests__/TaskRunDetails.spec.tsx
+++ b/src/components/PipelineRunDetailsView/sidepanels/__tests__/TaskRunDetails.spec.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import { PipelineTask } from '../../../../types';
+import { runStatus } from '../../../../utils/pipeline-utils';
+import TaskRunDetails from '../TaskRunDetails';
+
+describe('TaskRunDetails', () => {
+  it('should handle skipped tasks', () => {
+    const result = render(
+      <TaskRunDetails status={runStatus.Skipped} taskRun={{} as PipelineTask} />,
+    );
+    expect(result.queryByText('This task was skipped.')).toBeInTheDocument();
+  });
+
+  it('should display task info', () => {
+    const result = render(
+      <TaskRunDetails
+        status={runStatus.Running}
+        taskRun={{ status: { taskSpec: { description: 'test' } } } as PipelineTask}
+      />,
+    );
+    expect(result.queryByText('Description')).toBeInTheDocument();
+    expect(result.queryByText('test')).toBeInTheDocument();
+  });
+
+  it('should display task results', () => {
+    const result = render(
+      <TaskRunDetails
+        status={runStatus.Succeeded}
+        taskRun={
+          { status: { taskResults: [{ name: 'test-name', value: 'test-value' }] } } as PipelineTask
+        }
+      />,
+    );
+    expect(result.queryByText('Results')).toBeInTheDocument();
+    expect(result.queryByText('test-name')).toBeInTheDocument();
+    expect(result.queryByText('test-value')).toBeInTheDocument();
+  });
+});

--- a/src/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
@@ -36,7 +36,7 @@ import RunResultsList from './RunResultsList';
 type PipelineRunDetailsTabProps = {
   taskRuns: TaskRunKind[];
   pipelineRun: PipelineRunKind;
-  error: unknown;
+  error?: unknown;
 };
 const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({
   pipelineRun,

--- a/src/hooks/useComponents.ts
+++ b/src/hooks/useComponents.ts
@@ -6,13 +6,17 @@ import { useWorkspaceInfo } from '../utils/workspace-context-utils';
 
 export const useComponent = (
   namespace: string,
-  componentName: string,
+  componentName?: string,
 ): [ComponentKind, boolean, unknown] => {
-  const [component, componentsLoaded, error] = useK8sWatchResource<ComponentKind>({
-    groupVersionKind: ComponentGroupVersionKind,
-    namespace,
-    name: componentName,
-  });
+  const [component, componentsLoaded, error] = useK8sWatchResource<ComponentKind>(
+    componentName
+      ? {
+          groupVersionKind: ComponentGroupVersionKind,
+          namespace,
+          name: componentName,
+        }
+      : undefined,
+  );
   return React.useMemo(() => {
     if (componentsLoaded && !error && component?.metadata.deletionTimestamp) {
       return [null, componentsLoaded, { code: 404 }];

--- a/src/utils/component-utils.ts
+++ b/src/utils/component-utils.ts
@@ -61,7 +61,7 @@ export const disablePAC = (component: ComponentKind) => {
   });
 };
 
-export const startNewBuild = (component: ComponentKind) => {
+export const startNewBuild = (component: ComponentKind) =>
   k8sPatchResource({
     model: ComponentModel,
     queryOptions: {
@@ -75,7 +75,6 @@ export const startNewBuild = (component: ComponentKind) => {
       },
     ],
   });
-};
 
 const GIT_URL_PREFIX = 'https://github.com/';
 


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/HAC-3180
https://issues.redhat.com/browse/HAC-3320

## Description
Added a `Start new build` action to the pipeline run details page.
This action is only visible for default build components. Even if the pipeline run was previously run from a default pipeline component which was then later updated, the action would not be available. Similarly if the pipeline run was from PAC but later the component was returned to a default pipeline, the action will be available.

After starting the action, the user is brought to the pipeline run list page with a filter set to the related component name.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
![image](https://user-images.githubusercontent.com/14068621/225416327-9bf9ca08-7d4a-4482-8cb3-64f30765a9a8.png)

landing page after execution:
![image](https://user-images.githubusercontent.com/14068621/225417572-0d257787-5a5b-4939-ad8b-36837f37ab14.png)


## How to test or reproduce?
Visit a pipeline run details page.
Ensure the related component is a sample or default build.
Click the actions dropdown menu and select `Start new build`

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
