### PR TITLE
Show Clair-Scan as warning when vulnerabilities

### DIFF
--- a/src/components/ApplicationDetails/tabs/overview/visualization/hooks/__tests__/useAppIntegrationTestNodes.spec.ts
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/hooks/__tests__/useAppIntegrationTestNodes.spec.ts
@@ -5,9 +5,13 @@ import { mockIntegrationTestScenariosData } from '../../../../../__data__';
 import { testPipelineRuns } from '../__data__/test-pipeline-data';
 import { useAppApplicationTestNodes } from '../useAppApplicationTestNodes';
 
-jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
-  useK8sWatchResource: jest.fn(),
-}));
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => {
+  const actual = jest.requireActual('@openshift/dynamic-plugin-sdk-utils');
+  return {
+    ...actual,
+    useK8sWatchResource: jest.fn(),
+  };
+});
 
 const useK8sWatchResourceMock = useK8sWatchResource as jest.Mock;
 

--- a/src/components/Environment/__tests__/EditStrategyModal.spec.tsx
+++ b/src/components/Environment/__tests__/EditStrategyModal.spec.tsx
@@ -5,9 +5,13 @@ import { act, render, screen } from '@testing-library/react';
 import { EnvironmentKind } from '../../../types';
 import { EditStrategyModal } from '../EditStrategyModal';
 
-jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
-  k8sPatchResource: jest.fn(),
-}));
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => {
+  const actual = jest.requireActual('@openshift/dynamic-plugin-sdk-utils');
+  return {
+    ...actual,
+    k8sPatchResource: jest.fn(),
+  };
+});
 
 const patchResourceMock = k8sPatchResource as jest.Mock;
 

--- a/src/components/PipelineRunDetailsView/__tests__/PipelineVisualization.spec.tsx
+++ b/src/components/PipelineRunDetailsView/__tests__/PipelineVisualization.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import '@testing-library/jest-dom';
 import { configure, render, screen } from '@testing-library/react';
+import { SCAN_TASK } from '../../../hooks/useClairScanResults';
 import { CustomError } from '../../../shared/utils/error/custom-error';
 import { testPipelineRun } from '../../topology/__data__/pipeline-test-data';
 import { mockPipelineRun, mockTaskRuns } from '../__data__/mockVisualizationData';
@@ -84,12 +85,33 @@ describe('PipelineRunVisualization', () => {
         error={null}
       />,
     );
-    const graph = screen.getByTestId('pipelinerun-vis-graph');
+    const sanityCheck = screen.getByTestId('sanity-optional-label-check');
 
-    const warningNodes = graph.querySelectorAll('.pipelinerun-node.pf-m-warning');
-    expect(warningNodes).toHaveLength(3);
+    const warningNodes = sanityCheck.querySelectorAll('.pipelinerun-node.pf-m-warning');
+    expect(warningNodes).toHaveLength(1);
 
-    const warningBadges = graph.querySelectorAll('.pipelinerun-node__test-status-badge--warning');
-    expect(warningBadges).toHaveLength(2);
+    const warningBadges = sanityCheck.querySelectorAll(
+      '.pipelinerun-node__test-status-badge--warning > text',
+    );
+    expect(warningBadges[0].textContent).toBe('2');
+  });
+
+  it('should render the Clair scan results correctly on the task runs', () => {
+    render(
+      <PipelineRunVisualization
+        pipelineRun={mockPipelineRun}
+        taskRuns={mockTaskRuns}
+        error={null}
+      />,
+    );
+    const clairScan = screen.getByTestId(SCAN_TASK);
+
+    const warningNodes = clairScan.querySelectorAll('.pipelinerun-node.pf-m-warning');
+    expect(warningNodes).toHaveLength(1);
+
+    const warningBadges = clairScan.querySelectorAll(
+      '.pipelinerun-node__test-status-badge--warning > text',
+    );
+    expect(warningBadges[0].textContent).toBe('4');
   });
 });

