### PR TITLE
handle cdq errors in import wizard

### DIFF
--- a/src/components/ImportForm/ReviewSection/ReviewSection.tsx
+++ b/src/components/ImportForm/ReviewSection/ReviewSection.tsx
@@ -57,7 +57,7 @@ const ReviewSection: React.FunctionComponent = () => {
   const cachedComponentsLoaded = React.useRef(false);
   const isContainerImage = containerImageRegex.test(sourceUrl);
 
-  const [detectedComponents, detectionLoaded] = useComponentDetection(
+  const [detectedComponents, detectionLoaded, detectionError] = useComponentDetection(
     !isContainerImage ? sourceUrl : null,
     application,
     secret,
@@ -89,7 +89,7 @@ const ReviewSection: React.FunctionComponent = () => {
       cachedComponentsLoaded.current = true;
     }
 
-    if (!isContainerImage && detectionLoaded) {
+    if (!isContainerImage && (detectionLoaded || detectionError)) {
       if (detectedComponents) {
         components = detectedComponents;
       }
@@ -103,7 +103,7 @@ const ReviewSection: React.FunctionComponent = () => {
       cachedComponents.current = transformedComponents;
     }
 
-    if (detectionLoaded && !components) {
+    if ((detectionLoaded || detectionError) && !components) {
       const transformedComponents = transformComponentValues({
         myComponent: {
           componentStub: {
@@ -119,7 +119,7 @@ const ReviewSection: React.FunctionComponent = () => {
       setFieldValue('detectionFailed', true);
     }
 
-    setFieldValue('initialDetectionLoaded', detectionLoaded);
+    setFieldValue('initialDetectionLoaded', detectionLoaded || detectionError);
     return () => {
       unmounted = true;
     };
@@ -127,6 +127,7 @@ const ReviewSection: React.FunctionComponent = () => {
     application,
     detectedComponents,
     detectionLoaded,
+    detectionError,
     isContainerImage,
     setFieldValue,
     sourceUrl,

--- a/src/components/ImportForm/ReviewSection/RuntimeSelector.tsx
+++ b/src/components/ImportForm/ReviewSection/RuntimeSelector.tsx
@@ -97,7 +97,7 @@ export const RuntimeSelector: React.FC<RuntimeSelectorProps> = ({ detectedCompon
 
   const isDetectingRuntime =
     !initialDetectionLoaded ||
-    (runtimeSource && !detectionLoaded) ||
+    (runtimeSource && !detectionLoaded && !detectionError) ||
     selectedRuntime?.name === DetectingRuntime;
 
   const detectingRuntimeToggle = React.useCallback(

--- a/src/components/ImportForm/ReviewSection/__tests__/ReviewSection.spec.tsx
+++ b/src/components/ImportForm/ReviewSection/__tests__/ReviewSection.spec.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { screen } from '@testing-library/react';
+import { formikRenderer } from '../../../../utils/test-utils';
+import { useComponentDetection } from '../../utils/cdq-utils';
+import ReviewSection from '../ReviewSection';
+
+const setFieldValueMock = jest.fn();
+
+jest.mock('../../utils/cdq-utils', () => ({ useComponentDetection: jest.fn() }));
+
+jest.mock('formik', () => ({
+  ...(jest as any).requireActual('formik'),
+  useFormikContext: jest.fn(() => ({
+    ...(jest as any).requireActual('formik').useFormikContext(),
+    setFieldValue: setFieldValueMock,
+  })),
+}));
+
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  useChrome: () => ({
+    helpTopics: { setActiveTopic: jest.fn(), enableTopics: jest.fn(), disableTopics: jest.fn() },
+  }),
+}));
+
+const useComponentDetectionMock = useComponentDetection as jest.Mock;
+
+describe('ReviewSection', () => {
+  it('should handle waiting on cdq', async () => {
+    useComponentDetectionMock.mockReturnValue([[], false]);
+    const result = formikRenderer(<ReviewSection />, { source: { git: {} } });
+    // force a re-render because formik is mocked
+    result.rerender(<ReviewSection />);
+    expect(screen.getByText('Detecting')).toBeInTheDocument();
+  });
+
+  it('should handle cdq loaded but no results', async () => {
+    useComponentDetectionMock.mockReturnValue([[], true]);
+    const result = formikRenderer(<ReviewSection />, { source: { git: {} } });
+    // force a re-render because formik is mocked
+    result.rerender(<ReviewSection />);
+    expect(screen.getByText('Configure your components for deployment')).toBeInTheDocument();
+  });
+
+  it('should handle cdq errors', async () => {
+    useComponentDetectionMock.mockReturnValue([[], false, 'error']);
+    const result = formikRenderer(<ReviewSection />, { source: { git: {} } });
+    // force a re-render because formik is mocked
+    result.rerender(<ReviewSection />);
+    expect(screen.getByText('Configure your components for deployment')).toBeInTheDocument();
+  });
+});

--- a/src/components/ImportForm/ReviewSection/__tests__/RuntimeSelector.spec.tsx
+++ b/src/components/ImportForm/ReviewSection/__tests__/RuntimeSelector.spec.tsx
@@ -77,6 +77,27 @@ describe('RuntimeSelector', () => {
     await act(() => expect(screen.getByText('Dockerfile')).toBeVisible());
   });
 
+  it('should show Select a runtime when an error occurs', async () => {
+    useDevfileSamplesMock.mockReturnValue([
+      [{ name: 'Basic Nodejs', attributes: { projectType: 'nodejs' }, icon: {} }],
+      true,
+    ]);
+    useComponentDetectionMock.mockReturnValue([[], false, 'error']);
+    formikRenderer(<RuntimeSelector detectedComponentIndex={0} />, {
+      isDetected: true,
+      initialDetectionLoaded: true,
+      detectionFailed: true,
+      components: [
+        {
+          projectType: 'quarkus',
+        },
+      ],
+      source: { git: {} },
+    });
+
+    await act(() => expect(screen.getByText('Select a runtime')).toBeVisible());
+  });
+
   it('should show correct message if runtime is automatically detected', () => {
     useDevfileSamplesMock.mockReturnValue([
       [{ name: 'Basic Nodejs', attributes: { projectType: 'nodejs' }, icon: {} }],


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/HAC-3120

## Description
Handle errors returned by CDQ in the event of service or network errors.
Ensures that the wizard can advance to the review section if cdq errors out.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
no visible change other than user is advanced to next page in the event of an error.

## How to test or reproduce?
Will need to reproduce network errors during import to cause CDQ to fail.

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
