### PR TITLE
Update references to the new EC GitHub org name

### DIFF
--- a/helpers/resources/release/managed-workspace/ec-policy.yaml
+++ b/helpers/resources/release/managed-workspace/ec-policy.yaml
@@ -14,5 +14,5 @@ spec:
       - test
   sources:
     - git:
-        repository: https://github.com/hacbs-contract/ec-policies
+        repository: https://github.com/enterprise-contract/ec-policies
         revision: main

--- a/src/components/EnterpriseContractView/__data__/mockECPolicy.ts
+++ b/src/components/EnterpriseContractView/__data__/mockECPolicy.ts
@@ -15,7 +15,7 @@ export const MockECPolicy: EnterpriseContractPolicyKind = {
     sources: [
       {
         git: {
-          repository: 'https://github.com/hacbs-contract/ec-policies',
+          repository: 'https://github.com/enterprise-contract/ec-policies',
           revision: 'main',
         },
       },

--- a/src/components/EnterpriseContractView/__data__/mockEnterpriseContractPolicies.ts
+++ b/src/components/EnterpriseContractView/__data__/mockEnterpriseContractPolicies.ts
@@ -123,7 +123,7 @@ export const MockEnterpriseContractPolicies = {
         shortName: 'out_of_date_task_bundle',
         title: 'Task bundle is out of date',
         description:
-          'Check if the Tekton Bundle used for the Tasks in the Pipeline definition\nis the most recent acceptable one. See the list of acceptable\ntask bundles at xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles] or look at\nlink:https://github.com/hacbs-contract/ec-policies/blob/main/data/acceptable_tekton_bundles.yml[data/acceptable_tekton_bundles.yml]\nin this git repository.',
+          'Check if the Tekton Bundle used for the Tasks in the Pipeline definition\nis the most recent acceptable one. See the list of acceptable\ntask bundles at xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles] or look at\nlink:https://github.com/enterprise-contract/ec-policies/blob/main/data/acceptable_tekton_bundles.yml[data/acceptable_tekton_bundles.yml]\nin this git repository.',
         warningOrFailure: 'warning',
         failureMsg: "Pipeline task '%s' uses an out of date task bundle '%s'",
         file: 'policy/pipeline/task_bundle.rego',
@@ -142,7 +142,7 @@ export const MockEnterpriseContractPolicies = {
         shortName: 'unacceptable_task_bundle',
         title: 'Task bundle is not acceptable',
         description:
-          'Check if the Tekton Bundle used for the Tasks in the Pipeline definition\nare acceptable given the tracked effective_on date. See the list of acceptable\ntask bundles at xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles] or look at\nlink:https://github.com/hacbs-contract/ec-policies/blob/main/data/acceptable_tekton_bundles.yml[data/acceptable_tekton_bundles.yml]\nin this git repository.',
+          'Check if the Tekton Bundle used for the Tasks in the Pipeline definition\nare acceptable given the tracked effective_on date. See the list of acceptable\ntask bundles at xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles] or look at\nlink:https://github.com/enterprise-contract/ec-policies/blob/main/data/acceptable_tekton_bundles.yml[data/acceptable_tekton_bundles.yml]\nin this git repository.',
         warningOrFailure: 'failure',
         failureMsg: "Pipeline task '%s' uses an unacceptable task bundle '%s'",
         file: 'policy/pipeline/task_bundle.rego',
@@ -376,7 +376,7 @@ export const MockEnterpriseContractPolicies = {
         shortName: 'out_of_date_task_bundle',
         title: 'Task bundle is out of date',
         description:
-          'Check if the Tekton Bundle used for the Tasks in the attestation\nis the most recent acceptable one. See the list of acceptable\ntask bundles at xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles] or look at\nlink:https://github.com/hacbs-contract/ec-policies/blob/main/data/acceptable_tekton_bundles.yml[data/acceptable_tekton_bundles.yml]\nin this git repository.',
+          'Check if the Tekton Bundle used for the Tasks in the attestation\nis the most recent acceptable one. See the list of acceptable\ntask bundles at xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles] or look at\nlink:https://github.com/enterprise-contract/ec-policies/blob/main/data/acceptable_tekton_bundles.yml[data/acceptable_tekton_bundles.yml]\nin this git repository.',
         warningOrFailure: 'warning',
         failureMsg: "Pipeline task '%s' uses an out of date task bundle '%s'",
         file: 'policy/release/attestation_task_bundle.rego',
@@ -395,7 +395,7 @@ export const MockEnterpriseContractPolicies = {
         shortName: 'unacceptable_task_bundle',
         title: 'Task bundle is not acceptable',
         description:
-          'Check if the Tekton Bundle used for the Tasks in the attestation\nare acceptable given the tracked effective_on date. See the list of acceptable\ntask bundles at xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles] or look at\nlink:https://github.com/hacbs-contract/ec-policies/blob/main/data/acceptable_tekton_bundles.yml[data/acceptable_tekton_bundles.yml]\nin this git repository.',
+          'Check if the Tekton Bundle used for the Tasks in the attestation\nare acceptable given the tracked effective_on date. See the list of acceptable\ntask bundles at xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles] or look at\nlink:https://github.com/enterprise-contract/ec-policies/blob/main/data/acceptable_tekton_bundles.yml[data/acceptable_tekton_bundles.yml]\nin this git repository.',
         warningOrFailure: 'failure',
         failureMsg: "Pipeline task '%s' uses an unacceptable task bundle '%s'",
         file: 'policy/release/attestation_task_bundle.rego',

--- a/src/components/EnterpriseContractView/const.ts
+++ b/src/components/EnterpriseContractView/const.ts
@@ -1,7 +1,7 @@
 export const ENTERPRISE_CONTRACT_INFO_LINK =
   'https://red-hat-hybrid-application-cloud-build-services-documentation.pages.redhat.com/hacbs-documentation/ec-policies/release_policy.html';
 export const ENTERPRISE_CONTRACT_POLICIES_DATA =
-  'https://hacbs-contract.github.io/ec-policies/data.json';
+  'https://enterprise-contract.github.io/ec-policies/data.json';
 
 export const BASE_INFO_URL =
   'https://red-hat-hybrid-application-cloud-build-services-documentation.pages.redhat.com/hacbs-documentation/ec-policies/release_policy.html';


### PR DESCRIPTION
https://issues.redhat.com/browse/HACBS-2004


## Description
The hacbs-contract GitHub organization has been renamed to `enterprise-contract`. This change updates references to the new name as to not rely on the redirect put in place automatically by GitHub.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):
