### PR TITLE
Add CommitLabel for displaying Commit IDs

### DIFF
--- a/src/components/Commits/CommitDetailsView.tsx
+++ b/src/components/Commits/CommitDetailsView.tsx
@@ -9,10 +9,10 @@ import {
   Text,
   TextVariants,
 } from '@patternfly/react-core';
-import { GithubIcon } from '@patternfly/react-icons/dist/js/icons/github-icon';
 import { PipelineRunLabel, PipelineRunType } from '../../consts/pipelinerun';
 import { useCommitPipelineruns } from '../../hooks/useCommitPipelineruns';
 import { PipelineRunGroupVersionKind } from '../../models';
+import CommitLabel from '../../shared/components/commit-label/CommitLabel';
 import ExternalLink from '../../shared/components/links/ExternalLink';
 import { Timestamp } from '../../shared/components/timestamp/Timestamp';
 import { HttpError } from '../../shared/utils/error/http-error';
@@ -201,15 +201,12 @@ const CommitDetailsView: React.FC<CommitDetailsViewProps> = ({ commitName, appli
               description={
                 <>
                   <Text component="p" className="pf-u-mt-lg pf-u-mb-xs">
-                    <span className="pf-u-mr-sm">Commit ID:</span>
-                    <ExternalLink href={commit.shaURL}>
-                      {commitName}
-                      {commit.gitProvider === 'github' && (
-                        <span className="pf-u-ml-sm">
-                          <GithubIcon />
-                        </span>
-                      )}
-                    </ExternalLink>
+                    <span className="pf-u-mr-sm">Commit:</span>
+                    <CommitLabel
+                      gitProvider={commit.gitProvider}
+                      sha={commit.sha}
+                      shaURL={commit.shaURL}
+                    />
                   </Text>
                   {commit.isPullRequest ? (
                     <Text component="p" className="pf-u-mt-xs pf-u-mb-xs">

--- a/src/components/Commits/CommitsListHeader.tsx
+++ b/src/components/Commits/CommitsListHeader.tsx
@@ -4,7 +4,7 @@ export const commitsTableColumnClasses = {
   component: 'pf-m-width-15',
   byUser: 'pf-m-hidden pf-m-visible-on-xl pf-m-width-10',
   committedAt: 'pf-m-hidden pf-m-visible-on-lg pf-m-width-20',
-  status: 'pf-m-hidden pf-m-visible-on-xl pf-m-width-15',
+  status: 'pf-m-hidden pf-m-visible-on-xl',
   kebab: 'pf-c-table__action',
 };
 

--- a/src/components/Commits/CommitsListRow.tsx
+++ b/src/components/Commits/CommitsListRow.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { GithubIcon } from '@patternfly/react-icons/dist/js/icons/github-icon';
 import ActionMenu from '../../shared/components/action-menu/ActionMenu';
+import CommitLabel from '../../shared/components/commit-label/CommitLabel';
 import ExternalLink from '../../shared/components/links/ExternalLink';
 import { RowFunctionArgs, TableData } from '../../shared/components/table';
 import { Timestamp } from '../../shared/components/timestamp/Timestamp';
@@ -31,12 +31,11 @@ const CommitsListRow: React.FC<RowFunctionArgs<Commit>> = ({ obj }) => {
         >
           {prNumber} {obj.shaTitle}
         </Link>
-
         {obj.shaURL && (
-          <ExternalLink href={obj.shaURL}>
+          <>
             {' '}
-            <GithubIcon />
-          </ExternalLink>
+            <CommitLabel gitProvider={obj.gitProvider} sha={obj.sha} shaURL={obj.shaURL} />
+          </>
         )}
       </TableData>
       <TableData className={commitsTableColumnClasses.branch}>

--- a/src/shared/components/commit-label/CommitLabel.tsx
+++ b/src/shared/components/commit-label/CommitLabel.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { Label, Tooltip } from '@patternfly/react-core';
+import { BitbucketIcon } from '@patternfly/react-icons/dist/js/icons/bitbucket-icon';
+import { GithubIcon } from '@patternfly/react-icons/dist/js/icons/github-icon';
+import { GitlabIcon } from '@patternfly/react-icons/dist/js/icons/gitlab-icon';
+import { GitProvider } from '../../utils/git-utils';
+
+const tipText = {
+  [GitProvider.GITHUB]: 'Open in GitHub',
+  [GitProvider.GITLAB]: 'Open in GitLab',
+  [GitProvider.BITBUCKET]: 'Open in BitBucket',
+};
+const providerIcon = {
+  [GitProvider.GITHUB]: <GithubIcon data-test-id="git-hub-icon" />,
+  [GitProvider.GITLAB]: <GitlabIcon data-test-id="git-lab-icon" />,
+  [GitProvider.BITBUCKET]: <BitbucketIcon data-test-id="bit-bucket-icon" />,
+};
+
+type CommitLabelProps = {
+  gitProvider: GitProvider | string;
+  sha: string;
+  shaURL: string;
+};
+const CommitLabel: React.FC<CommitLabelProps> = ({ gitProvider, sha, shaURL }) => {
+  const label = (
+    <Label
+      className="commit-label"
+      color="blue"
+      icon={providerIcon[gitProvider]}
+      isCompact
+      render={({ className, content }) => (
+        <a
+          href={shaURL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={className}
+          data-test-id={`commit-label-${sha.slice(0, 6)}`}
+        >
+          {content}
+        </a>
+      )}
+    >
+      {sha.slice(0, 6)}
+    </Label>
+  );
+  const tooltip = tipText[gitProvider];
+  if (tooltip) {
+    return <Tooltip content={tooltip}>{label}</Tooltip>;
+  }
+  return label;
+};
+
+export default CommitLabel;

--- a/src/shared/components/commit-label/__tests__/CommitLabel.spec.tsx
+++ b/src/shared/components/commit-label/__tests__/CommitLabel.spec.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { configure, render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { GitProvider } from '../../../utils/git-utils';
+import CommitLabel from '../CommitLabel';
+
+configure({ testIdAttribute: 'data-test' });
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const sha = '9135b3ad0a2c16726523b12cf3b8f0365be33566';
+const shaURL =
+  'https://github.com/test-owner/test-repo/commit/9135b3ad0a2c16726523b12cf3b8f0365be33566';
+
+configure({ testIdAttribute: 'data-test-id' });
+
+describe('CommitLabel', () => {
+  it('should render commit label', () => {
+    const label = render(<CommitLabel gitProvider="github" sha={sha} shaURL={shaURL} />);
+    const link = label.getByTestId(`commit-label-9135b3`);
+    expect(link).toBeInTheDocument();
+    expect(label.getByRole('link')).toHaveAttribute('href', shaURL);
+  });
+  it('should render the correct provider icon', () => {
+    let label = render(<CommitLabel gitProvider={GitProvider.GITHUB} sha={sha} shaURL={shaURL} />);
+    let icon = label.queryByTestId(`git-hub-icon`);
+    expect(icon).toBeInTheDocument();
+    label.unmount();
+
+    label = render(<CommitLabel gitProvider={GitProvider.GITLAB} sha={sha} shaURL={shaURL} />);
+    icon = label.queryByTestId(`git-lab-icon`);
+    expect(icon).toBeInTheDocument();
+    label.unmount();
+
+    label = render(<CommitLabel gitProvider={GitProvider.BITBUCKET} sha={sha} shaURL={shaURL} />);
+    icon = label.queryByTestId(`bit-bucket-icon`);
+    expect(icon).toBeInTheDocument();
+    label.unmount();
+
+    label = render(<CommitLabel gitProvider={GitProvider.UNSURE} sha={sha} shaURL={shaURL} />);
+    expect(label.queryByTestId(`git-hub-icon`)).not.toBeInTheDocument();
+    expect(label.queryByTestId(`git-lab-icon`)).not.toBeInTheDocument();
+    expect(label.queryByTestId(`bit-bucket-icon`)).not.toBeInTheDocument();
+    label.unmount();
+
+    label = render(<CommitLabel gitProvider={undefined} sha={sha} shaURL={shaURL} />);
+    expect(label.queryByTestId(`git-hub-icon`)).not.toBeInTheDocument();
+    expect(label.queryByTestId(`git-lab-icon`)).not.toBeInTheDocument();
+    expect(label.queryByTestId(`bit-bucket-icon`)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Fixes 
Fixes [HAC-3579](https://issues.redhat.com/browse/HAC-3579)

## Description
Adds a component `CommitLabel` to be used for displaying commit IDs.

## Type of change
- [x] Feature

## Screen shots / Gifs for design review 

![image](https://user-images.githubusercontent.com/11633780/228356932-0d880288-1ac3-4c6c-86ea-e660d961da61.png)

![image](https://user-images.githubusercontent.com/11633780/228356986-daf30c7f-6731-48a8-8607-320f8a682835.png)


![image](https://user-images.githubusercontent.com/11633780/228357056-00eb3f0d-84f6-4c7b-9ebd-e663bad4b7d9.png)

/cc @karthikjeeyar @christianvogt 