### PR TITLE
Fix route URL not showing up if first component doesn't have route

### DIFF
--- a/src/components/ApplicationDetails/ApplicationHeader.tsx
+++ b/src/components/ApplicationDetails/ApplicationHeader.tsx
@@ -7,7 +7,7 @@ import { useSortedComponents } from '../../hooks/useComponents';
 import ExternalLink from '../../shared/components/links/ExternalLink';
 import { ApplicationKind } from '../../types';
 import { runStatus } from '../../utils/pipeline-utils';
-import { getComponentRouteWebURL } from '../../utils/route-utils';
+import { getFirstComponentRouteWebURL } from '../../utils/route-utils';
 import { StatusIconWithTextLabel } from '../topology/StatusIcon';
 import { ApplicationThumbnail } from './ApplicationThumbnail';
 
@@ -17,10 +17,11 @@ export const ApplicationHeader: React.FC<{ application: ApplicationKind }> = ({ 
   const [components, componentsLoaded] = useSortedComponents(application.metadata.name);
 
   const [routes, loaded] = useApplicationRoutes(application.metadata.name);
+
   const selectedComponentRoute = React.useMemo(
     () =>
       loaded && routes.length > 0 && componentsLoaded && components.length > 0
-        ? getComponentRouteWebURL(routes, components[0].metadata.name)
+        ? getFirstComponentRouteWebURL(routes, components)
         : null,
     [components, componentsLoaded, loaded, routes],
   );

--- a/src/utils/__tests__/route-utils.spec.ts
+++ b/src/utils/__tests__/route-utils.spec.ts
@@ -1,5 +1,6 @@
 import { mockRoutes } from '../../hooks/__data__/mock-data';
-import { getComponentRouteWebURL } from './../route-utils';
+import { componentCRMocks } from './../../components/ApplicationDetails/__data__/mock-data';
+import { getComponentRouteWebURL, getFirstComponentRouteWebURL } from './../route-utils';
 
 describe('Route Utils', () => {
   it('Should return route url for given component', async () => {
@@ -12,5 +13,14 @@ describe('Route Utils', () => {
     const result = getComponentRouteWebURL(mockRoutes, 'nodejs-1');
 
     expect(result).toBeUndefined();
+  });
+
+  it('should find the first component that has route and return routeWebURL for it', () => {
+    const result = getFirstComponentRouteWebURL(mockRoutes, [
+      componentCRMocks[1],
+      componentCRMocks[0],
+    ]);
+
+    expect(result).toEqual('https://nodejs-test.apps.appstudio-stage.x99m.p1.openshiftapps.com');
   });
 });

--- a/src/utils/route-utils.ts
+++ b/src/utils/route-utils.ts
@@ -1,6 +1,7 @@
 import lodashEach from 'lodash/each';
 import lodashFind from 'lodash/find';
 import lodashGet from 'lodash/get';
+import { ComponentKind } from './../types/component';
 import { RouteKind, RouteIngress } from './../types/routes';
 
 const getRouteHost = (route: RouteKind, onlyAdmitted: boolean): string => {
@@ -39,4 +40,18 @@ export const getComponentRouteWebURL = (routes: RouteKind[], component: string):
   );
 
   return componentRoute && getRouteWebURL(componentRoute);
+};
+
+export const getFirstComponentRouteWebURL = (
+  routes: RouteKind[],
+  components: ComponentKind[],
+): string => {
+  let routeWebURL;
+
+  components.some((component) => {
+    routeWebURL = getComponentRouteWebURL(routes, component.metadata.name);
+    return routeWebURL;
+  });
+
+  return routeWebURL;
 };


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
- https://issues.redhat.com/browse/HAC-3420

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- The application header was only considering first component to show the route.
- Updated that logic to find first component that has a route.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

https://user-images.githubusercontent.com/6041994/225864866-dd6ff8d6-efaa-41fc-9639-bf2062b15406.mov





## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
