### PR TITLE
Prevent link redirection in disabled action button 

### DIFF
--- a/src/components/ApplicationDetails/DetailsPage.tsx
+++ b/src/components/ApplicationDetails/DetailsPage.tsx
@@ -84,7 +84,7 @@ const DetailsPage: React.FC<DetailsPageProps> = ({
   const dropdownItems = React.useMemo(
     () =>
       actions?.reduce((acc, action) => {
-        const { type, key, label, isDisabled, disabledTooltip, ...props } = action;
+        const { type, key, label, isDisabled, disabledTooltip, component, ...props } = action;
         if (action.hidden) {
           return acc;
         }
@@ -113,7 +113,13 @@ const DetailsPage: React.FC<DetailsPageProps> = ({
           );
         } else {
           acc.push(
-            <DropdownItem key={key} data-test={key} isDisabled={isDisabled} {...props}>
+            <DropdownItem
+              key={key}
+              data-test={key}
+              isDisabled={isDisabled}
+              component={!isDisabled ? component : 'a'}
+              {...props}
+            >
               {label}
             </DropdownItem>,
           );

--- a/src/components/ApplicationDetails/__tests__/DetailsPage.spec.tsx
+++ b/src/components/ApplicationDetails/__tests__/DetailsPage.spec.tsx
@@ -102,6 +102,71 @@ describe('DetailsPage', () => {
     expect(getByTestId('help-section')).toBeInTheDocument();
   });
 
+  it('should not perform an action when the button is disabled', async () => {
+    const componentMock = jest.fn();
+
+    const { getByTestId, getByRole } = routerRenderer(
+      <DetailsPage
+        headTitle="test"
+        title="Details"
+        baseURL="/"
+        tabs={[]}
+        actions={[
+          {
+            key: 'disabled-section',
+            label: 'Disabled Section',
+            component: componentMock,
+            isDisabled: true,
+            disabledTooltip: 'disabled link',
+          },
+        ]}
+      />,
+    );
+    const actionsMenu = getByRole('button', { name: /Actions/ });
+
+    act(() => {
+      actionsMenu.click();
+    });
+    fireEvent.click(getByTestId('disabled-section'));
+
+    await waitFor(() => {
+      expect(componentMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should show disabled tooltip on hovering a disabled action', async () => {
+    const componentMock = jest.fn();
+
+    const { getByTestId, getByRole } = routerRenderer(
+      <DetailsPage
+        headTitle="test"
+        title="Details"
+        baseURL="/"
+        tabs={[]}
+        actions={[
+          {
+            key: 'disabled-section',
+            label: 'Disabled Section',
+            component: componentMock,
+            isDisabled: true,
+            disabledTooltip: 'This link is disabled',
+          },
+        ]}
+      />,
+    );
+    const actionsMenu = getByRole('button', { name: /Actions/ });
+
+    act(() => {
+      actionsMenu.click();
+    });
+
+    fireEvent.mouseEnter(getByTestId('disabled-section'));
+
+    await waitFor(() => {
+      screen.getByText('This link is disabled');
+    });
+  });
+
   it('should render head title based on the tab and headTitle', async () => {
     const onTabSelect = jest.fn();
     routerRenderer(

--- a/src/shared/components/action-menu/ActionMenuItem.tsx
+++ b/src/shared/components/action-menu/ActionMenuItem.tsx
@@ -76,7 +76,16 @@ const ActionItem: React.FC<ActionMenuItemProps & { isAllowed: boolean }> = ({
       {...props}
       {...(component ? {} : extraProps)}
       component={(compProps) => (
-        <Button {...compProps} variant="plain" isAriaDisabled={isDisabled} />
+        <Button
+          {...compProps}
+          variant="plain"
+          style={{
+            color: isDisabled
+              ? 'var(--pf-global--disabled-color--100)'
+              : 'var(--pf-c-content--Color)',
+          }}
+          isAriaDisabled={isDisabled}
+        />
       )}
     >
       {label}

--- a/src/shared/components/action-menu/__tests__/ActionMenuItem.spec.tsx
+++ b/src/shared/components/action-menu/__tests__/ActionMenuItem.spec.tsx
@@ -1,0 +1,207 @@
+import * as React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import ActionMenuItem, { ActionMenuItemProps } from '../ActionMenuItem';
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: jest.fn(),
+  };
+});
+
+const useNavigateMock = useNavigate as jest.Mock;
+
+const ActionMenuItemRenderer = (props: ActionMenuItemProps) =>
+  render(<ActionMenuItem {...props} />);
+
+describe('ActionMenuItem', () => {
+  let navigateMock;
+
+  beforeEach(() => {
+    navigateMock = jest.fn();
+    useNavigateMock.mockImplementation(() => navigateMock);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the action', async () => {
+    ActionMenuItemRenderer({
+      action: {
+        cta: () => {},
+        id: 'action-1',
+        label: 'Action 1',
+      },
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('Action 1').textContent).toBe('Action 1');
+    });
+  });
+
+  it('should use custom component', async () => {
+    ActionMenuItemRenderer({
+      action: {
+        cta: () => {},
+        id: 'action-1',
+        label: 'Action 1',
+      },
+      component: () => <a data-testid="custom-component">Custom Action</a>,
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('custom-component').textContent).toBe('Custom Action');
+    });
+  });
+
+  it('should show tooltip on hover', async () => {
+    ActionMenuItemRenderer({
+      action: {
+        cta: () => {},
+        id: 'action-1',
+        label: 'Action 1',
+        tooltip: 'Test tooltip description',
+      },
+    });
+
+    fireEvent.mouseEnter(screen.getByTestId('Action 1'));
+
+    await waitFor(() => {
+      screen.getByText('Test tooltip description');
+    });
+  });
+
+  it('should call the cta function', async () => {
+    const handleCta = jest.fn();
+    const { getByTestId } = ActionMenuItemRenderer({
+      action: {
+        cta: handleCta,
+        id: 'action-1',
+        label: 'Action 1',
+      },
+    });
+
+    fireEvent.click(within(getByTestId('Action 1')).getByRole('button'));
+
+    await waitFor(() => {
+      expect(handleCta).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should use href from the cta', async () => {
+    const { getByTestId } = ActionMenuItemRenderer({
+      action: {
+        cta: {
+          href: 'www.example.com',
+        },
+        id: 'action-1',
+        label: 'Action 1',
+      },
+    });
+
+    fireEvent.click(within(getByTestId('Action 1')).getByRole('button'));
+
+    await waitFor(() => {
+      expect(useNavigateMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should render an external link', async () => {
+    const { getByTestId } = ActionMenuItemRenderer({
+      action: {
+        cta: {
+          href: 'www.example.com',
+          external: true,
+        },
+        id: 'action-1',
+        label: 'Action 1',
+      },
+    });
+
+    fireEvent.click(within(getByTestId('Action 1')).getByRole('menuitem'));
+
+    await waitFor(() => {
+      expect(useNavigateMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should navigate to the link when enter is pressed ', async () => {
+    const { getByTestId } = ActionMenuItemRenderer({
+      action: {
+        cta: {
+          href: 'www.example.com',
+        },
+        id: 'action-1',
+        label: 'Action 1',
+      },
+    });
+
+    fireEvent.keyDown(within(getByTestId('Action 1')).getByRole('button'), {
+      key: 'Enter',
+      code: 'Enter',
+      keyCode: 13,
+    });
+
+    await waitFor(() => {
+      expect(useNavigateMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should call onEscape function when escape key is pressed ', async () => {
+    const onEscapeHandler = jest.fn();
+    const { getByTestId } = ActionMenuItemRenderer({
+      action: {
+        cta: () => {},
+        id: 'action-1',
+        label: 'Action 1',
+      },
+      onEscape: onEscapeHandler,
+    });
+
+    fireEvent.keyDown(within(getByTestId('Action 1')).getByRole('button'), {
+      key: 'ESCAPE',
+      keyCode: 27,
+    });
+
+    await waitFor(() => {
+      expect(onEscapeHandler).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should call custom onClick handler', async () => {
+    const onClickHandler = jest.fn();
+    const { getByTestId } = ActionMenuItemRenderer({
+      action: {
+        cta: () => {},
+        id: 'action-1',
+        label: 'Action 1',
+      },
+      onClick: onClickHandler,
+    });
+
+    fireEvent.click(within(getByTestId('Action 1')).getByRole('button'));
+
+    await waitFor(() => {
+      expect(onClickHandler).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should not call the cta when the action is disabled', async () => {
+    const handleCta = jest.fn();
+    const { getByTestId } = ActionMenuItemRenderer({
+      action: {
+        cta: handleCta,
+        id: 'action-1',
+        label: 'Action 1',
+        disabled: true,
+      },
+    });
+
+    fireEvent.click(within(getByTestId('Action 1')).getByRole('button'));
+
+    await waitFor(() => {
+      expect(handleCta).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-3612

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When a user doesn't have a enough permission to perform an action, then the button is disabled but the user is still able to click on the button and it redirects to the underlying link.

This PR also fixes the colour scheme for kebab menu actions.


## Type of change
<!-- Please delete options that are not relevant. -->


- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Link redirection:

**Before:**
![disabled_button_click](https://user-images.githubusercontent.com/9964343/228441679-d24cd603-4bdb-402c-8f92-48fb31719dbb.gif)


**After:**

![fixed_disabled_button_click](https://user-images.githubusercontent.com/9964343/228441692-e5b1cee4-4d8a-42a4-99ce-f6b026b09e3e.gif)


Kebab menu action color Schemes:

|  **Before** | **After**
|---|---|
|  <img width="298" alt="Screenshot 2023-03-29 at 10 08 22 AM" src="https://user-images.githubusercontent.com/9964343/228442341-23e139c0-14bf-41bb-af71-0e24d1839a2a.png">| <img width="335" alt="Screenshot 2023-03-29 at 11 44 38 AM" src="https://user-images.githubusercontent.com/9964343/228442789-8abf0854-cea5-485c-8fa4-cfbf44aab2fc.png"> |




## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

/cc @rottencandy 