### PR TITLE
Add preview to caddy uristip and chrome redirect

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -12,6 +12,7 @@
         # Substitution for alias from nginx
         uri strip_prefix /api/plugins/hac-dev
         uri strip_prefix /beta/api/plugins/hac-dev
+        uri strip_prefix /preview/api/plugins/hac-dev
         file_server * {
             root /opt/app-root/src/dist 
             browse
@@ -26,6 +27,7 @@
         # Substitution for alias from nginx
         uri strip_prefix /apps/hac-dev
         uri strip_prefix /beta/apps/hac-dev
+        uri strip_prefix /preview/apps/hac-dev
         file_server * {
             root /opt/app-root/src/dist 
             browse
@@ -33,6 +35,6 @@
     }
 
     handle / {
-        try_files {path} {path}/ /apps/chrome/index.html /beta/apps/chrome/index.html
+        try_files {path} {path}/ /apps/chrome/index.html /beta/apps/chrome/index.html /preview/chrome/index.html
     }
 }


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-3609


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

HCC is moving away from beta environment to preview environment in order to do that we need to have preview prefix strip when user requests hac-dev files.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):
