### PR TITLE
Update task name for scraping EC report output

### DIFF
--- a/src/components/EnterpriseContractView/__tests__/useEnterpriseContractResultFromLogs.spec.tsx
+++ b/src/components/EnterpriseContractView/__tests__/useEnterpriseContractResultFromLogs.spec.tsx
@@ -54,7 +54,7 @@ describe('useEnterpriseContractResultFromLogs', () => {
       name: 'pod-acdf',
       path: 'log',
       queryParams: {
-        container: 'step-validate',
+        container: 'step-report',
         follow: 'true',
       },
     };

--- a/src/components/EnterpriseContractView/useEnterpriseContractResultFromLogs.tsx
+++ b/src/components/EnterpriseContractView/useEnterpriseContractResultFromLogs.tsx
@@ -27,7 +27,7 @@ export const useEnterpriseContractResultFromLogs = (
           name: podName,
           path: 'log',
           queryParams: {
-            container: 'step-validate',
+            container: 'step-report',
             follow: 'true',
           },
         }


### PR DESCRIPTION
## Fixes 

No Jira filed currently.

## Description

There were some changes to the Enterprise Contract task definition and now the step containing the Enterprise Contract output in YAML format is called "report" instead of "validate".

See the task definition change here:
https://github.com/enterprise-contract/ec-cli/pull/589

This is related to the recently merged #530 .

## Type of change

- Bugfix

## How to test or reproduce?

I believe the newly merged code from #530 won't be working as expected in RHTAP stage and prod due to the recent step name change.

I'm not sure how to test this, or whether there are other changes required. Feel free to advise if there's something else needed. Attention @christianvogt @sahil143 .