### PR TITLE
enable all what's next help topics at once

### DIFF
--- a/src/components/HelpTopicLink/HelpTopicLink.tsx
+++ b/src/components/HelpTopicLink/HelpTopicLink.tsx
@@ -13,7 +13,7 @@ export const HelpTopicLink: React.FC<HelpTopicLinkProps> = ({ topicId, isInline,
   } = useChrome();
 
   React.useEffect(() => {
-    enableTopics(topicId);
+    enableTopics({ names: [topicId], append: true });
 
     return () => disableTopics(topicId);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/HelpTopicLink/__tests__/HelpTopicLink.spec.tsx
+++ b/src/components/HelpTopicLink/__tests__/HelpTopicLink.spec.tsx
@@ -18,7 +18,7 @@ describe('HelpTopicLink', () => {
     });
 
     render(<HelpTopicLink topicId="test" />);
-    expect(enableTopics).toHaveBeenCalledWith('test');
+    expect(enableTopics).toHaveBeenCalledWith({ names: ['test'], append: true });
     cleanup();
     expect(disableTopics).toHaveBeenCalledWith('test');
   });


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/HAC-3646

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

There are 4 what's next learn more help topics, but only a single one at a time would be displayed in drop down menu.
Fixed this and now all 4 are displayed at once.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
![image](https://user-images.githubusercontent.com/14068621/229216680-d01ed220-ac80-4913-9d2c-316d9de2f35a.png)


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