--- a/src/components/PipelineRunDetailsView/visualization/nodes/PipelineRunNode.scss
+++ b/src/components/PipelineRunDetailsView/visualization/nodes/PipelineRunNode.scss
@@ -4,6 +4,7 @@
     &--failed {
       > rect {
         fill: var(--pf-global--danger-color--100);
+        stroke: var(--pf-global--Color--light-100);
       }
       > text {
         fill: var(--pf-global--Color--light-100);
@@ -12,6 +13,7 @@
     &--warning {
       > rect {
         fill: var(--pf-global--warning-color--100);
+        stroke: var(--pf-global--Color--light-100);
       }
       > text {
         fill: var(--pf-global--Color--dark-100);

--- a/src/components/PipelineRunDetailsView/visualization/nodes/PipelineRunNode.tsx
+++ b/src/components/PipelineRunDetailsView/visualization/nodes/PipelineRunNode.tsx
@@ -12,6 +12,7 @@ import {
 import { observer } from 'mobx-react';
 import { runStatusToRunStatus } from '../../../topology/utils';
 import { PipelineRunNodeData } from '../types';
+import { getTaskBadgeCount } from '../utils/pipelinerun-graph-utils';
 import PipelineRunNodeTooltip from './PipelineRunNodeTooltip';
 
 import './PipelineRunNode.scss';
@@ -24,11 +25,7 @@ type PipelineRunNodeProps = {
 const PipelineRunNode: React.FunctionComponent<PipelineRunNodeProps> = ({ element, ...rest }) => {
   const data = element.getData();
   const status = runStatusToRunStatus(data.status);
-
-  const badge =
-    data.testFailCount || data.testWarnCount
-      ? `${data.testFailCount + data.testWarnCount}`
-      : undefined;
+  const badgeCount = getTaskBadgeCount(data);
 
   const whenDecorator = data.whenStatus ? (
     <WhenDecorator element={element} status={data.whenStatus} leftOffset={DEFAULT_WHEN_OFFSET} />
@@ -39,7 +36,7 @@ const PipelineRunNode: React.FunctionComponent<PipelineRunNodeProps> = ({ elemen
       className="pipelinerun-node"
       element={element}
       status={status}
-      badge={badge}
+      badge={badgeCount ? `${badgeCount}` : undefined}
       badgeClassName="pipelinerun-node__test-status-badge--warning"
       toolTip={<PipelineRunNodeTooltip label={element.getLabel()} steps={data.steps} />}
       toolTipProps={{

--- a/src/components/PipelineRunDetailsView/visualization/types.ts
+++ b/src/components/PipelineRunDetailsView/visualization/types.ts
@@ -1,4 +1,5 @@
 import { PipelineNodeModel as PfPipelineNodeModel, WhenStatus } from '@patternfly/react-topology';
+import { ClairScanResult } from '../../../hooks/useClairScanResults';
 import { PipelineTask, TaskRunStatus, TaskRunKind } from '../../../types';
 import { runStatus } from '../../../utils/pipeline-utils';
 
@@ -23,6 +24,7 @@ export type PipelineRunNodeData = {
   namespace: string;
   testFailCount?: number;
   testWarnCount?: number;
+  scanResults?: ClairScanResult;
   whenStatus?: WhenStatus;
   steps?: StepStatus[];
   taskRun?: TaskRunKind;
@@ -33,6 +35,7 @@ export type PipelineTaskStatus = TaskRunStatus & {
   duration?: string;
   testFailCount?: number;
   testWarnCount?: number;
+  scanResults?: ClairScanResult;
 };
 
 export type PipelineTaskWithStatus = PipelineTask & {

--- a/src/components/PipelineRunDetailsView/visualization/utils/__tests__/pipelinerun-graph-utils.spec.ts
+++ b/src/components/PipelineRunDetailsView/visualization/utils/__tests__/pipelinerun-graph-utils.spec.ts
@@ -5,13 +5,14 @@ import { PipelineRunKind, TaskRunKind, TektonResourceLabel } from '../../../../.
 import { runStatus, SucceedConditionReason } from '../../../../../utils/pipeline-utils';
 import { NodeType } from '../../../../ApplicationDetails/tabs/overview/visualization/const';
 import { testPipelineRun } from '../../../../topology/__data__/pipeline-test-data';
-import { PipelineRunNodeType, PipelineTaskStatus } from '../../types';
+import { PipelineRunNodeData, PipelineRunNodeType, PipelineTaskStatus } from '../../types';
 import {
   appendStatus,
   createStepStatus,
   extractDepsFromContextVariables,
   getPipelineFromPipelineRun,
   getPipelineRunDataModel,
+  getTaskBadgeCount,
   isTaskNode,
   nodesHasWhenExpression,
   scrollNodeIntoView,
@@ -128,6 +129,37 @@ describe('pipelinerun-graph-utils: ', () => {
       const successTestNode = nodes.find((n) => n.id === 'task3');
       expect(successTestNode.data.testFailCount).toEqual(0);
       expect(successTestNode.data.testWarnCount).toEqual(0);
+    });
+  });
+
+  describe('getTaskBadgeCount', () => {
+    it('should return the correct badge count for tasks', () => {
+      const data: PipelineRunNodeData = {
+        namespace: 'test-ns',
+        task: null,
+      };
+      expect(getTaskBadgeCount(data)).toBe(0);
+
+      data.testWarnCount = 1;
+      data.testFailCount = 0;
+      expect(getTaskBadgeCount(data)).toBe(1);
+
+      data.testFailCount = 3;
+      expect(getTaskBadgeCount(data)).toBe(4);
+
+      data.scanResults = {
+        vulnerabilities: {
+          critical: 1,
+          high: 3,
+          medium: 1,
+          low: 1,
+        },
+      };
+      expect(getTaskBadgeCount(data)).toBe(4);
+
+      data.testWarnCount = 0;
+      data.testFailCount = 0;
+      expect(getTaskBadgeCount(data)).toBe(6);
     });
   });
 

--- a/src/components/modal/__tests__/DeleteResourceModal.spec.tsx
+++ b/src/components/modal/__tests__/DeleteResourceModal.spec.tsx
@@ -5,9 +5,13 @@ import '@testing-library/jest-dom';
 import { ApplicationModel } from '../../../models';
 import { DeleteResourceModal } from '../DeleteResourceModal';
 
-jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
-  k8sDeleteResource: jest.fn(),
-}));
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => {
+  const actual = jest.requireActual('@openshift/dynamic-plugin-sdk-utils');
+  return {
+    ...actual,
+    k8sDeleteResource: jest.fn(),
+  };
+});
 
 const k8sDeleteMock = k8sDeleteResource as jest.Mock;
 

--- a/src/hacbs/components/Environment/__tests__/EnvironmentCard.spec.tsx
+++ b/src/hacbs/components/Environment/__tests__/EnvironmentCard.spec.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { useFeatureFlag } from '@openshift/dynamic-plugin-sdk';
-import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { getActiveWorkspace } from '@openshift/dynamic-plugin-sdk-utils';
+import { render, screen } from '@testing-library/react';
 import { EnvironmentModel } from '../../../../models';
 import { EnvironmentKind } from '../../../../types';
 import EnvironmentCard from '../EnvironmentCard';
@@ -12,10 +13,14 @@ jest.mock('@openshift/dynamic-plugin-sdk', () => ({
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   commonFetch: jest.fn(),
+  getActiveWorkspace: jest.fn(),
 }));
 
 const useFeatureFlagMock = useFeatureFlag as jest.Mock;
 useFeatureFlagMock.mockReturnValue([false, () => {}]);
+
+const getActiveWorkspaceMock = getActiveWorkspace as jest.Mock;
+getActiveWorkspaceMock.mockReturnValue('test-ws');
 
 const testEnv: EnvironmentKind = {
   apiVersion: `${EnvironmentModel.apiGroup}/${EnvironmentModel.apiVersion}`,
@@ -67,4 +72,3 @@ describe('', () => {
     expect(screen.getByText('Application Healthy')).toBeVisible();
   });
 });
-EnvironmentCard;

--- a/src/hooks/useClairScanResults.ts
+++ b/src/hooks/useClairScanResults.ts
@@ -3,8 +3,8 @@ import { TektonResourceLabel, TaskRunKind } from '../types';
 import { useWorkspaceInfo } from '../utils/workspace-context-utils';
 import { useTaskRuns } from './useTaskRuns';
 
-const SCAN_TASK = 'clair-scan';
-const SCAN_RESULT = 'CLAIR_SCAN_RESULT';
+export const SCAN_TASK = 'clair-scan';
+export const SCAN_RESULT = 'CLAIR_SCAN_RESULT';
 
 export type ClairScanResult = {
   vulnerabilities: {

--- a/src/utils/pipeline-utils.ts
+++ b/src/utils/pipeline-utils.ts
@@ -1,5 +1,6 @@
 import merge from 'lodash/merge';
 import { preferredNameAnnotation } from '../consts/pipeline';
+import { ClairScanResult, SCAN_RESULT } from '../hooks/useClairScanResults';
 import { PipelineRunModel } from '../models';
 import {
   Condition,
@@ -220,6 +221,20 @@ export const taskResultsStatus = (taskResults: TektonResultsRun[]): runStatus =>
           break;
       }
     } catch (e) {
+      // ignore
+    }
+  }
+  const scanResult = taskResults?.find((result) => result.name === SCAN_RESULT);
+  if (scanResult) {
+    try {
+      const resultObj: ClairScanResult = JSON.parse(scanResult.value);
+      if (resultObj.vulnerabilities?.critical || resultObj.vulnerabilities?.high) {
+        return runStatus.TestFailed;
+      }
+      if (resultObj.vulnerabilities?.medium || resultObj.vulnerabilities?.low) {
+        return runStatus.TestWarning;
+      }
+    } catch {
       // ignore
     }
   }


### PR DESCRIPTION
## Fixes 
Fixes [HAC-3379](https://issues.redhat.com/browse/HAC-3379)

## Description
Show a the clair-scan task as warning when there are vulnerabilities. Display a badge showing the total number of
vulnerabilities found in the node for the pipeline run details graph.

## Type of change
- [x] Bugfix

## Screen shots / Gifs for design review 
![image](https://user-images.githubusercontent.com/11633780/227520020-e15b34f2-35a4-4872-88c7-c599415d2d71.png)


![image](https://user-images.githubusercontent.com/11633780/227520048-334b3950-948c-4c4f-b966-04f153146f5c.png)


![image](https://user-images.githubusercontent.com/11633780/227520202-1fbf0d69-95f2-4bc7-8b33-68879b0c1238.png)

/cc @karthikjeeyar 