### PR TITLE
User provided component name should not be overridden by cdq defaults

### DIFF
--- a/src/components/ImportForm/ReviewSection/ReviewComponentCard.tsx
+++ b/src/components/ImportForm/ReviewSection/ReviewComponentCard.tsx
@@ -11,6 +11,7 @@ import {
   FormSection,
   TextInputTypes,
 } from '@patternfly/react-core';
+import { useField } from 'formik';
 import {
   EditableLabelField,
   EnvironmentField,
@@ -45,6 +46,9 @@ export const ReviewComponentCard: React.FC<ReviewComponentCardProps> = ({
   const fieldPrefix = `components[${detectedComponentIndex}].componentStub`;
   const [expandedComponent, setExpandedComponent] = React.useState(isExpanded);
   const [expandedConfig, setExpandedConfig] = React.useState(true);
+  const [, { value: componentValue }, { setValue: setComponentValue }] = useField(
+    `components[${detectedComponentIndex}]`,
+  );
 
   return (
     <Card isFlat isCompact isSelected={expandedComponent} isExpanded={expandedComponent}>
@@ -67,6 +71,7 @@ export const ReviewComponentCard: React.FC<ReviewComponentCardProps> = ({
                 <EditableLabelField
                   name={`${fieldPrefix}.componentName`}
                   type={TextInputTypes.text}
+                  onEdit={() => setComponentValue({ ...componentValue, nameModified: true })}
                 />
               )}
               <ExternalLink

--- a/src/components/ImportForm/ReviewSection/RuntimeSelector.tsx
+++ b/src/components/ImportForm/ReviewSection/RuntimeSelector.tsx
@@ -53,7 +53,8 @@ export const RuntimeSelector: React.FC<RuntimeSelectorProps> = ({ detectedCompon
   const [detecting, setDetecting] = React.useState(false);
   const [runtimeSource, setRuntimeSource] = React.useState('');
   const [selectedRuntime, setSelectedRuntime] = React.useState(null);
-
+  const originalComponentRef = React.useRef(components?.[detectedComponentIndex]);
+  originalComponentRef.current = components?.[detectedComponentIndex];
   const DetectingRuntime = 'Detecting runtime...';
 
   const items = React.useMemo(() => {
@@ -163,7 +164,10 @@ export const RuntimeSelector: React.FC<RuntimeSelectorProps> = ({ detectedCompon
       // To avoid formik validating on old values due to a formik bug - https://github.com/jaredpalmer/formik/issues/2083
       setTimeout(() => setFieldValue('isDetected', true));
       setTimeout(() => setFieldValue('detectionFailed', false));
-      const componentValues = transformComponentValues(detectedComponents)[0];
+      const componentValues = transformComponentValues(
+        detectedComponents,
+        originalComponentRef.current,
+      )[0];
       const component = patchSourceUrl(componentValues.componentStub, sourceUrl);
       setFieldValue(`${fieldPrefix}.componentStub`, component);
       setFieldValue(`${fieldPrefix}.language`, componentValues.language);

--- a/src/components/ImportForm/utils/__tests__/transform-utils.spec.ts
+++ b/src/components/ImportForm/utils/__tests__/transform-utils.spec.ts
@@ -1,5 +1,6 @@
 import { mockDetectedComponent } from '../__data__/mock-cdq';
 import { createResourceData, transformComponentValues } from '../transform-utils';
+import { CPUUnits, DetectedFormComponent, MemoryUnits } from '../types';
 
 const mockResourceRequests = {
   requests: {
@@ -13,6 +14,32 @@ const mockResourceLimits = {
     cpu: '48m',
     memory: '516Mi',
   },
+};
+
+const mockComponent: DetectedFormComponent = {
+  componentStub: {
+    application: 'insert-application-name',
+    componentName: 'nodejs',
+    source: {
+      git: {
+        context: './',
+        url: 'https://github.com/nodeshift-starters/devfile-sample.git',
+      },
+    },
+    resources: {
+      cpu: '10',
+      cpuUnit: CPUUnits.millicores,
+      memory: '50',
+      memoryUnit: MemoryUnits.Mi,
+    },
+    replicas: 1,
+    targetPort: 8080,
+    route: undefined,
+    env: undefined,
+  },
+  devfileFound: true,
+  language: 'nodejs',
+  projectType: 'nodejs',
 };
 
 describe('Transform Utils', () => {
@@ -48,27 +75,39 @@ describe('Transform Utils', () => {
 
   it('should transform component values for submit utils', () => {
     const transformedComponentValues = transformComponentValues(mockDetectedComponent);
-    expect(transformedComponentValues).toEqual([
-      {
-        componentStub: {
-          application: 'insert-application-name',
-          componentName: 'nodejs',
-          source: {
-            git: {
-              context: './',
-              url: 'https://github.com/nodeshift-starters/devfile-sample.git',
-            },
-          },
-          resources: { cpu: '10', cpuUnit: 'millicores', memory: '50', memoryUnit: 'Mi' },
-          replicas: 1,
-          targetPort: 8080,
-          route: undefined,
-          env: undefined,
-        },
-        devfileFound: true,
-        language: 'nodejs',
-        projectType: 'nodejs',
+    expect(transformedComponentValues).toEqual([mockComponent]);
+  });
+
+  it('should modify the component name if the user has not modified the name', () => {
+    const userModifiedComponent: DetectedFormComponent = {
+      ...mockComponent,
+      componentStub: {
+        ...mockComponent.componentStub,
+        componentName: 'my-component-name',
       },
-    ]);
+    };
+
+    const transformedComponentValues = transformComponentValues(
+      mockDetectedComponent,
+      userModifiedComponent,
+    );
+    expect(transformedComponentValues[0].componentStub.componentName).toBe('nodejs');
+  });
+
+  it('should not modify the component name if the user has modified the name', () => {
+    const userModifiedComponent: DetectedFormComponent = {
+      ...mockComponent,
+      componentStub: {
+        ...mockComponent.componentStub,
+        componentName: 'my-component-name',
+      },
+      nameModified: true,
+    };
+
+    const transformedComponentValues = transformComponentValues(
+      mockDetectedComponent,
+      userModifiedComponent,
+    );
+    expect(transformedComponentValues[0].componentStub.componentName).toBe('my-component-name');
   });
 });

--- a/src/components/ImportForm/utils/transform-utils.ts
+++ b/src/components/ImportForm/utils/transform-utils.ts
@@ -43,6 +43,7 @@ export const transformResources = (formResources: FormResources): ResourceRequir
 
 export const transformComponentValues = (
   detectedComponents: DetectedComponents,
+  originalComponent?: DetectedFormComponent,
 ): DetectedFormComponent[] => {
   return Object.values(detectedComponents).map((detectedComponent) => {
     const component = detectedComponent.componentStub;
@@ -50,6 +51,11 @@ export const transformComponentValues = (
       ...detectedComponent,
       componentStub: {
         ...component,
+        ...(originalComponent && {
+          componentName: originalComponent?.nameModified
+            ? originalComponent.componentStub.componentName
+            : component.componentName,
+        }),
         resources: createResourceData(component?.resources || {}),
         replicas: component?.replicas || 1,
         targetPort: component?.targetPort || 8080,

--- a/src/components/ImportForm/utils/types.ts
+++ b/src/components/ImportForm/utils/types.ts
@@ -27,6 +27,7 @@ export type DetectedFormComponent = {
   componentStub: Omit<ComponentSpecs, 'resources'> & {
     resources?: FormResources;
   };
+  nameModified?: boolean;
   language?: string;
   projectType?: string;
   devfileFound?: boolean;

--- a/src/shared/components/formik-fields/EditableLabelField.tsx
+++ b/src/shared/components/formik-fields/EditableLabelField.tsx
@@ -10,12 +10,14 @@ import './EditableLabelField.scss';
 type EditableLabelFieldProps = {
   name: string;
   type?: TextInputTypes;
+  onEdit?: () => void;
 } & Omit<FormGroupProps, 'fieldId'>;
 
 const EditableLabelField: React.FC<EditableLabelFieldProps> = ({
   name,
   label,
   type = TextInputTypes.text,
+  onEdit,
   ...props
 }) => {
   const [, { value, error }, { setValue, setTouched }] = useField({ name, type });
@@ -42,6 +44,7 @@ const EditableLabelField: React.FC<EditableLabelFieldProps> = ({
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
       setEditing(false);
+      onEdit && onEdit();
       e.preventDefault();
     }
   };
@@ -56,7 +59,10 @@ const EditableLabelField: React.FC<EditableLabelFieldProps> = ({
           <FlexItem>
             <ActionGroupWithIcons
               className="editable-label-field__action-group"
-              onSubmit={() => setEditing(false)}
+              onSubmit={() => {
+                setEditing(false);
+                onEdit && onEdit();
+              }}
               isDisabled={!!error}
               onClose={() => {
                 setEditing(false);

--- a/src/shared/components/formik-fields/__tests__/EditableLabelField.spec.tsx
+++ b/src/shared/components/formik-fields/__tests__/EditableLabelField.spec.tsx
@@ -136,6 +136,24 @@ describe('EditableLabelField', () => {
     });
   });
 
+  it('should call onEdit handler on submit ', async () => {
+    const onEdit = jest.fn();
+    render(
+      <Wrapper initialValues={initialValues} onSubmit={jest.fn()}>
+        <EditableLabelField name={fieldName} onEdit={onEdit} />
+      </Wrapper>,
+    );
+    fireEvent.click(screen.getByTestId('pencil-icon'));
+    await waitFor(() => {
+      const inputField = screen.getByTestId('editable-label-input').querySelector('input');
+      const submitButton = screen.getByTestId('check-icon');
+      fireEvent.input(inputField, { target: { value: 'new field value' } });
+      fireEvent.click(submitButton);
+    });
+
+    expect(onEdit).toHaveBeenCalled();
+  });
+
   it('should show label field with old value and unmount editable field on close button click ', async () => {
     render(
       <Wrapper initialValues={initialValues} onSubmit={jest.fn()}>


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-3585

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

If the user has provided a component name, then it should not be updated when a runtime is changed.


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


https://user-images.githubusercontent.com/9964343/229850506-19e7ed42-d994-401c-adf3-326aee724e5e.mov


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

1. In the review step, change the component name
2. choose a different runtime

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
