### PR TITLE
add clair scan results to task run side panel

### DIFF
--- a/src/components/PipelineRunDetailsView/PipelineRunSidePanel.tsx
+++ b/src/components/PipelineRunDetailsView/PipelineRunSidePanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
   SELECTION_STATE,
   useVisualizationController,
@@ -7,7 +7,7 @@ import {
 } from '@patternfly/react-topology';
 import SidePanel from '../SidePanel/SidePanel';
 import TaskRunPanel from './sidepanels/TaskRunPanel';
-import { isTaskRunNode } from './visualization/utils/pipelinerun-graph-utils';
+import { isTaskNode } from './visualization/utils/pipelinerun-graph-utils';
 
 type Props = {
   scrollIntoView?: (node: Node) => void;
@@ -17,38 +17,38 @@ const PipelineRunSidePanel: React.FC<Props> = ({ scrollIntoView }) => {
   const [[selectedId], setSelectedIds] = useVisualizationState<string[]>(SELECTION_STATE, []);
   const controller = useVisualizationController();
 
-  const taskRunNode = React.useMemo(() => {
+  const taskNode = React.useMemo(() => {
     if (selectedId) {
       const element = controller.getElementById(selectedId);
-      if (isTaskRunNode(element)) {
+      if (isTaskNode(element)) {
         return element;
       }
     }
     return null;
   }, [controller, selectedId]);
 
-  const panel = taskRunNode ? (
-    <TaskRunPanel onClose={() => setSelectedIds([])} taskRunNode={taskRunNode} />
+  const panel = taskNode ? (
+    <TaskRunPanel onClose={() => setSelectedIds([])} taskNode={taskNode} />
   ) : null;
 
   const isExpanded = !!panel;
 
   const onExpand = React.useCallback(() => {
-    if (isExpanded && taskRunNode) {
-      scrollIntoView?.(taskRunNode);
+    if (isExpanded && taskNode) {
+      scrollIntoView?.(taskNode);
     }
-  }, [isExpanded, scrollIntoView, taskRunNode]);
+  }, [isExpanded, scrollIntoView, taskNode]);
 
   React.useEffect(() => {
-    if (isExpanded && taskRunNode) {
-      scrollIntoView?.(taskRunNode);
+    if (isExpanded && taskNode) {
+      scrollIntoView?.(taskNode);
     }
     // only run when the node changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [taskRunNode]);
+  }, [taskNode]);
 
   return (
-    <SidePanel isExpanded={isExpanded} onExpand={onExpand} isInline>
+    <SidePanel isExpanded={isExpanded} onExpand={onExpand} isInline defaultSize={500}>
       {panel}
     </SidePanel>
   );

--- a/src/components/PipelineRunDetailsView/sidepanels/TaskRunDetails.tsx
+++ b/src/components/PipelineRunDetailsView/sidepanels/TaskRunDetails.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
   DescriptionList,
   DescriptionListDescription,
@@ -6,12 +6,13 @@ import {
   DescriptionListTerm,
 } from '@patternfly/react-core';
 import { Timestamp } from '../../../shared/components/timestamp/Timestamp';
-import { PipelineTask } from '../../../types/pipeline';
+import { TaskRunKind } from '../../../types';
 import { calculateDuration, runStatus } from '../../../utils/pipeline-utils';
+import ClairScanDescriptionListGroup from '../tabs/ClairScanDescriptionListGroup';
 import RunResultsList from '../tabs/RunResultsList';
 
 type Props = {
-  taskRun: PipelineTask;
+  taskRun?: TaskRunKind;
   status: runStatus;
 };
 
@@ -23,32 +24,32 @@ const TaskRunDetails: React.FC<Props> = ({ taskRun, status }) => (
           <DescriptionListGroup>
             <DescriptionListTerm>Started</DescriptionListTerm>
             <DescriptionListDescription>
-              <Timestamp timestamp={taskRun.status?.startTime} />
+              <Timestamp timestamp={taskRun?.status?.startTime} />
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>
             <DescriptionListTerm>Duration</DescriptionListTerm>
             <DescriptionListDescription>
-              {taskRun.status?.startTime
+              {taskRun?.status?.startTime
                 ? calculateDuration(taskRun.status?.startTime, taskRun.status?.completionTime)
                 : '-'}
             </DescriptionListDescription>
           </DescriptionListGroup>
         </DescriptionList>
-
-        <DescriptionList className="pf-u-mt-sm">
+        <DescriptionList className="pf-u-mt-lg">
           <DescriptionListGroup>
             <DescriptionListTerm>Description</DescriptionListTerm>
             <DescriptionListDescription>
-              {taskRun.status?.taskSpec?.description || '-'}
+              {taskRun?.status?.taskSpec?.description || '-'}
             </DescriptionListDescription>
           </DescriptionListGroup>
+          <ClairScanDescriptionListGroup taskRuns={[taskRun]} hideIfNotFound />
         </DescriptionList>
       </>
     ) : (
       'This task was skipped.'
     )}
-    {taskRun.status?.taskResults?.length ? (
+    {taskRun?.status?.taskResults?.length ? (
       <>
         <br />
         <RunResultsList status={status} results={taskRun.status.taskResults} />

--- a/src/components/PipelineRunDetailsView/sidepanels/TaskRunPanel.tsx
+++ b/src/components/PipelineRunDetailsView/sidepanels/TaskRunPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
   DrawerActions,
   DrawerCloseButton,
@@ -17,25 +17,25 @@ import './TaskRunPanel.scss';
 
 type Props = {
   onClose: () => void;
-  taskRunNode: GraphElement<ElementModel, PipelineRunNodeData>;
+  taskNode: GraphElement<ElementModel, PipelineRunNodeData>;
 };
 
-const TaskRunPanel: React.FC<Props> = ({ taskRunNode, onClose }) => {
-  const taskRun = taskRunNode.getData().task;
-  const { status } = taskRunNode.getData();
+const TaskRunPanel: React.FC<Props> = ({ taskNode, onClose }) => {
+  const task = taskNode.getData().task;
+  const taskRun = taskNode.getData().taskRun;
+  const { status } = taskNode.getData();
   return (
     <>
       <div className="task-run-panel__head">
         <DrawerHead>
           <span>
-            {taskRun.name} <StatusIconWithTextLabel status={status} />
+            {task.name} <StatusIconWithTextLabel status={status} />
           </span>
           <DrawerActions>
             <DrawerCloseButton onClick={onClose} />
           </DrawerActions>
         </DrawerHead>
       </div>
-
       <div className="task-run-panel__tabs">
         <Tabs defaultActiveKey="details" unmountOnExit className="">
           <Tab title="Details" eventKey="details">
@@ -46,9 +46,9 @@ const TaskRunPanel: React.FC<Props> = ({ taskRunNode, onClose }) => {
           <Tab title="Logs" eventKey="logs">
             <DrawerPanelBody style={{ height: '100%' }}>
               <TaskRunLogs
-                taskName={taskRun.name}
-                namespace={taskRunNode.getData().namespace}
-                podName={taskRun.status?.podName}
+                taskName={task.name}
+                namespace={taskNode.getData().namespace}
+                podName={taskRun?.status?.podName}
                 status={status}
               />
             </DrawerPanelBody>

--- a/src/components/PipelineRunDetailsView/sidepanels/__tests__/TaskRunDetails.spec.tsx
+++ b/src/components/PipelineRunDetailsView/sidepanels/__tests__/TaskRunDetails.spec.tsx
@@ -1,23 +1,29 @@
 import * as React from 'react';
-import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
-import { PipelineTask } from '../../../../types';
+import '@testing-library/jest-dom';
+import { TaskRunKind } from '../../../../types';
 import { runStatus } from '../../../../utils/pipeline-utils';
 import TaskRunDetails from '../TaskRunDetails';
 
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    Link: (props: any) => <a href={props.to}>{props.children}</a>,
+  };
+});
+
 describe('TaskRunDetails', () => {
   it('should handle skipped tasks', () => {
-    const result = render(
-      <TaskRunDetails status={runStatus.Skipped} taskRun={{} as PipelineTask} />,
-    );
-    expect(result.queryByText('This task was skipped.')).toBeInTheDocument();
+    const { container } = render(<TaskRunDetails status={runStatus.Skipped} />);
+    expect(container).toHaveTextContent('This task was skipped.');
   });
 
-  it('should display task info', () => {
+  it('should display task description', () => {
     const result = render(
       <TaskRunDetails
         status={runStatus.Running}
-        taskRun={{ status: { taskSpec: { description: 'test' } } } as PipelineTask}
+        taskRun={{ status: { taskSpec: { description: 'test' } } } as TaskRunKind}
       />,
     );
     expect(result.queryByText('Description')).toBeInTheDocument();
@@ -29,12 +35,48 @@ describe('TaskRunDetails', () => {
       <TaskRunDetails
         status={runStatus.Succeeded}
         taskRun={
-          { status: { taskResults: [{ name: 'test-name', value: 'test-value' }] } } as PipelineTask
+          {
+            status: {
+              startTime: '2023-03-15T20:12:55Z',
+              completionTime: '2023-03-15T20:13:13Z',
+              taskResults: [{ name: 'test-name', value: 'test-value' }],
+            },
+          } as TaskRunKind
         }
       />,
     );
+    expect(result.queryByText('Started')).toBeInTheDocument();
+    expect(result.queryByText('Duration')).toBeInTheDocument();
+    expect(result.queryByText('18 seconds')).toBeInTheDocument();
     expect(result.queryByText('Results')).toBeInTheDocument();
     expect(result.queryByText('test-name')).toBeInTheDocument();
     expect(result.queryByText('test-value')).toBeInTheDocument();
+    expect(result.container).not.toHaveTextContent('Vulnerabilities scan');
+  });
+
+  it('should render task run vulnerabilities scan results', () => {
+    const { container } = render(
+      <TaskRunDetails
+        status={runStatus.Succeeded}
+        taskRun={
+          {
+            metadata: {
+              labels: {
+                'tekton.dev/pipelineTask': 'clair-scan',
+              },
+            },
+            status: {
+              taskResults: [
+                {
+                  name: 'CLAIR_SCAN_RESULTS',
+                  value: '{"vulnerabilities":{"critical":0,"high":0,"medium":1,"low":0}}',
+                },
+              ],
+            },
+          } as unknown as TaskRunKind
+        }
+      />,
+    );
+    expect(container).toHaveTextContent('Vulnerabilities scan');
   });
 });

--- a/src/components/PipelineRunDetailsView/tabs/ClairScanDescriptionListGroup.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/ClairScanDescriptionListGroup.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import {
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Popover,
+} from '@patternfly/react-core';
+import { QuestionCircleIcon } from '@patternfly/react-icons/dist/js/icons/question-circle-icon';
+import { PipelineRunLabel } from '../../../consts/pipelinerun';
+import { getClairScanResults } from '../../../hooks/useClairScanResults';
+import { TaskRunKind } from '../../../types';
+import { useWorkspaceInfo } from '../../../utils/workspace-context-utils';
+import { ClairScanDetailStatus } from './ClairScanDetailStatus';
+
+type Props = {
+  taskRuns: TaskRunKind[];
+  showLogsLink?: boolean;
+  hideIfNotFound?: boolean;
+};
+
+const ClairScanDescriptionListGroup: React.FC<Props> = ({
+  taskRuns,
+  hideIfNotFound,
+  showLogsLink,
+}) => {
+  const { workspace } = useWorkspaceInfo();
+  const [scanResults, scanTaskRun] = getClairScanResults(taskRuns);
+
+  if (!scanTaskRun && hideIfNotFound) {
+    return null;
+  }
+
+  return (
+    <DescriptionListGroup>
+      <DescriptionListTerm>
+        Vulnerabilities scan{' '}
+        <Popover
+          aria-label="Vulnerability scan"
+          headerContent="Vulnerability scan"
+          bodyContent="Clair-scan is a task in a pipeline run that scans your components for potential vulnerabilities."
+        >
+          <QuestionCircleIcon />
+        </Popover>{' '}
+        {scanTaskRun && showLogsLink ? (
+          <Link
+            to={`/stonesoup/workspaces/${workspace}/applications/${
+              scanTaskRun.metadata.labels[PipelineRunLabel.APPLICATION]
+            }/taskruns/${scanTaskRun.metadata.name}/logs`}
+            className="pf-u-font-weight-normal"
+          >
+            See logs
+          </Link>
+        ) : null}
+      </DescriptionListTerm>
+      <DescriptionListDescription>
+        {scanResults?.vulnerabilities ? <ClairScanDetailStatus scanResults={scanResults} /> : '-'}
+      </DescriptionListDescription>
+    </DescriptionListGroup>
+  );
+};
+
+export default ClairScanDescriptionListGroup;

--- a/src/components/PipelineRunDetailsView/tabs/ClairScanDetailStatus.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/ClairScanDetailStatus.tsx
@@ -1,8 +1,5 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-import { Spinner } from '@patternfly/react-core';
-import { useClairScanResults } from '../../../hooks/useClairScanResults';
-import { useWorkspaceInfo } from '../../../utils/workspace-context-utils';
+import * as React from 'react';
+import { ClairScanResult } from '../../../hooks/useClairScanResults';
 import {
   CriticalIcon,
   HighIcon,
@@ -10,49 +7,29 @@ import {
   MediumIcon,
 } from '../../PipelineRunListView/ClairScanStatus';
 
-export const ClairScanDetailStatus: React.FC<{ pipelineRunName: string }> = ({
-  pipelineRunName,
-}) => {
-  const [scanResults, loaded] = useClairScanResults(pipelineRunName);
-  const { workspace, namespace } = useWorkspaceInfo();
-
-  if (!loaded) {
-    return <Spinner isSVG size="lg" aria-label="Loading Vulnerability Scan details" />;
-  }
-
-  if (!scanResults?.vulnerabilities) {
-    return <>-</>;
-  }
-
-  return (
-    <>
-      <CriticalIcon />
-      Critical{' '}
-      <span className="pf-u-font-weight-bold pf-u-ml-sm pf-u-mr-md">
-        {scanResults.vulnerabilities.critical}
-      </span>
-      <HighIcon />
-      High{' '}
-      <span className="pf-u-font-weight-bold pf-u-ml-sm pf-u-mr-md">
-        {scanResults.vulnerabilities.high}
-      </span>
-      <MediumIcon />
-      Medium{' '}
-      <span className="pf-u-font-weight-bold pf-u-ml-sm pf-u-mr-md">
-        {scanResults.vulnerabilities.medium}
-      </span>
-      <LowIcon />
-      Low{' '}
-      <span className="pf-u-font-weight-bold pf-u-ml-sm pf-u-mr-md">
-        {scanResults.vulnerabilities.low}
-      </span>
-      <div>
-        <Link
-          to={`/stonesoup/workspaces/${workspace}/applications/${namespace}/pipelineruns/${pipelineRunName}/logs`}
-        >
-          View logs
-        </Link>
-      </div>
-    </>
-  );
-};
+export const ClairScanDetailStatus: React.FC<{ scanResults: ClairScanResult }> = ({
+  scanResults,
+}) => (
+  <>
+    <CriticalIcon />
+    Critical{' '}
+    <span className="pf-u-font-weight-bold pf-u-ml-sm pf-u-mr-md">
+      {scanResults.vulnerabilities.critical}
+    </span>
+    <HighIcon />
+    High{' '}
+    <span className="pf-u-font-weight-bold pf-u-ml-sm pf-u-mr-md">
+      {scanResults.vulnerabilities.high}
+    </span>
+    <MediumIcon />
+    Medium{' '}
+    <span className="pf-u-font-weight-bold pf-u-ml-sm pf-u-mr-md">
+      {scanResults.vulnerabilities.medium}
+    </span>
+    <LowIcon />
+    Low{' '}
+    <span className="pf-u-font-weight-bold pf-u-ml-sm pf-u-mr-md">
+      {scanResults.vulnerabilities.low}
+    </span>
+  </>
+);

--- a/src/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
@@ -13,9 +13,7 @@ import {
   Title,
   Divider,
   ClipboardCopy,
-  Popover,
 } from '@patternfly/react-core';
-import { QuestionCircleIcon } from '@patternfly/react-icons/dist/js/icons/question-circle-icon';
 import { PipelineRunLabel } from '../../../consts/pipelinerun';
 import ExternalLink from '../../../shared/components/links/ExternalLink';
 import { ErrorDetailsWithStaticLog } from '../../../shared/components/pipeline-run-logs/logs/log-snippet-types';
@@ -30,7 +28,7 @@ import MetadataList from '../MetadataList';
 import PipelineRunVisualization from '../PipelineRunVisualization';
 import RelatedPipelineRuns from '../RelatedPipelineRuns';
 import { getSourceUrl } from '../utils/pipelinerun-utils';
-import { ClairScanDetailStatus } from './ClairScanDetailStatus';
+import ClairScanDescriptionListGroup from './ClairScanDescriptionListGroup';
 import RunResultsList from './RunResultsList';
 
 type PipelineRunDetailsTabProps = {
@@ -194,21 +192,7 @@ const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({
                     )}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
-                <DescriptionListGroup>
-                  <DescriptionListTerm>
-                    Vulnerabilities scan{' '}
-                    <Popover
-                      aria-label="Vulnerability scan"
-                      headerContent="Vulnerability scan"
-                      bodyContent="Clair-scan is a task in a pipeline run that scans your components for potential vulnerabilities."
-                    >
-                      <QuestionCircleIcon />
-                    </Popover>
-                  </DescriptionListTerm>
-                  <DescriptionListDescription>
-                    <ClairScanDetailStatus pipelineRunName={pipelineRun.metadata?.name} />
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
+                <ClairScanDescriptionListGroup taskRuns={taskRuns} showLogsLink />
                 <DescriptionListGroup>
                   <DescriptionListTerm>Component</DescriptionListTerm>
                   <DescriptionListDescription>

--- a/src/components/PipelineRunDetailsView/tabs/__tests__/ClairScanDescriptionListGroup.spec.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/__tests__/ClairScanDescriptionListGroup.spec.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TaskRunKind } from '../../../../types';
+import ClairScanDescriptionListGroup from '../ClairScanDescriptionListGroup';
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    Link: (props: any) => <a href={props.to}>{props.children}</a>,
+  };
+});
+
+jest.mock('../../../../utils/workspace-context-utils', () => ({
+  useWorkspaceInfo: jest.fn(() => ({ namespace: 'test-ns', workspace: 'test-ws' })),
+}));
+
+const mockTaskRun = {
+  metadata: {
+    name: 'test-tr',
+    labels: {
+      'tekton.dev/pipelineTask': 'clair-scan',
+      'appstudio.openshift.io/application': 'test-app',
+    },
+  },
+  status: {
+    taskResults: [
+      {
+        name: 'CLAIR_SCAN_RESULT',
+        value: '{"vulnerabilities":{"critical":1,"high":2,"medium":3,"low":4}}',
+      },
+    ],
+  },
+} as unknown as TaskRunKind;
+
+describe('ClairScanDescriptionListGroup', () => {
+  it('should show empty state if results are not available', () => {
+    const { container } = render(<ClairScanDescriptionListGroup taskRuns={[]} />);
+    expect(container).toHaveTextContent('Vulnerabilities scan');
+    expect(container).toHaveTextContent('-');
+  });
+
+  it('should show nothing if results are not available and hideIfNotFound=true', () => {
+    const { container } = render(<ClairScanDescriptionListGroup taskRuns={[]} hideIfNotFound />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('should show vulnerability scans', () => {
+    const { container } = render(
+      <ClairScanDescriptionListGroup taskRuns={[mockTaskRun]} hideIfNotFound />,
+    );
+    expect(container).toHaveTextContent('Vulnerabilities scan');
+    expect(container).toHaveTextContent('Critical 1');
+    expect(container).toHaveTextContent('High 2');
+    expect(container).toHaveTextContent('Medium 3');
+    expect(container).toHaveTextContent('Low 4');
+  });
+
+  it('should render logs link', () => {
+    const result = render(<ClairScanDescriptionListGroup taskRuns={[mockTaskRun]} showLogsLink />);
+
+    const logsLink = result.queryByRole('link', { name: 'See logs' });
+    expect(logsLink).toBeInTheDocument();
+
+    expect(logsLink).toHaveAttribute(
+      'href',
+      '/stonesoup/workspaces/test-ws/applications/test-app/taskruns/test-tr/logs',
+    );
+  });
+});

--- a/src/components/PipelineRunDetailsView/tabs/__tests__/ClairScanDetailStatus.spec.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/__tests__/ClairScanDetailStatus.spec.tsx
@@ -1,53 +1,18 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
+import * as React from 'react';
+import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { useClairScanResults } from '../../../../hooks/useClairScanResults';
 import { ClairScanDetailStatus } from '../ClairScanDetailStatus';
 
-jest.mock('react-router-dom', () => {
-  const actual = jest.requireActual('react-router-dom');
-  return {
-    ...actual,
-    Link: (props: any) => <a href={props.to}>{props.children}</a>,
-  };
-});
-
-jest.mock('../../../../hooks/useClairScanResults', () => ({
-  useClairScanResults: jest.fn(),
-}));
-
-jest.mock('../../../../utils/workspace-context-utils', () => ({
-  useWorkspaceInfo: jest.fn(() => ({ namespace: 'test-ns', workspace: 'test-ws' })),
-}));
-
-const mockScanResults = useClairScanResults as jest.Mock;
-
 describe('ClairScanDetailStatus', () => {
-  it('shows loading indicator if results are not fetchec', () => {
-    mockScanResults.mockReturnValue([null, false]);
-    render(<ClairScanDetailStatus pipelineRunName="test" />);
-    expect(screen.getByRole('progressbar')).toBeVisible();
-  });
-
-  it('shows empty state if results are not available', () => {
-    mockScanResults.mockReturnValue([null, true]);
-    const { container } = render(<ClairScanDetailStatus pipelineRunName="test" />);
-    expect(container).toHaveTextContent('-');
-  });
-
-  it('shows scan results after values are fetched', () => {
-    mockScanResults.mockReturnValue([
-      { vulnerabilities: { critical: 1, high: 2, medium: 3, low: 4 } },
-      true,
-    ]);
-    const { container } = render(<ClairScanDetailStatus pipelineRunName="test" />);
+  it('should show scan results', () => {
+    const { container } = render(
+      <ClairScanDetailStatus
+        scanResults={{ vulnerabilities: { critical: 1, high: 2, medium: 3, low: 4 } }}
+      />,
+    );
     expect(container).toHaveTextContent('Critical 1');
     expect(container).toHaveTextContent('High 2');
     expect(container).toHaveTextContent('Medium 3');
     expect(container).toHaveTextContent('Low 4');
-    expect(screen.getByText('View logs')).toHaveAttribute(
-      'href',
-      '/stonesoup/workspaces/test-ws/applications/test-ns/pipelineruns/test/logs',
-    );
   });
 });

--- a/src/components/PipelineRunDetailsView/visualization/types.ts
+++ b/src/components/PipelineRunDetailsView/visualization/types.ts
@@ -1,5 +1,5 @@
 import { PipelineNodeModel as PfPipelineNodeModel, WhenStatus } from '@patternfly/react-topology';
-import { PipelineTask, TaskRunStatus } from '../../../types';
+import { PipelineTask, TaskRunStatus, TaskRunKind } from '../../../types';
 import { runStatus } from '../../../utils/pipeline-utils';
 
 export enum PipelineRunNodeType {
@@ -24,6 +24,7 @@ export type PipelineRunNodeData = {
   testWarnCount?: number;
   whenStatus?: WhenStatus;
   steps?: StepStatus[];
+  taskRun?: TaskRunKind;
 };
 
 export type PipelineTaskStatus = TaskRunStatus & {

--- a/src/components/PipelineRunDetailsView/visualization/utils/__tests__/pipelinerun-graph-utils.spec.ts
+++ b/src/components/PipelineRunDetailsView/visualization/utils/__tests__/pipelinerun-graph-utils.spec.ts
@@ -11,7 +11,7 @@ import {
   extractDepsFromContextVariables,
   getPipelineFromPipelineRun,
   getPipelineRunDataModel,
-  isTaskRunNode,
+  isTaskNode,
   nodesHasWhenExpression,
   scrollNodeIntoView,
   taskHasWhenExpression,
@@ -288,19 +288,19 @@ describe('pipelinerun-graph-utils: ', () => {
     });
   });
 
-  describe('isTaskRunNode', () => {
+  describe('isTaskNode', () => {
     it('should identify task run nodes', () => {
       const createNode = (type: PipelineRunNodeType) =>
         ({
           getType: () => type,
         } as GraphElement);
 
-      expect(isTaskRunNode(createNode(PipelineRunNodeType.TASK_NODE))).toBe(true);
-      expect(isTaskRunNode(createNode(PipelineRunNodeType.FINALLY_NODE))).toBe(true);
-      expect(isTaskRunNode(createNode(PipelineRunNodeType.FINALLY_GROUP))).toBe(false);
-      expect(isTaskRunNode(createNode(PipelineRunNodeType.EDGE))).toBe(false);
-      expect(isTaskRunNode(createNode(PipelineRunNodeType.SPACER_NODE))).toBe(false);
-      expect(isTaskRunNode(createNode(PipelineRunNodeType.EDGE))).toBe(false);
+      expect(isTaskNode(createNode(PipelineRunNodeType.TASK_NODE))).toBe(true);
+      expect(isTaskNode(createNode(PipelineRunNodeType.FINALLY_NODE))).toBe(true);
+      expect(isTaskNode(createNode(PipelineRunNodeType.FINALLY_GROUP))).toBe(false);
+      expect(isTaskNode(createNode(PipelineRunNodeType.EDGE))).toBe(false);
+      expect(isTaskNode(createNode(PipelineRunNodeType.SPACER_NODE))).toBe(false);
+      expect(isTaskNode(createNode(PipelineRunNodeType.EDGE))).toBe(false);
     });
   });
 

--- a/src/components/PipelineRunDetailsView/visualization/utils/pipelinerun-graph-utils.ts
+++ b/src/components/PipelineRunDetailsView/visualization/utils/pipelinerun-graph-utils.ts
@@ -358,6 +358,9 @@ const getGraphDataModel = (
         whenStatus: taskWhenStatus(vertex.data),
         task: vertex.data,
         steps: vertex.data.steps,
+        taskRun: taskRuns.find(
+          (tr) => tr.metadata.labels[TektonResourceLabel.pipelineTask] === vertex.data.name,
+        ),
       },
     };
     nodes.push(node);
@@ -379,6 +382,9 @@ const getGraphDataModel = (
       status: fTask.status.reason,
       whenStatus: taskWhenStatus(fTask),
       task: fTask,
+      taskRun: taskRuns.find(
+        (tr) => tr.metadata.labels[TektonResourceLabel.pipelineTask] === fTask.name,
+      ),
     },
   }));
   const finallyGroup = finallyNodes.length
@@ -432,7 +438,7 @@ export const getPipelineRunDataModel = (pipelineRun: PipelineRunKind, taskRuns: 
   return getGraphDataModel(getPipelineFromPipelineRun(pipelineRun), pipelineRun, taskRuns);
 };
 
-export const isTaskRunNode = (e?: GraphElement): e is Node<ElementModel, PipelineRunNodeData> =>
+export const isTaskNode = (e?: GraphElement): e is Node<ElementModel, PipelineRunNodeData> =>
   e?.getType() === PipelineRunNodeType.TASK_NODE ||
   e?.getType() === PipelineRunNodeType.FINALLY_NODE;
 

--- a/src/components/SidePanel/SidePanel.tsx
+++ b/src/components/SidePanel/SidePanel.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import SidePanelContext, { SidePanelProps } from './SidePanelContext';
 
-const SidePanel: React.FC<SidePanelProps> = ({ isExpanded, isInline, onExpand, children }) => {
+const SidePanel: React.FC<SidePanelProps> = ({
+  isExpanded,
+  isInline,
+  onExpand,
+  defaultSize,
+  children,
+}) => {
   const { close, setProps } = React.useContext(SidePanelContext);
 
   React.useEffect(
@@ -11,8 +17,8 @@ const SidePanel: React.FC<SidePanelProps> = ({ isExpanded, isInline, onExpand, c
   );
 
   React.useEffect(() => {
-    setProps({ isExpanded, isInline, onExpand, children });
-  }, [setProps, isExpanded, isInline, onExpand, children]);
+    setProps({ isExpanded, isInline, onExpand, defaultSize, children });
+  }, [setProps, isExpanded, isInline, onExpand, defaultSize, children]);
 
   return null;
 };

--- a/src/components/SidePanel/SidePanelContext.ts
+++ b/src/components/SidePanel/SidePanelContext.ts
@@ -5,6 +5,7 @@ export type SidePanelProps = {
   children?: React.ReactNode;
   isInline?: boolean;
   onExpand?: () => void;
+  defaultSize?: string | number;
 };
 
 export type SidePanelContextValue = {

--- a/src/components/SidePanel/SidePanelHost.tsx
+++ b/src/components/SidePanel/SidePanelHost.tsx
@@ -11,7 +11,16 @@ const SidePanelHost: React.FC = ({ children }) => {
     setProps({ ...propsRef.current, isExpanded: false });
   }, []);
 
-  const panelContent = <DrawerPanelContent isResizable>{props.children}</DrawerPanelContent>;
+  const panelContent = (
+    <DrawerPanelContent
+      isResizable
+      defaultSize={
+        typeof props.defaultSize === 'number' ? `${props.defaultSize}px` : props.defaultSize
+      }
+    >
+      {props.children}
+    </DrawerPanelContent>
+  );
 
   return (
     <SidePanelContext.Provider value={{ setProps, close }}>

--- a/src/components/SidePanel/__tests__/SidePanel.spec.tsx
+++ b/src/components/SidePanel/__tests__/SidePanel.spec.tsx
@@ -21,7 +21,7 @@ describe('SidePanel', () => {
     const setPropsFn = jest.fn();
     const onExpandFn = jest.fn();
     render(
-      <SidePanel isExpanded isInline onExpand={onExpandFn}>
+      <SidePanel isExpanded isInline onExpand={onExpandFn} defaultSize={500}>
         test
       </SidePanel>,
       {
@@ -37,6 +37,7 @@ describe('SidePanel', () => {
       isInline: true,
       children: 'test',
       onExpand: onExpandFn,
+      defaultSize: 500,
     });
   });
 

--- a/src/hooks/__tests__/useClairScanResults.spec.ts
+++ b/src/hooks/__tests__/useClairScanResults.spec.ts
@@ -29,7 +29,9 @@ describe('useClairScanResults', () => {
     useK8sWatchResourceMock.mockReturnValue([
       [
         {
-          metadata: { labels: { 'tekton.dev/pipelineRun': 'test' } },
+          metadata: {
+            labels: { 'tekton.dev/pipelineRun': 'test', 'tekton.dev/pipelineTask': 'clair-scan' },
+          },
           spec: { taskRef: { name: 'clair-scan' } },
           status: {
             taskResults: [


### PR DESCRIPTION
## Fixes 
Add on to: https://issues.redhat.com/browse/HAC-3303

## Description
Added clair-scan results visual to the side panel.
Adjusted the default width of the side panel to 500px such that the full scan results show on a single line.

Updated `see logs` link to point to the task run logs page which requires this PR: https://github.com/openshift/hac-dev/pull/492
![image](https://user-images.githubusercontent.com/14068621/225682488-0f8b9a05-2357-4280-8a4b-f8e65493bc0a.png)

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
![image](https://user-images.githubusercontent.com/14068621/225682577-72f6bcf2-027d-4978-bfa1-751cad449588.png)


## How to test or reproduce?
Create a new Component with a customized build.
Wait for build to complete.
Go to pipeline run details page of said build.
Click on the `clair-scan` node.

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

cc @rottencandy @MariaLeonova 