### PR TITLE
Tasks order should be consistent when user selects a task in plr logs

### DIFF
--- a/src/hooks/__tests__/useTaskRuns.spec.ts
+++ b/src/hooks/__tests__/useTaskRuns.spec.ts
@@ -1,0 +1,52 @@
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { renderHook } from '@testing-library/react-hooks';
+import { testTaskRuns } from '../../components/TaskRunListView/__data__/mock-TaskRun-data';
+import { useTaskRuns } from '../useTaskRuns';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  useK8sWatchResource: jest.fn(() => [[], true]),
+}));
+
+const useK8sWatchResourceMock = useK8sWatchResource as jest.Mock;
+
+describe('useTaskRuns', () => {
+  it('returns undefined if results are not fetched', () => {
+    useK8sWatchResourceMock.mockReturnValue([null, false, undefined]);
+    const { result } = renderHook(() => useTaskRuns('test-ns'));
+
+    expect(result.current).toEqual([undefined, false, undefined]);
+  });
+
+  it('should return sorted taskruns', () => {
+    useK8sWatchResourceMock.mockReturnValue([testTaskRuns, true, undefined]);
+    const { result } = renderHook(() => useTaskRuns('test-ns', 'test-pipelinerun', 'test-task'));
+
+    const [taskRuns, loaded] = result.current;
+    expect(loaded).toBe(true);
+    expect(taskRuns.map((tr) => tr.metadata?.name)).toEqual(['example-234', 'example']);
+  });
+
+  it('should sort the taskruns based on the completionTime', () => {
+    const taskRuns = [
+      testTaskRuns[0],
+      {
+        ...testTaskRuns[1],
+        metadata: {
+          ...testTaskRuns[1].metadata,
+          name: 'example-task-running',
+        },
+        status: {
+          ...testTaskRuns[1].status,
+          completionTime: undefined,
+        },
+      },
+    ];
+
+    useK8sWatchResourceMock.mockReturnValue([taskRuns, true, undefined]);
+    const { result } = renderHook(() => useTaskRuns('test-ns', 'test-pipelinerun', 'test-task'));
+
+    const [tRuns, loaded] = result.current;
+    expect(loaded).toBe(true);
+    expect(tRuns.map((tr) => tr.metadata?.name)).toEqual(['example-234', 'example-task-running']);
+  });
+});

--- a/src/hooks/useTaskRuns.ts
+++ b/src/hooks/useTaskRuns.ts
@@ -5,8 +5,8 @@ export const useTaskRuns = (
   namespace: string,
   pipelineRunName?: string,
   taskName?: string,
-): [TaskRunKind[], boolean, unknown] =>
-  useK8sWatchResource<TaskRunKind[]>({
+): [TaskRunKind[], boolean, unknown] => {
+  const [taskRuns, loaded, error] = useK8sWatchResource<TaskRunKind[]>({
     groupVersionKind: TaskRunGroupVersionKind,
     namespace,
     selector: {
@@ -17,3 +17,18 @@ export const useTaskRuns = (
     },
     isList: true,
   });
+
+  const sortedTaskRuns = taskRuns?.sort((a, b) => {
+    if (a?.status?.completionTime) {
+      return b?.status?.completionTime &&
+        new Date(a?.status?.completionTime) > new Date(b?.status?.completionTime)
+        ? 1
+        : -1;
+    }
+    return b?.status?.completionTime ||
+      new Date(a?.status?.startTime) > new Date(b?.status?.startTime)
+      ? 1
+      : -1;
+  });
+  return [sortedTaskRuns, loaded, error];
+};

--- a/src/shared/components/pipeline-run-logs/__tests__/PipelineRunLogs.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/__tests__/PipelineRunLogs.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
-import { screen, render, within } from '@testing-library/react';
+import { screen, render, within, fireEvent, act } from '@testing-library/react';
 import { DataState, testPipelineRuns } from '../../../../__data__/pipelinerun-data';
 import { TektonResourceLabel } from '../../../../types';
 import { HttpError } from '../../../utils/error/http-error';
@@ -98,6 +98,39 @@ describe('PipelineRunLogs', () => {
     render(<PipelineRunLogs obj={pipelineRun} taskRuns={testTaskRuns} />);
 
     screen.getByTestId('logs-error-message');
-    screen.getByText('Logs are no longer accessible for do-something task');
+    screen.getByText('Logs are no longer accessible for finally-do-something task');
+  });
+
+  it('should render the task names in the same order when a task is clicked', () => {
+    render(<PipelineRunLogs obj={pipelineRun} taskRuns={testTaskRuns} />);
+
+    const expectTasktoBeOrdered = () => {
+      const logsContainer = within(screen.getByTestId('logs-tasklist'));
+
+      const first = logsContainer.getByText('first');
+      const second = logsContainer.getByText('second');
+      const generateSuffix = logsContainer.getByText('generate-suffix');
+      const doSomething = logsContainer.getByText('do-something');
+
+      expect(first.compareDocumentPosition(second)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+      expect(second.compareDocumentPosition(generateSuffix)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+      expect(generateSuffix.compareDocumentPosition(doSomething)).toBe(
+        Node.DOCUMENT_POSITION_FOLLOWING,
+      );
+    };
+
+    expectTasktoBeOrdered();
+
+    fireEvent.click(screen.getByText('second'));
+
+    act(() => {
+      expectTasktoBeOrdered();
+    });
+
+    fireEvent.click(screen.getByText('do-something'));
+
+    act(() => {
+      expectTasktoBeOrdered();
+    });
   });
 });


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/HAC-3557

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When viewing logs of a Pipelinerun, the ordering of the tasks constantly changes on clicking a task.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

**Before:**

https://user-images.githubusercontent.com/9964343/227000748-dcbc81ae-3b45-4082-8d32-15c6be064c3d.mp4


**After:**

https://user-images.githubusercontent.com/9964343/227000790-35da1ec6-a763-4bdb-a146-26a9a6c3417b.mp4



## Unit tests

```
PipelineRunLogs.spec.tsx

    ✓ should render the task names in the same order when a task is clicked (75 ms)
```

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

/cc @jeff-phillips-18 