### PR TITLE
Show Integration details page based on integration test name

### DIFF
--- a/src/components/IntegrationTest/__tests__/IntegrationTestDetailsView.spec.tsx
+++ b/src/components/IntegrationTest/__tests__/IntegrationTestDetailsView.spec.tsx
@@ -37,7 +37,7 @@ const mockIntegrationTests: IntegrationTestScenarioKind[] = [...MockIntegrationT
 const getMockedResources = (params: WatchK8sResource) => {
   if (params.groupVersionKind === IntegrationTestScenarioGroupVersionKind) {
     return [
-      mockIntegrationTests.filter((t) => !params.name || t.metadata.name === params.name),
+      mockIntegrationTests.find((t) => !params.name || t.metadata.name === params.name),
       true,
     ];
   }

--- a/src/hooks/useIntegrationTestScenarios.ts
+++ b/src/hooks/useIntegrationTestScenarios.ts
@@ -8,26 +8,24 @@ export const useIntegrationTestScenario = (
   applicationName: string,
   testName: string,
 ): [IntegrationTestScenarioKind, boolean, unknown] => {
-  const [tests, testsLoaded, error] = useK8sWatchResource<IntegrationTestScenarioKind[]>({
+  const [test, testsLoaded, error] = useK8sWatchResource<IntegrationTestScenarioKind>({
     groupVersionKind: IntegrationTestScenarioGroupVersionKind,
     name: testName,
     namespace,
-    isList: true,
   });
 
   return React.useMemo(() => {
     if (testsLoaded && !error) {
-      const test = tests.find(
-        (t) => t.spec.application === applicationName && !t.metadata.deletionTimestamp,
-      );
-      if (!test) {
+      const integrationTest =
+        test.spec.application === applicationName && !test.metadata.deletionTimestamp ? test : null;
+      if (!integrationTest) {
         return [null, testsLoaded, { code: 404 }];
       }
-      return [test, testsLoaded, error];
+      return [integrationTest, testsLoaded, error];
     }
 
     return [null, testsLoaded, error];
-  }, [testsLoaded, tests, error, applicationName]);
+  }, [testsLoaded, test, error, applicationName]);
 };
 
 export const useIntegrationTestScenarios = (


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-3538

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When there are multiple integration test scenarios, clicking on the second test takes the user to the correct route but shows the data from first integration test in the application.


## Type of change
<!-- Please delete options that are not relevant. -->


- [x] Bugfix

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
Before:

https://user-images.githubusercontent.com/9964343/226851889-10cdabc9-5a76-4789-b078-aa0e342caf3c.mp4



After:

https://user-images.githubusercontent.com/9964343/226850485-228eab75-961e-44f7-807e-c5827e3f712f.mp4




## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

1. Add multiple integration tests
2. Clicking on an integration test should load the details page with that integration test data.

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
