### PR TITLE
Change stonesoup url to application-pipeline

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -29,7 +29,7 @@ const webpackProxy = {
   deployment: process.env.BETA ? 'beta/api/plugins' : 'api/plugins',
   useProxy: true,
   env,
-  appUrl: process.env.BETA ? '/beta/hac/stonesoup' : '/hac/stonesoup',
+  appUrl: process.env.BETA ? '/beta/hac/application-pipeline' : '/hac/application-pipeline',
   standalone: Boolean(process.env.STANDALONE),
   ...(process.env.INSIGHTS_CHROME && {
     localChrome: process.env.INSIGHTS_CHROME,

--- a/config/remotePlugin.js
+++ b/config/remotePlugin.js
@@ -5,14 +5,14 @@ const navExtensions = [
   {
     type: 'core.navigation/href',
     properties: {
-      href: '/stonesoup',
+      href: '/application-pipeline',
       name: 'Overview',
     },
   },
   {
     type: 'core.navigation/href',
     properties: {
-      href: '/stonesoup/workspaces',
+      href: '/application-pipeline/workspaces',
       name: 'Applications',
     },
     flags: {
@@ -22,7 +22,7 @@ const navExtensions = [
   {
     type: 'core.navigation/href',
     properties: {
-      href: '/stonesoup/environments',
+      href: '/application-pipeline/environments',
       name: 'Environments',
     },
     flags: {
@@ -84,6 +84,17 @@ const routeExtensions = [
     },
   },
 
+  // Redirect from stonesoup for now
+  {
+    type: 'core.page/route',
+    properties: {
+      path: '/stonesoup',
+      component: {
+        $codeRef: 'Redirect',
+      },
+    },
+  },
+
   // Main nav routes
   // sets workspace context for the below route
   // For `/workspaces` route redirect to applications page with workspace context added (default).
@@ -92,7 +103,7 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
-      path: '/stonesoup/workspaces',
+      path: '/application-pipeline/workspaces',
       exact: true,
       component: {
         $codeRef: 'WorkspacedPage',
@@ -105,7 +116,7 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
-      path: '/stonesoup/environments',
+      path: '/application-pipeline/environments',
       exact: true,
       component: {
         $codeRef: 'WorkspacedPage',
@@ -116,11 +127,11 @@ const routeExtensions = [
     },
   },
 
-  // Stonesoup overview
+  // application-pipeline overview
   {
     type: 'core.page/route',
     properties: {
-      path: '/stonesoup',
+      path: '/application-pipeline',
       exact: true,
       component: {
         $codeRef: 'OverviewPage',
@@ -132,7 +143,7 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
-      path: '/stonesoup/workspaces',
+      path: '/application-pipeline/workspaces',
       exact: true,
       component: {
         $codeRef: 'OverviewPage',
@@ -145,7 +156,7 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
-      path: '/stonesoup/environments',
+      path: '/application-pipeline/environments',
       exact: true,
       component: {
         $codeRef: 'OverviewPage',
@@ -160,7 +171,7 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
-      path: '/stonesoup/workspaces/:workspaceName/applications',
+      path: '/application-pipeline/workspaces/:workspaceName/applications',
       exact: true,
       component: {
         $codeRef: 'Applications',
@@ -175,7 +186,7 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
-      path: '/stonesoup/workspaces/:workspaceName/import',
+      path: '/application-pipeline/workspaces/:workspaceName/import',
       exact: true,
       component: {
         $codeRef: 'Import',
@@ -189,7 +200,7 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
-      path: '/stonesoup/workspaces/:workspaceName/applications/:appName',
+      path: '/application-pipeline/workspaces/:workspaceName/applications/:appName',
       exact: true,
       component: {
         $codeRef: 'ApplicationDetails',
@@ -202,7 +213,7 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
-      path: '/stonesoup/workspaces/:workspaceName/applications/:appName/:activeTab',
+      path: '/application-pipeline/workspaces/:workspaceName/applications/:appName/:activeTab',
       exact: true,
       component: {
         $codeRef: 'ApplicationDetails',
@@ -215,7 +226,7 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
-      path: '/stonesoup/workspaces/:workspaceName/applications/:appName/:activeTab/:activity',
+      path: '/application-pipeline/workspaces/:workspaceName/applications/:appName/:activeTab/:activity',
       exact: true,
       component: {
         $codeRef: 'ApplicationDetails',
@@ -230,7 +241,7 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
-      path: '/stonesoup/workspaces/:workspaceName/applications/:appName/pipelineruns/:plrName',
+      path: '/application-pipeline/workspaces/:workspaceName/applications/:appName/pipelineruns/:plrName',
       exact: true,
       component: {
         $codeRef: 'PipelineRuns',
@@ -243,7 +254,7 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
-      path: '/stonesoup/workspaces/:workspaceName/applications/:appName/pipelineruns/:plrName/:activeTab',
+      path: '/application-pipeline/workspaces/:workspaceName/applications/:appName/pipelineruns/:plrName/:activeTab',
       exact: true,
       component: {
         $codeRef: 'PipelineRuns',
@@ -258,7 +269,7 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
-      path: '/stonesoup/workspaces/:workspaceName/applications/:appName/integrationtests/add',
+      path: '/application-pipeline/workspaces/:workspaceName/applications/:appName/integrationtests/add',
       exact: true,
       component: {
         $codeRef: 'IntegrationTest',
@@ -271,7 +282,7 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
-      path: '/stonesoup/workspaces/:workspaceName/applications/:appName/integrationtests/:name/edit',
+      path: '/application-pipeline/workspaces/:workspaceName/applications/:appName/integrationtests/:name/edit',
       exact: true,
       component: {
         $codeRef: 'EditIntegrationTest',
@@ -284,7 +295,7 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
-      path: '/stonesoup/workspaces/:workspaceName/applications/:appName/integrationtests/:testName',
+      path: '/application-pipeline/workspaces/:workspaceName/applications/:appName/integrationtests/:testName',
       exact: true,
       component: {
         $codeRef: 'IntegrationTestDetails',
@@ -297,7 +308,7 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
-      path: '/stonesoup/workspaces/:workspaceName/applications/:appName/integrationtests/:testName/:activeTab',
+      path: '/application-pipeline/workspaces/:workspaceName/applications/:appName/integrationtests/:testName/:activeTab',
       exact: true,
       component: {
         $codeRef: 'IntegrationTestDetails',
@@ -312,7 +323,7 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
-      path: '/stonesoup/workspaces/:workspaceName/applications/:appName/taskruns/:trName',
+      path: '/application-pipeline/workspaces/:workspaceName/applications/:appName/taskruns/:trName',
       exact: true,
       component: {
         $codeRef: 'TaskRuns',
@@ -325,7 +336,7 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
-      path: '/stonesoup/workspaces/:workspaceName/applications/:appName/taskruns/:trName/:activeTab',
+      path: '/application-pipeline/workspaces/:workspaceName/applications/:appName/taskruns/:trName/:activeTab',
       exact: true,
       component: {
         $codeRef: 'TaskRuns',
@@ -340,7 +351,7 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
-      path: '/stonesoup/workspaces/:workspaceName/applications/:appName/commit/:commitName',
+      path: '/application-pipeline/workspaces/:workspaceName/applications/:appName/commit/:commitName',
       exact: true,
       component: {
         $codeRef: 'CommitsPage',
@@ -353,7 +364,7 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
-      path: '/stonesoup/workspaces/:workspaceName/applications/:appName/commit/:commitName/:activeTab',
+      path: '/application-pipeline/workspaces/:workspaceName/applications/:appName/commit/:commitName/:activeTab',
       exact: true,
       component: {
         $codeRef: 'CommitsPage',
@@ -369,7 +380,7 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
-      path: '/stonesoup/workspaces/:workspaceName/applications/:appName/component-settings',
+      path: '/application-pipeline/workspaces/:workspaceName/applications/:appName/component-settings',
       exact: true,
       component: {
         $codeRef: 'ComponentSettings',
@@ -384,7 +395,7 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
-      path: '/stonesoup/environments/workspaces/:workspaceName',
+      path: '/application-pipeline/environments/workspaces/:workspaceName',
       exact: true,
       component: {
         $codeRef: 'EnvironmentsListPage',
@@ -397,7 +408,7 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
-      path: '/stonesoup/environments/workspaces/:workspaceName/create',
+      path: '/application-pipeline/environments/workspaces/:workspaceName/create',
       exact: true,
       component: {
         $codeRef: 'CreateEnvironment',
@@ -412,7 +423,7 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
-      path: '/stonesoup',
+      path: '/application-pipeline',
       exact: false,
       component: {
         $codeRef: 'NotFound',

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -12,7 +12,7 @@ Run `npm run start:prod:beta`, then `../node_modules/.bin/cypress run --env USER
 You can also use more variables - see the table below:
 | Environment Variable | Description | Default value | Example |
 | -- | -- | -- | -- |
-| `HAC_BASE_URL` | Base URL for testing | 'https://prod.foo.redhat.com:1337/beta/hac/stonesoup' | HAC_BASE_URL=https://prod.foo.redhat.com:1337/hac/stonesoup |
+| `HAC_BASE_URL` | Base URL for testing | 'https://prod.foo.redhat.com:1337/beta/hac/application-pipeline' | HAC_BASE_URL=https://prod.foo.redhat.com:1337/hac/application-pipeline |
 | `USERNAME` | Username for testing (SSO) | '' |  USERNAME=admin |
 | `PASSWORD` | Password for testing (SSO) | '' | PASSWORD=adminPassword |
 | `KUBECONFIG` | Kubeconfig for cleaning namespace | '/home/user/.kube/appstudio-config' | KUBECONFIG=/home/user/kube/config |

--- a/integration-tests/cypress.config.ts
+++ b/integration-tests/cypress.config.ts
@@ -117,7 +117,7 @@ export default defineConfig({
       });
 
       const defaultValues: { [key: string]: string | boolean } = {
-        HAC_BASE_URL: 'https://prod.foo.redhat.com:1337/beta/hac/stonesoup',
+        HAC_BASE_URL: 'https://prod.foo.redhat.com:1337/beta/hac/application-pipeline',
         USERNAME: '',
         PASSWORD: '',
         GH_USERNAME: 'hac-test',

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -64,7 +64,7 @@ COMMON_SETUP="-v $WORKSPACE/artifacts:/tmp/artifacts:Z \
     -v $PWD/integration-tests:/e2e:Z \
     -e CYPRESS_PR_CHECK=true \
     -e CYPRESS_GH_PR_LINK=${ghprbPullLink} \
-    -e CYPRESS_HAC_BASE_URL=https://${HOSTNAME}/hac/stonesoup \
+    -e CYPRESS_HAC_BASE_URL=https://${HOSTNAME}/hac/application-pipeline \
     -e CYPRESS_USERNAME=`echo ${B64_USER} | base64 -d` \
     -e CYPRESS_PASSWORD=`echo ${B64_PASS} | base64 -d` \
     -e CYPRESS_GH_PR_TITLE=${PR_TITLE} \

--- a/src/components/Activity/ActivityTab.tsx
+++ b/src/components/Activity/ActivityTab.tsx
@@ -17,7 +17,7 @@ export const ActivityTab: React.FC<{ applicationName?: string }> = ({ applicatio
     (newTab: string) => {
       if (activeTab !== newTab) {
         navigate(
-          `/stonesoup/workspaces/${workspace}/applications/${applicationName}/${parentTab}/${newTab}`,
+          `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/${parentTab}/${newTab}`,
         );
       }
     },

--- a/src/components/Activity/__tests__/ActivityTab.spec.tsx
+++ b/src/components/Activity/__tests__/ActivityTab.spec.tsx
@@ -54,7 +54,7 @@ describe('Activity Tab', () => {
       fireEvent.click(plrTab);
     });
     expect(navigateMock).toHaveBeenCalledWith(
-      '/stonesoup/workspaces/test-ws/applications/abcd/undefined/pipelineruns',
+      '/application-pipeline/workspaces/test-ws/applications/abcd/undefined/pipelineruns',
     );
   });
   it('should display the correct tab', async () => {

--- a/src/components/ApplicationDetails/ApplicationDetails.tsx
+++ b/src/components/ApplicationDetails/ApplicationDetails.tsx
@@ -104,7 +104,9 @@ const ApplicationDetails: React.FC<HacbsApplicationDetailsProps> = ({ applicatio
             key: 'add-component',
             label: 'Add component',
             component: (
-              <Link to={`/stonesoup/workspaces/${workspace}/import?application=${applicationName}`}>
+              <Link
+                to={`/application-pipeline/workspaces/${workspace}/import?application=${applicationName}`}
+              >
                 Add component
               </Link>
             ),
@@ -116,7 +118,7 @@ const ApplicationDetails: React.FC<HacbsApplicationDetailsProps> = ({ applicatio
             label: 'Add integration test',
             component: (
               <Link
-                to={`/stonesoup/workspaces/${workspace}/applications/${applicationName}/integrationtests/add`}
+                to={`/application-pipeline/workspaces/${workspace}/applications/${applicationName}/integrationtests/add`}
               >
                 Add integration test
               </Link>
@@ -128,7 +130,9 @@ const ApplicationDetails: React.FC<HacbsApplicationDetailsProps> = ({ applicatio
             key: 'create-environment',
             label: 'Create environment',
             component: (
-              <Link to={`/stonesoup/workspaces/${workspace}/workspace-settings/environment/create`}>
+              <Link
+                to={`/application-pipeline/workspaces/${workspace}/workspace-settings/environment/create`}
+              >
                 Create environment
               </Link>
             ),
@@ -161,13 +165,13 @@ const ApplicationDetails: React.FC<HacbsApplicationDetailsProps> = ({ applicatio
               showModal<{ submitClicked: boolean }>(
                 applicationDeleteModal(application),
               ).closed.then(({ submitClicked }) => {
-                if (submitClicked) navigate('/stonesoup/workspaces');
+                if (submitClicked) navigate('/application-pipeline/workspaces');
               }),
             isDisabled: !canDeleteApplication,
             disabledTooltip: "You don't have access to delete this application",
           },
         ]}
-        baseURL={`/stonesoup/workspaces/${workspace}/applications/${applicationName}`}
+        baseURL={`/application-pipeline/workspaces/${workspace}/applications/${applicationName}`}
         tabs={[
           {
             key: 'overview',

--- a/src/components/ApplicationDetails/ApplicationSwitcher.tsx
+++ b/src/components/ApplicationDetails/ApplicationSwitcher.tsx
@@ -28,7 +28,7 @@ export const ApplicationSwitcher: React.FC<{ selectedApplication?: string }> = (
 
   const onSelect = (item: ContextMenuItem) => {
     selectedItem.key !== item.key &&
-      navigate(`/stonesoup/workspaces/${workspace}/applications/${item.key}`);
+      navigate(`/application-pipeline/workspaces/${workspace}/applications/${item.key}`);
   };
 
   return menuItems.length > 1 ? (
@@ -43,7 +43,7 @@ export const ApplicationSwitcher: React.FC<{ selectedApplication?: string }> = (
             <ButtonWithAccessTooltip
               variant="link"
               component={(props) => (
-                <Link {...props} to={`/stonesoup/workspaces/${workspace}/import`} />
+                <Link {...props} to={`/application-pipeline/workspaces/${workspace}/import`} />
               )}
               isInline
               tooltip="You don't have access to create an application"
@@ -56,7 +56,10 @@ export const ApplicationSwitcher: React.FC<{ selectedApplication?: string }> = (
             <Button
               variant="link"
               component={(props) => (
-                <Link {...props} to={`/stonesoup/workspaces/${workspace}/applications`} />
+                <Link
+                  {...props}
+                  to={`/application-pipeline/workspaces/${workspace}/applications`}
+                />
               )}
               isInline
             >

--- a/src/components/ApplicationDetails/WorkspaceSwitcher.tsx
+++ b/src/components/ApplicationDetails/WorkspaceSwitcher.tsx
@@ -14,7 +14,7 @@ export const WorkspaceSwitcher: React.FC<{ selectedWorkspace?: string }> = () =>
   const selectedItem = workspaces.find((item) => item.metadata.name === workspace) || workspaces[0];
 
   const onSelect = (item: ContextMenuItem) => {
-    navigate(`/stonesoup/workspaces/${item.name}/applications`);
+    navigate(`/application-pipeline/workspaces/${item.name}/applications`);
     setWorkspace(item.name);
   };
 

--- a/src/components/ApplicationDetails/__tests__/ApplicationSwitcher.spec.tsx
+++ b/src/components/ApplicationDetails/__tests__/ApplicationSwitcher.spec.tsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import { act, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useApplications } from '../../../hooks/useApplications';
+import { useAccessReviewForModel } from '../../../utils/rbac';
+import { routerRenderer } from '../../../utils/test-utils';
+import { mockApplication } from '../__data__/mock-data';
+import { ApplicationSwitcher } from '../ApplicationSwitcher';
+
+jest.mock('../../../hooks', () => ({
+  useLocalStorage: jest.fn(() => [{}, jest.fn()]),
+}));
+
+jest.mock('../../../utils/workspace-context-utils', () => ({
+  useWorkspaceInfo: jest.fn(() => ({ workspace: 'test-ws' })),
+}));
+
+jest.mock('../../../utils/rbac', () => ({
+  useAccessReviewForModel: jest.fn(() => [true, true]),
+}));
+const useAccessReviewForModelMock = useAccessReviewForModel as jest.Mock;
+
+const navigateMock = jest.fn();
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+jest.mock('../../../hooks/useApplications', () => ({
+  useApplications: jest.fn(),
+}));
+const useApplicationsMock = useApplications as jest.Mock;
+
+const app1 = {
+  ...mockApplication,
+  metadata: { ...mockApplication.metadata, name: 'test-app-1', uuid: '1' },
+  spec: { ...mockApplication.spec, displayName: 'Test Application 1' },
+};
+const app2 = {
+  ...mockApplication,
+  metadata: { ...mockApplication.metadata, name: 'test-app-2', uuid: '2' },
+  spec: { ...mockApplication.spec, displayName: 'Test Application 2' },
+};
+const app3 = {
+  ...mockApplication,
+  metadata: { ...mockApplication.metadata, name: 'test-app-3', uuid: '3' },
+  spec: { ...mockApplication.spec, displayName: 'Test Application 3' },
+};
+
+describe('ContextSwitcher', () => {
+  beforeEach(() => {
+    useApplicationsMock.mockReturnValue([[app1, app2, app3], true]);
+    useAccessReviewForModelMock.mockReturnValue([true, true]);
+  });
+
+  it('should render application switcher component', () => {
+    const switcher = routerRenderer(<ApplicationSwitcher selectedApplication="test-app-1" />);
+    act(() => screen.getByRole('button').click());
+
+    expect(screen.getByPlaceholderText('Filter application by name')).toBeVisible();
+    expect(screen.getByText('Recent')).toBeVisible();
+    expect(screen.getByText('All')).toBeVisible();
+    expect(screen.queryByText('Create application')).toHaveAttribute('aria-disabled', 'false');
+    switcher.unmount();
+  });
+
+  it('should inform user when there is no access', () => {
+    useAccessReviewForModelMock.mockReturnValue([false, true]);
+    const switcher = routerRenderer(<ApplicationSwitcher selectedApplication="test-app-1" />);
+    act(() => screen.getByRole('button').click());
+
+    expect(screen.getByPlaceholderText('Filter application by name')).toBeVisible();
+    expect(screen.getByText('Recent')).toBeVisible();
+    expect(screen.getByText('All')).toBeVisible();
+    expect(screen.queryByText('Create application')).toHaveAttribute('aria-disabled', 'true');
+    switcher.unmount();
+  });
+
+  it('should show currently selected item', () => {
+    const switcher = routerRenderer(<ApplicationSwitcher selectedApplication="test-app-1" />);
+    act(() => screen.getByRole('button').click());
+
+    const selectedItem = screen.queryAllByRole('menuitem')[0];
+    expect(selectedItem).toBeVisible();
+    expect(selectedItem).toHaveClass('pf-m-selected');
+    switcher.unmount();
+  });
+
+  it('should navigate to the selected application', () => {
+    const switcher = routerRenderer(<ApplicationSwitcher selectedApplication="test-app-1" />);
+    act(() => screen.getByRole('button').click());
+
+    expect(screen.getByText('Test Application 2')).toBeVisible();
+    act(() => screen.getByText('Test Application 2').click());
+    expect(navigateMock).toHaveBeenCalledWith(
+      '/application-pipeline/workspaces/test-ws/applications/test-app-2',
+    );
+    expect(screen.queryByText('Test Application 2')).toBeNull();
+    switcher.unmount();
+  });
+});

--- a/src/components/ApplicationDetails/component-actions.tsx
+++ b/src/components/ApplicationDetails/component-actions.tsx
@@ -41,7 +41,7 @@ export const useComponentActions = (component: ComponentKind, name: string): Act
   actions.push(
     {
       cta: {
-        href: `/stonesoup/workspaces/${workspace}/applications/${applicationName}/component-settings?componentName=${name}`,
+        href: `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/component-settings?componentName=${name}`,
       },
       id: 'component-settings',
       label: 'Edit component settings',

--- a/src/components/ApplicationDetails/tabs/__tests__/__snapshots__/useWhatsNextItems.spec.ts.snap
+++ b/src/components/ApplicationDetails/tabs/__tests__/__snapshots__/useWhatsNextItems.spec.ts.snap
@@ -6,7 +6,7 @@ Array [
     "cta": Object {
       "disabled": false,
       "disabledTooltip": "You don't have access to add a component",
-      "href": "/stonesoup/workspaces/undefined/import?application=test-application",
+      "href": "/application-pipeline/workspaces/undefined/import?application=test-application",
       "label": "Add component",
     },
     "description": "Grow your application by adding components.",
@@ -27,7 +27,7 @@ Array [
   },
   Object {
     "cta": Object {
-      "href": "/stonesoup/workspaces/undefined/applications/test-application/activity",
+      "href": "/application-pipeline/workspaces/undefined/applications/test-application/activity",
       "label": "View build activity",
     },
     "description": "Make a change to your source code to automatically trigger a new build.",

--- a/src/components/ApplicationDetails/tabs/__tests__/useWhatsNextItems.spec.ts
+++ b/src/components/ApplicationDetails/tabs/__tests__/useWhatsNextItems.spec.ts
@@ -7,8 +7,11 @@ jest.mock('../../../../utils/workspace-context-utils', () => ({
   useWorkspaceInfo: jest.fn(() => ({ namespace: 'test-ns' })),
 }));
 
-jest.mock('../../../../hooks/useStoneSoupGitHubApp', () => ({
-  useStoneSoupGitHubApp: jest.fn(() => ({ name: 'test-app', url: 'https://github.com/test-app' })),
+jest.mock('../../../../hooks/useApplicationPipelineGitHubApp', () => ({
+  useApplicationPipelineGitHubApp: jest.fn(() => ({
+    name: 'test-app',
+    url: 'https://github.com/test-app',
+  })),
 }));
 
 jest.mock('../../../../utils/rbac', () => ({

--- a/src/components/ApplicationDetails/tabs/overview/sections/AppWorkflowSection.tsx
+++ b/src/components/ApplicationDetails/tabs/overview/sections/AppWorkflowSection.tsx
@@ -84,7 +84,7 @@ const AppWorkflowSection: React.FC<AppWorkflowSectionProps> = ({ applicationName
                 component={(props) => (
                   <Link
                     {...props}
-                    to={`/stonesoup/workspaces/${workspace}/import?application=${applicationName}`}
+                    to={`/application-pipeline/workspaces/${workspace}/import?application=${applicationName}`}
                   />
                 )}
                 tooltip="You don't have access to add a component"

--- a/src/components/ApplicationDetails/tabs/overview/sections/__tests__/AppWorkflowSection.spec.tsx
+++ b/src/components/ApplicationDetails/tabs/overview/sections/__tests__/AppWorkflowSection.spec.tsx
@@ -167,7 +167,7 @@ describe('useAppWorkflowData hook', () => {
 
     fireEvent.click(clickable);
     expect(mockNavigate).toHaveBeenCalledWith(
-      '/stonesoup/workspaces/test-ws/applications/test-dev-samples/components',
+      '/application-pipeline/workspaces/test-ws/applications/test-dev-samples/components',
     );
   });
   it('should navigate to the correct tab on a group node click', async () => {
@@ -182,7 +182,7 @@ describe('useAppWorkflowData hook', () => {
 
     fireEvent.click(clickable);
     expect(mockNavigate).toHaveBeenCalledWith(
-      '/stonesoup/workspaces/test-ws/applications/test-dev-samples/components',
+      '/application-pipeline/workspaces/test-ws/applications/test-dev-samples/components',
     );
   });
   it('should navigate to the correct tab on a node click', async () => {
@@ -198,7 +198,7 @@ describe('useAppWorkflowData hook', () => {
 
     fireEvent.click(clickable);
     expect(mockNavigate).toHaveBeenCalledWith(
-      `/stonesoup/workspaces/test-ws/applications/test-dev-samples/components?name=${mockComponentsData[0].metadata.name}`,
+      `/application-pipeline/workspaces/test-ws/applications/test-dev-samples/components?name=${mockComponentsData[0].metadata.name}`,
     );
   });
 });

--- a/src/components/ApplicationDetails/tabs/overview/visualization/utils/node-utils.ts
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/utils/node-utils.ts
@@ -105,7 +105,7 @@ export const getLinkDataForElement = (
     case WorkflowNodeType.APPLICATION_TEST:
       return !groupNode && !isDisabled
         ? {
-            path: `/stonesoup/workspaces/${workspace}/applications/${
+            path: `/application-pipeline/workspaces/${workspace}/applications/${
               element.getData().application
             }/integrationtests/${label}`,
           }
@@ -142,7 +142,7 @@ export const getLinksForElement = (
 ): { elementRef: string; pipelinesRef: string; appRef: string } => {
   const linkData = getLinkDataForElement(element, workspace);
 
-  const appPath = `/stonesoup/workspaces/${workspace}/applications/${
+  const appPath = `/application-pipeline/workspaces/${workspace}/applications/${
     element.getData().application
   }`;
   const tabPath = linkData.tab ? `/${linkData.tab}` : '';

--- a/src/components/ApplicationDetails/tabs/useWhatsNextItems.ts
+++ b/src/components/ApplicationDetails/tabs/useWhatsNextItems.ts
@@ -1,4 +1,4 @@
-import { useStoneSoupGitHubApp } from '../../../hooks/useStoneSoupGitHubApp';
+import { useApplicationPipelineGitHubApp } from '../../../hooks/useApplicationPipelineGitHubApp';
 import componentsIcon from '../../../imgs/illustrations/Components.svg';
 import editCodeIcon from '../../../imgs/illustrations/Edit code.svg';
 import githubAppIcon from '../../../imgs/illustrations/Github app.svg';
@@ -13,7 +13,7 @@ import { WhatsNextItem } from '../../WhatsNext/WhatsNextSection';
 export const useWhatsNextItems = (applicationName: string) => {
   const showModal = useModalLauncher();
   const { workspace, namespace } = useWorkspaceInfo();
-  const { url: githubAppURL } = useStoneSoupGitHubApp();
+  const { url: githubAppURL } = useApplicationPipelineGitHubApp();
   const [canCreateComponent] = useAccessReviewForModel(ComponentModel, 'create');
 
   const whatsNextItems: WhatsNextItem[] = [
@@ -23,7 +23,7 @@ export const useWhatsNextItems = (applicationName: string) => {
       icon: componentsIcon,
       cta: {
         label: 'Add component',
-        href: `/stonesoup/workspaces/${workspace}/import?application=${applicationName}`,
+        href: `/application-pipeline/workspaces/${workspace}/import?application=${applicationName}`,
         disabled: !canCreateComponent,
         disabledTooltip: "You don't have access to add a component",
       },
@@ -46,7 +46,7 @@ export const useWhatsNextItems = (applicationName: string) => {
       icon: editCodeIcon,
       cta: {
         label: 'View build activity',
-        href: `/stonesoup/workspaces/${workspace}/applications/${applicationName}/activity`,
+        href: `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/activity`,
       },
       helpId: 'stonesoup-whatsnext-make-code-change',
     },

--- a/src/components/ApplicationListView/ApplicationListRow.tsx
+++ b/src/components/ApplicationListView/ApplicationListRow.tsx
@@ -36,7 +36,7 @@ const ApplicationListRow: React.FC<RowFunctionArgs<ApplicationKind>> = ({ obj })
     <>
       <TableData className={applicationTableColumnClasses.name} data-testid="app-row-test-id">
         <Link
-          to={`/stonesoup/workspaces/${workspace}/applications/${obj.metadata.name}`}
+          to={`/application-pipeline/workspaces/${workspace}/applications/${obj.metadata.name}`}
           title={displayName}
         >
           {displayName}

--- a/src/components/ApplicationListView/ApplicationListView.tsx
+++ b/src/components/ApplicationListView/ApplicationListView.tsx
@@ -91,7 +91,7 @@ const ApplicationListView: React.FC = () => {
               <ButtonWithAccessTooltip
                 variant="primary"
                 component={(props) => (
-                  <Link {...props} to={`/stonesoup/workspaces/${workspace}/import`} />
+                  <Link {...props} to={`/application-pipeline/workspaces/${workspace}/import`} />
                 )}
                 isDisabled={!(canCreateApplication && canCreateComponent)}
                 tooltip="You don't have access to create an application"
@@ -107,7 +107,10 @@ const ApplicationListView: React.FC = () => {
                     <ButtonWithAccessTooltip
                       variant="primary"
                       component={(props) => (
-                        <Link {...props} to={`/stonesoup/workspaces/${workspace}/import`} />
+                        <Link
+                          {...props}
+                          to={`/application-pipeline/workspaces/${workspace}/import`}
+                        />
                       )}
                       isDisabled={!(canCreateApplication && canCreateComponent)}
                       tooltip="You don't have access to create an application"

--- a/src/components/ApplicationListView/__tests__/ApplicationListView.spec.tsx
+++ b/src/components/ApplicationListView/__tests__/ApplicationListView.spec.tsx
@@ -139,7 +139,9 @@ describe('Application List', () => {
     screen.getByText('Create and manage your applications');
     const button = screen.getByText('Create application');
     expect(button).toBeInTheDocument();
-    expect(button.closest('a').href).toBe('http://localhost/stonesoup/workspaces/test-ws/import');
+    expect(button.closest('a').href).toBe(
+      'http://localhost/application-pipeline/workspaces/test-ws/import',
+    );
   });
 
   it('should render empty state with no card', () => {

--- a/src/components/Commits/CommitDetails/CommitDetailsView.tsx
+++ b/src/components/Commits/CommitDetails/CommitDetailsView.tsx
@@ -72,11 +72,11 @@ const CommitDetailsView: React.FC<CommitDetailsViewProps> = ({ commitName, appli
         breadcrumbs={[
           ...applicationBreadcrumbs,
           {
-            path: `/stonesoup/workspaces/${workspace}/applications/${applicationName}/activity/latest-commits`,
+            path: `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/activity/latest-commits`,
             name: 'commits',
           },
           {
-            path: `/stonesoup/workspaces/${workspace}/applications/${applicationName}/commit/${commitName}`,
+            path: `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/commit/${commitName}`,
             name: commitDisplayName,
           },
         ]}
@@ -96,7 +96,7 @@ const CommitDetailsView: React.FC<CommitDetailsViewProps> = ({ commitName, appli
             onClick: () => window.open(commit.shaURL),
           },
         ]}
-        baseURL={`/stonesoup/workspaces/${workspace}/applications/${applicationName}/commit/${commitName}`}
+        baseURL={`/application-pipeline/workspaces/${workspace}/applications/${applicationName}/commit/${commitName}`}
         tabs={[
           {
             key: 'details',

--- a/src/components/Commits/CommitDetails/sidepanels/BuildSidePanel.tsx
+++ b/src/components/Commits/CommitDetails/sidepanels/BuildSidePanel.tsx
@@ -53,7 +53,7 @@ const BuildSidePanel: React.FC<PipelineSidePanelBodyProps> = ({ workflowNode, on
         <DrawerHead data-testid="build-side-panel-head">
           <span className="commit-side-panel__head-title">
             <Link
-              to={`/stonesoup/workspaces/${workspace}/applications/${workflowData.application}/pipelineruns/${pipelineRun.metadata.name}`}
+              to={`/application-pipeline/workspaces/${workspace}/applications/${workflowData.application}/pipelineruns/${pipelineRun.metadata.name}`}
             >
               {pipelineRun.metadata.name}
             </Link>
@@ -107,7 +107,7 @@ const BuildSidePanel: React.FC<PipelineSidePanelBodyProps> = ({ workflowNode, on
                 {pipelineRun.metadata?.labels?.[PipelineRunLabel.COMPONENT] ? (
                   pipelineRun.metadata?.labels?.[PipelineRunLabel.APPLICATION] ? (
                     <Link
-                      to={`/stonesoup/workspaces/${workspace}/applications/${
+                      to={`/application-pipeline/workspaces/${workspace}/applications/${
                         pipelineRun.metadata.labels[PipelineRunLabel.APPLICATION]
                       }/components?name=${pipelineRun.metadata.labels[PipelineRunLabel.COMPONENT]}`}
                     >
@@ -125,7 +125,7 @@ const BuildSidePanel: React.FC<PipelineSidePanelBodyProps> = ({ workflowNode, on
             <DescriptionListGroup>
               <DescriptionListDescription>
                 <Link
-                  to={`/stonesoup/workspaces/${workspace}/applications/${workflowData.application}/pipelineruns/${pipelineRun.metadata.name}/logs`}
+                  to={`/application-pipeline/workspaces/${workspace}/applications/${workflowData.application}/pipelineruns/${pipelineRun.metadata.name}/logs`}
                 >
                   View logs
                 </Link>

--- a/src/components/Commits/CommitDetails/sidepanels/CommitSidePanel.tsx
+++ b/src/components/Commits/CommitDetails/sidepanels/CommitSidePanel.tsx
@@ -97,7 +97,7 @@ const CommitSidePanel: React.FC<CommitSidePanelBodyProps> = ({ workflowNode, onC
                 return (
                   <React.Fragment key={component}>
                     <Link
-                      to={`/stonesoup/workspaces/${workspace}/applications/${workflowData.application}/components?name=${component}`}
+                      to={`/application-pipeline/workspaces/${workspace}/applications/${workflowData.application}/components?name=${component}`}
                     >
                       {component}
                     </Link>

--- a/src/components/Commits/CommitDetails/sidepanels/IntegrationTestSidePanel.tsx
+++ b/src/components/Commits/CommitDetails/sidepanels/IntegrationTestSidePanel.tsx
@@ -62,7 +62,7 @@ const IntegrationTestSidePanel: React.FC<IntegrationTestSidePanelBodyProps> = ({
           <span className="commit-side-panel__head-title">
             {integrationTestPipeline ? (
               <Link
-                to={`/stonesoup/workspaces/${workspace}/applications/${
+                to={`/application-pipeline/workspaces/${workspace}/applications/${
                   workflowData.application
                 }/integrationtests/${workflowNode.getLabel()}`}
               >
@@ -123,7 +123,7 @@ const IntegrationTestSidePanel: React.FC<IntegrationTestSidePanelBodyProps> = ({
                 {integrationTestPipeline?.metadata?.labels?.[PipelineRunLabel.COMPONENT] ? (
                   integrationTestPipeline?.metadata?.labels?.[PipelineRunLabel.APPLICATION] ? (
                     <Link
-                      to={`/stonesoup/workspaces/${workspace}/applications/${
+                      to={`/application-pipeline/workspaces/${workspace}/applications/${
                         integrationTestPipeline.metadata.labels[PipelineRunLabel.APPLICATION]
                       }/components?name=${
                         integrationTestPipeline.metadata.labels[PipelineRunLabel.COMPONENT]
@@ -170,7 +170,7 @@ const IntegrationTestSidePanel: React.FC<IntegrationTestSidePanelBodyProps> = ({
                       component={(props) => (
                         <Link
                           {...props}
-                          to={`/stonesoup/workspaces/${workspace}/applications/${workflowData.application}/pipelineruns/${integrationTestPipeline.metadata?.name}/logs`}
+                          to={`/application-pipeline/workspaces/${workspace}/applications/${workflowData.application}/pipelineruns/${integrationTestPipeline.metadata?.name}/logs`}
                         />
                       )}
                     >

--- a/src/components/Commits/CommitDetails/sidepanels/ManagedEnvironmentSidePanel.tsx
+++ b/src/components/Commits/CommitDetails/sidepanels/ManagedEnvironmentSidePanel.tsx
@@ -61,7 +61,7 @@ const ManagedEnvironmentSidePanel: React.FC<ManagedEnvironmentSidePanelBodyProps
             <DescriptionListGroup>
               <DescriptionListDescription>
                 <Link
-                  to={`/stonesoup/workspaces/${workspace}/applications/${workflowData.application}/environments`}
+                  to={`/application-pipeline/workspaces/${workspace}/applications/${workflowData.application}/environments`}
                 >
                   View environments
                 </Link>

--- a/src/components/Commits/CommitDetails/sidepanels/ReleaseSidePanel.tsx
+++ b/src/components/Commits/CommitDetails/sidepanels/ReleaseSidePanel.tsx
@@ -56,7 +56,7 @@ const ReleaseSidePanel: React.FC<ReleaseSidePanelBodyProps> = ({ workflowNode, o
             <DescriptionListGroup>
               <DescriptionListDescription>
                 <Link
-                  to={`/stonesoup/workspaces/${workspace}/applications/${workflowData.application}/activity/pipelineruns`}
+                  to={`/application-pipeline/workspaces/${workspace}/applications/${workflowData.application}/activity/pipelineruns`}
                 >
                   View pipeline runs
                 </Link>

--- a/src/components/Commits/CommitsEmptyState.tsx
+++ b/src/components/Commits/CommitsEmptyState.tsx
@@ -32,7 +32,7 @@ const CommitsEmptyState: React.FC<CommitsEmptyStateProps> = ({ applicationName }
           component={(props) => (
             <Link
               {...props}
-              to={`/stonesoup/workspaces/${workspace}/import?application=${applicationName}`}
+              to={`/application-pipeline/workspaces/${workspace}/import?application=${applicationName}`}
             />
           )}
           variant="secondary"

--- a/src/components/Commits/CommitsListRow.tsx
+++ b/src/components/Commits/CommitsListRow.tsx
@@ -27,7 +27,7 @@ const CommitsListRow: React.FC<RowFunctionArgs<Commit>> = ({ obj }) => {
       <TableData className={commitsTableColumnClasses.name}>
         <CommitIcon isPR={obj.isPullRequest} className="sha-title-icon" />
         <Link
-          to={`/stonesoup/workspaces/${workspace}/applications/${obj.application}/commit/${obj.sha}`}
+          to={`/application-pipeline/workspaces/${workspace}/applications/${obj.application}/commit/${obj.sha}`}
         >
           {prNumber} {obj.shaTitle}
         </Link>

--- a/src/components/Commits/CommitsListView.tsx
+++ b/src/components/Commits/CommitsListView.tsx
@@ -212,7 +212,7 @@ const CommitsListView: React.FC<CommitsListViewProps> = ({
                   variant="secondary"
                   onClick={() =>
                     navigate(
-                      `/stonesoup/workspaces/${workspace}/applications/${applicationName}/activity/latest-commits`,
+                      `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/activity/latest-commits`,
                     )
                   }
                 >

--- a/src/components/Commits/__tests__/CommitsListView.spec.tsx
+++ b/src/components/Commits/__tests__/CommitsListView.spec.tsx
@@ -88,7 +88,7 @@ describe('CommitsListView', () => {
     const addButton = screen.queryByText('Add component');
     expect(addButton).toBeInTheDocument();
     expect(addButton.closest('a').href).toContain(
-      `http://localhost/stonesoup/workspaces/test-ws/import?application=purple-mermaid-app`,
+      `http://localhost/application-pipeline/workspaces/test-ws/import?application=purple-mermaid-app`,
     );
   });
 
@@ -123,7 +123,7 @@ describe('CommitsListView', () => {
     render(<CommitsListView applicationName="purple-mermaid-app" recentOnly />);
     fireEvent.click(screen.getByText('View More'));
     expect(navigate).toHaveBeenCalledWith(
-      `/stonesoup/workspaces/test-ws/applications/purple-mermaid-app/activity/latest-commits`,
+      `/application-pipeline/workspaces/test-ws/applications/purple-mermaid-app/activity/latest-commits`,
     );
   });
 

--- a/src/components/Commits/tabs/__tests__/CommitsPipelineRunTab.spec.tsx
+++ b/src/components/Commits/tabs/__tests__/CommitsPipelineRunTab.spec.tsx
@@ -65,7 +65,7 @@ describe('Commit Pipelinerun List', () => {
     const button = screen.getByText('Add component');
     expect(button).toBeInTheDocument();
     expect(button.closest('a').href).toContain(
-      `http://localhost/stonesoup/workspaces/test-ws/import?application=my-test-app`,
+      `http://localhost/application-pipeline/workspaces/test-ws/import?application=my-test-app`,
     );
   });
 

--- a/src/components/ComponentSettingsForm/ComponentSettingsForm.tsx
+++ b/src/components/ComponentSettingsForm/ComponentSettingsForm.tsx
@@ -39,7 +39,7 @@ const ComponentSettingsForm: React.FunctionComponent<FormikProps<FormikValues>> 
       breadcrumbs={[
         ...applicationBreadcrumbs,
         {
-          path: `/stonesoup/workspaces/${workspace}/applications/${components[0].componentStub.application}/components`,
+          path: `/application-pipeline/workspaces/${workspace}/applications/${components[0].componentStub.application}/components`,
           name: components[0].componentStub.componentName,
         },
         { path: '#', name: 'Component settings' },

--- a/src/components/ComponentSettingsForm/ComponentSettingsView.tsx
+++ b/src/components/ComponentSettingsForm/ComponentSettingsView.tsx
@@ -75,7 +75,9 @@ const ComponentSettingsView: React.FunctionComponent<ComponentSettingsViewProps>
       'update',
     )
       .then(() => {
-        navigate(`/stonesoup/workspaces/${workspace}/applications/${applicationName}/components`);
+        navigate(
+          `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/components`,
+        );
       })
       .catch((error) => {
         // eslint-disable-next-line no-console

--- a/src/components/Components/ComponentListView.tsx
+++ b/src/components/Components/ComponentListView.tsx
@@ -225,7 +225,7 @@ const ComponentListView: React.FC<ComponentListViewProps> = ({ applicationName }
                         <Link
                           {...p}
                           data-test="add-component-button"
-                          to={`/stonesoup/workspaces/${workspace}/import?application=${applicationName}`}
+                          to={`/application-pipeline/workspaces/${workspace}/import?application=${applicationName}`}
                         />
                       )}
                       isDisabled={!canCreateComponent}
@@ -326,7 +326,7 @@ const ComponentListView: React.FC<ComponentListViewProps> = ({ applicationName }
                 component={(props) => (
                   <Link
                     {...props}
-                    to={`/stonesoup/workspaces/${workspace}/import?application=${applicationName}`}
+                    to={`/application-pipeline/workspaces/${workspace}/import?application=${applicationName}`}
                   />
                 )}
                 isDisabled={!canCreateComponent}

--- a/src/components/Components/__tests__/ComponentListView.spec.tsx
+++ b/src/components/Components/__tests__/ComponentListView.spec.tsx
@@ -117,7 +117,7 @@ describe('ComponentListViewPage', () => {
     const button = screen.getByText('Add component');
     expect(button).toBeInTheDocument();
     expect(button.closest('a').href).toBe(
-      'http://localhost/stonesoup/workspaces/test-ws/import?application=test-app',
+      'http://localhost/application-pipeline/workspaces/test-ws/import?application=test-app',
     );
   });
 

--- a/src/components/CustomizedPipeline/CustomizeAllPipelines.tsx
+++ b/src/components/CustomizedPipeline/CustomizeAllPipelines.tsx
@@ -46,7 +46,7 @@ const CustomizeAllPipelines: React.FC<Props> = ({
           component={(props) => (
             <Link
               {...props}
-              to={`/stonesoup/workspaces/${workspace}/import?application=${applicationName}`}
+              to={`/application-pipeline/workspaces/${workspace}/import?application=${applicationName}`}
             />
           )}
           isDisabled={!canCreateComponent}

--- a/src/components/CustomizedPipeline/CustomizePipelines.tsx
+++ b/src/components/CustomizedPipeline/CustomizePipelines.tsx
@@ -18,8 +18,8 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import { Tbody, Thead, Th, Tr, Td, TableComposable } from '@patternfly/react-table';
+import { useApplicationPipelineGitHubApp } from '../../hooks/useApplicationPipelineGitHubApp';
 import { PACState } from '../../hooks/usePACState';
-import { useStoneSoupGitHubApp } from '../../hooks/useStoneSoupGitHubApp';
 import sendIconUrl from '../../imgs/send.svg';
 import successIconUrl from '../../imgs/success.svg';
 import { ComponentModel } from '../../models';
@@ -68,7 +68,7 @@ const Row: React.FC<{
   component: ComponentKind;
   onStateChange: (state: PACState) => void;
 }> = ({ component, onStateChange }) => {
-  const { url: githubAppURL } = useStoneSoupGitHubApp();
+  const { url: githubAppURL } = useApplicationPipelineGitHubApp();
   const [pacState, setPacState] = React.useState<PACState>(PACState.loading);
   const onComponentStateChange = React.useCallback(
     (state) => {
@@ -221,7 +221,7 @@ const Row: React.FC<{
 };
 
 const CustomizePipeline: React.FC<Props> = ({ components, onClose }) => {
-  const { url: githubAppURL } = useStoneSoupGitHubApp();
+  const { url: githubAppURL } = useApplicationPipelineGitHubApp();
   const sortedComponents = React.useMemo(
     () => [...components].sort((a, b) => a.metadata.name.localeCompare(b.metadata.name)),
     [components],

--- a/src/components/CustomizedPipeline/__tests__/CustomizeAllPipelines.spec.tsx
+++ b/src/components/CustomizedPipeline/__tests__/CustomizeAllPipelines.spec.tsx
@@ -9,8 +9,11 @@ jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   getActiveWorkspace: jest.fn(() => 'test-ws'),
 }));
 
-jest.mock('../../../hooks/useStoneSoupGitHubApp', () => ({
-  useStoneSoupGitHubApp: jest.fn(() => ({ name: 'test-app', url: 'https://github.com/test-app' })),
+jest.mock('../../../hooks/useApplicationPipelineGitHubApp', () => ({
+  useApplicationPipelineGitHubApp: jest.fn(() => ({
+    name: 'test-app',
+    url: 'https://github.com/test-app',
+  })),
 }));
 
 jest.mock('react-router-dom', () => ({

--- a/src/components/CustomizedPipeline/__tests__/CustomizeComponentPipeline.spec.tsx
+++ b/src/components/CustomizedPipeline/__tests__/CustomizeComponentPipeline.spec.tsx
@@ -10,8 +10,11 @@ jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   getActiveWorkspace: jest.fn(() => 'test-ws'),
 }));
 
-jest.mock('../../../hooks/useStoneSoupGitHubApp', () => ({
-  useStoneSoupGitHubApp: jest.fn(() => ({ name: 'test-app', url: 'https://github.com/test-app' })),
+jest.mock('../../../hooks/useApplicationPipelineGitHubApp', () => ({
+  useApplicationPipelineGitHubApp: jest.fn(() => ({
+    name: 'test-app',
+    url: 'https://github.com/test-app',
+  })),
 }));
 
 jest.mock('../../../utils/rbac', () => ({

--- a/src/components/CustomizedPipeline/__tests__/CustomizePipeline.spec.tsx
+++ b/src/components/CustomizedPipeline/__tests__/CustomizePipeline.spec.tsx
@@ -13,8 +13,11 @@ jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   getActiveWorkspace: jest.fn(() => 'test-ws'),
 }));
 
-jest.mock('../../../hooks/useStoneSoupGitHubApp', () => ({
-  useStoneSoupGitHubApp: jest.fn(() => ({ name: 'test-app', url: 'https://github.com/test-app' })),
+jest.mock('../../../hooks/useApplicationPipelineGitHubApp', () => ({
+  useApplicationPipelineGitHubApp: jest.fn(() => ({
+    name: 'test-app',
+    url: 'https://github.com/test-app',
+  })),
 }));
 
 jest.mock('../../../utils/rbac', () => ({

--- a/src/components/EmptyState/ErrorEmptyState.tsx
+++ b/src/components/EmptyState/ErrorEmptyState.tsx
@@ -31,7 +31,10 @@ export const NotFoundEmptyState: React.FC<{ className?: string }> = ({ className
       <EmptyStateBody>
         {`Looks like that page doesn't exist. Let's get you back to your applications list.`}
       </EmptyStateBody>
-      <Button variant={ButtonVariant.primary} onClick={() => navigate('/stonesoup/workspaces')}>
+      <Button
+        variant={ButtonVariant.primary}
+        onClick={() => navigate('/application-pipeline/workspaces')}
+      >
         Go to applications list
       </Button>
     </EmptyState>

--- a/src/components/EmptyState/SecurityTabEmptyState.tsx
+++ b/src/components/EmptyState/SecurityTabEmptyState.tsx
@@ -39,7 +39,7 @@ const SecurityTabEmptyState: React.FC<Omit<EmptyStateProps, 'children'>> = ({ ..
           variant={ButtonVariant.primary}
           onClick={() =>
             navigate(
-              `/stonesoup/workspaces/${workspaceName}/applications/${appName}/pipelineruns/${plrName}`,
+              `/application-pipeline/workspaces/${workspaceName}/applications/${appName}/pipelineruns/${plrName}`,
             )
           }
         >

--- a/src/components/EmptyState/__tests__/ErrorEmptyState.spec.tsx
+++ b/src/components/EmptyState/__tests__/ErrorEmptyState.spec.tsx
@@ -39,7 +39,7 @@ describe('ErrorEmptyState', () => {
     await act(async () => {
       fireEvent.click(appsButton);
     });
-    expect(navigateMock).toHaveBeenCalledWith('/stonesoup/workspaces');
+    expect(navigateMock).toHaveBeenCalledWith('/application-pipeline/workspaces');
   });
 
   it('Should show title and body on non-404 errors', async () => {

--- a/src/components/EnterpriseContractView/EnterpriseContractTable/EnterpriseContractRow.tsx
+++ b/src/components/EnterpriseContractView/EnterpriseContractTable/EnterpriseContractRow.tsx
@@ -84,7 +84,9 @@ export const EnterpriseContractRow: React.FC<EnterpriseContractRowType> = ({ dat
         <Td>{getRuleStatus(data.status)}</Td>
         <Td>{data.timestamp ? <Timestamp timestamp={data.timestamp} /> : '-'}</Td>
         <Td>
-          <Link to={`/stonesoup/workspaces/${workspace}/applications/${appName}/components`}>
+          <Link
+            to={`/application-pipeline/workspaces/${workspace}/applications/${appName}/components`}
+          >
             {data.component}
           </Link>
         </Td>

--- a/src/components/EnterpriseContractView/__data__/mockEnterpriseContractPolicies.ts
+++ b/src/components/EnterpriseContractView/__data__/mockEnterpriseContractPolicies.ts
@@ -30,7 +30,7 @@ export const MockEnterpriseContractPolicies = {
           fullName: 'policy.pipeline.required_tasks',
           title: 'Required tasks',
           description:
-            'Stonesoup expects that certain tests are going to be run during image builds.\nThis package includes some rules to confirm that the pipeline definition\nincludes the Tekton tasks to run those required tests.',
+            'Application pipline expects that certain tests are going to be run during image builds.\nThis package includes some rules to confirm that the pipeline definition\nincludes the Tekton tasks to run those required tests.',
         },
         shortName: 'required_tasks',
         title: 'Pipeline does not include all required check tasks',

--- a/src/components/Environment/EnvironmentList.tsx
+++ b/src/components/Environment/EnvironmentList.tsx
@@ -64,7 +64,10 @@ const EnvironmentList: React.FC<EnvironmentListProps> = ({
     return (
       <ButtonWithAccessTooltip
         component={(props) => (
-          <Link {...props} to={`/stonesoup/environments/workspaces/${workspace}/create`} />
+          <Link
+            {...props}
+            to={`/application-pipeline/environments/workspaces/${workspace}/create`}
+          />
         )}
         isDisabled={!canCreateEnvironment}
         tooltip="You don't have access to create an environment"

--- a/src/components/Environment/create/CreateEnvironment.tsx
+++ b/src/components/Environment/create/CreateEnvironment.tsx
@@ -21,7 +21,7 @@ const CreateEnvironment: React.FC = () => {
     (values: CreateEnvironmentFormValues, actions) => {
       createEnvironment(values, namespace, true)
         .then(() => createEnvironment(values, namespace))
-        .then(() => navigate(`/stonesoup/environments/workspaces/${workspace}`))
+        .then(() => navigate(`/application-pipeline/environments/workspaces/${workspace}`))
         .catch((error) => {
           // eslint-disable-next-line no-console
           console.warn('Error while submitting import form:', error);

--- a/src/components/Environment/create/__tests__/CreateEnvironment.spec.tsx
+++ b/src/components/Environment/create/__tests__/CreateEnvironment.spec.tsx
@@ -158,7 +158,9 @@ describe('CreateEnvironment', () => {
     const submitButton = screen.getByRole('button', { name: 'Create environment' });
     fireEvent.click(submitButton);
     await waitFor(() =>
-      expect(navigateMock).toHaveBeenCalledWith('/stonesoup/environments/workspaces/test-ws'),
+      expect(navigateMock).toHaveBeenCalledWith(
+        '/application-pipeline/environments/workspaces/test-ws',
+      ),
     );
   });
 
@@ -166,6 +168,8 @@ describe('CreateEnvironment', () => {
     render(<CreateEnvironment />);
     const cancelButton = screen.getByText('Cancel');
     fireEvent.click(cancelButton);
-    expect(navigateMock).toHaveBeenCalledWith('/stonesoup/environments/workspaces/test-ws');
+    expect(navigateMock).toHaveBeenCalledWith(
+      '/application-pipeline/environments/workspaces/test-ws',
+    );
   });
 });

--- a/src/components/ImportForm/ImportForm.tsx
+++ b/src/components/ImportForm/ImportForm.tsx
@@ -45,7 +45,7 @@ const ImportForm: React.FunctionComponent<ImportFormProps> = ({ applicationName 
       return createResources(values, strategy)
         .then(({ applicationName: appName, componentNames }) => {
           const doNavigate = () =>
-            navigate(`/stonesoup/workspaces/${workspace}/applications/${appName}`);
+            navigate(`/application-pipeline/workspaces/${workspace}/applications/${appName}`);
           if (values.pipelinesascode === 'automatic') {
             showModal(
               createCustomizeAllPipelinesModalLauncher(

--- a/src/components/ImportForm/__tests__/ImportForm.spec.tsx
+++ b/src/components/ImportForm/__tests__/ImportForm.spec.tsx
@@ -83,7 +83,9 @@ describe('ImportForm', () => {
     await waitFor(() => {
       wizardProps.onSubmit({ ...wizardProps.initialValues, application: 'my-app' }, {} as any);
     });
-    expect(navigateMock).toHaveBeenCalledWith('/stonesoup/workspaces/test-ws/applications/my-app');
+    expect(navigateMock).toHaveBeenCalledWith(
+      '/application-pipeline/workspaces/test-ws/applications/my-app',
+    );
   });
 
   it('should warn the users about the errors on form submit', async () => {

--- a/src/components/IntegrationTest/IntegrationTestDetailsView.tsx
+++ b/src/components/IntegrationTest/IntegrationTestDetailsView.tsx
@@ -60,11 +60,11 @@ const IntegrationTestDetailsView: React.FC<IntegrationTestDetailsViewProps> = ({
         breadcrumbs={[
           ...applicationBreadcrumbs,
           {
-            path: `/stonesoup/workspaces/${workspace}/applications/${applicationName}/integrationtests`,
+            path: `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/integrationtests`,
             name: 'Integration tests',
           },
           {
-            path: `/stonesoup/workspaces/${workspace}/applications/${applicationName}/integrationtests/${testName}`,
+            path: `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/integrationtests/${testName}`,
             name: integrationTest.metadata.name,
           },
         ]}
@@ -79,7 +79,7 @@ const IntegrationTestDetailsView: React.FC<IntegrationTestDetailsViewProps> = ({
             label: 'Edit',
             component: (
               <Link
-                to={`/stonesoup/workspaces/${workspace}/applications/${applicationName}/integrationtests/${testName}/edit`}
+                to={`/application-pipeline/workspaces/${workspace}/applications/${applicationName}/integrationtests/${testName}/edit`}
               >
                 Edit
               </Link>
@@ -94,7 +94,7 @@ const IntegrationTestDetailsView: React.FC<IntegrationTestDetailsViewProps> = ({
               ).closed.then(({ submitClicked }) => {
                 if (submitClicked)
                   navigate(
-                    `/stonesoup/workspaces/${workspace}/applications/${applicationName}/integrationtests`,
+                    `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/integrationtests`,
                   );
               }),
             key: `delete-${integrationTest.metadata.name.toLowerCase()}`,
@@ -103,7 +103,7 @@ const IntegrationTestDetailsView: React.FC<IntegrationTestDetailsViewProps> = ({
             disabledTooltip: "You don't have access to delete this integration test",
           },
         ]}
-        baseURL={`/stonesoup/workspaces/${workspace}/applications/${applicationName}/integrationtests/${testName}`}
+        baseURL={`/application-pipeline/workspaces/${workspace}/applications/${applicationName}/integrationtests/${testName}`}
         tabs={[
           {
             key: 'overview',

--- a/src/components/IntegrationTest/IntegrationTestForm/IntegrationTestForm.tsx
+++ b/src/components/IntegrationTest/IntegrationTestForm/IntegrationTestForm.tsx
@@ -40,7 +40,7 @@ const IntegrationTestForm: React.FunctionComponent<IntegrationTestFormProps> = (
       breadcrumbs={[
         ...applicationBreadcrumbs,
         {
-          path: `/stonesoup/workspaces/${workspace}/applications/${applicationName}/integrationtests`,
+          path: `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/integrationtests`,
           name: 'Integration tests',
         },
         { path: '#', name: title },

--- a/src/components/IntegrationTest/IntegrationTestForm/IntegrationTestView.tsx
+++ b/src/components/IntegrationTest/IntegrationTestForm/IntegrationTestView.tsx
@@ -44,12 +44,12 @@ const IntegrationTestView: React.FunctionComponent<IntegrationTestViewProps> = (
             navigate(-1);
           } else {
             navigate(
-              `/stonesoup/workspaces/${workspace}/applications/${applicationName}/integrationtests/${integrationTest.metadata.name}`,
+              `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/integrationtests/${integrationTest.metadata.name}`,
             );
           }
         } else {
           navigate(
-            `/stonesoup/workspaces/${workspace}/applications/${applicationName}/integrationtests`,
+            `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/integrationtests`,
           );
         }
       })

--- a/src/components/IntegrationTest/IntegrationTestForm/__tests__/IntegrationTestView.spec.tsx
+++ b/src/components/IntegrationTest/IntegrationTestForm/__tests__/IntegrationTestView.spec.tsx
@@ -146,7 +146,7 @@ describe('IntegrationTestView', () => {
     await waitFor(() => expect(createIntegrationTestMock).toHaveBeenCalledTimes(1));
     await waitFor(() =>
       expect(navigateMock).toHaveBeenCalledWith(
-        '/stonesoup/workspaces/test-ws/applications/test-app/integrationtests',
+        '/application-pipeline/workspaces/test-ws/applications/test-app/integrationtests',
       ),
     );
   });

--- a/src/components/IntegrationTest/IntegrationTestsListView/IntegrationTestListRow.tsx
+++ b/src/components/IntegrationTest/IntegrationTestsListView/IntegrationTestListRow.tsx
@@ -22,7 +22,7 @@ const IntegrationTestListRow: React.FC<RowFunctionArgs<IntegrationTestScenarioKi
         data-test="integration-tests__row-name"
       >
         <Link
-          to={`/stonesoup/workspaces/${workspace}/applications/${obj.spec.application}/integrationtests/${obj.metadata.name}`}
+          to={`/application-pipeline/workspaces/${workspace}/applications/${obj.spec.application}/integrationtests/${obj.metadata.name}`}
         >
           {obj.metadata.name}
         </Link>

--- a/src/components/IntegrationTest/IntegrationTestsListView/IntegrationTestsListView.tsx
+++ b/src/components/IntegrationTest/IntegrationTestsListView/IntegrationTestsListView.tsx
@@ -101,7 +101,7 @@ const IntegrationTestsListView: React.FC<IntegrationTestsListViewProps> = ({ app
 
   const handleAddTest = React.useCallback(() => {
     navigate(
-      `/stonesoup/workspaces/${workspace}/applications/${applicationName}/integrationtests/add`,
+      `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/integrationtests/add`,
     );
   }, [navigate, applicationName, workspace]);
 

--- a/src/components/IntegrationTest/IntegrationTestsListView/__tests__/IntegrationTestsListView.spec.tsx
+++ b/src/components/IntegrationTest/IntegrationTestsListView/__tests__/IntegrationTestsListView.spec.tsx
@@ -80,7 +80,7 @@ describe('IntegrationTestsListView', () => {
 
     await waitFor(() =>
       expect(navigateMock).toHaveBeenCalledWith(
-        '/stonesoup/workspaces/test-ws/applications/test-app/integrationtests/add',
+        '/application-pipeline/workspaces/test-ws/applications/test-app/integrationtests/add',
       ),
     );
   });

--- a/src/components/IntegrationTest/IntegrationTestsListView/useIntegrationTestActions.tsx
+++ b/src/components/IntegrationTest/IntegrationTestsListView/useIntegrationTestActions.tsx
@@ -42,7 +42,7 @@ export const useIntegrationTestActions = (
       id: `edit-${integrationTest.metadata.name.toLowerCase()}`,
       label: 'Edit',
       cta: {
-        href: `/stonesoup/workspaces/${workspace}/applications/${integrationTest.spec.application}/integrationtests/${integrationTest.metadata.name}/edit`,
+        href: `/application-pipeline/workspaces/${workspace}/applications/${integrationTest.spec.application}/integrationtests/${integrationTest.metadata.name}/edit`,
       },
       disabled: !canUpdateIntegrationTest,
       disabledTooltip: "You don't have access to edit this integration test",

--- a/src/components/IntegrationTest/tabs/IntegrationTestOverviewTab.tsx
+++ b/src/components/IntegrationTest/tabs/IntegrationTestOverviewTab.tsx
@@ -107,7 +107,7 @@ const IntegrationTestOverviewTab: React.FC<IntegrationTestOverviewTabProps> = ({
                 <DescriptionListTerm>Application</DescriptionListTerm>
                 <DescriptionListDescription>
                   <Link
-                    to={`/stonesoup/workspaces/${workspace}/applications/${integrationTest.spec.application}`}
+                    to={`/application-pipeline/workspaces/${workspace}/applications/${integrationTest.spec.application}`}
                   >
                     {integrationTest.spec.application}
                   </Link>

--- a/src/components/IntegrationTest/tabs/__tests__/IntegrationTestOverviewTab.spec.tsx
+++ b/src/components/IntegrationTest/tabs/__tests__/IntegrationTestOverviewTab.spec.tsx
@@ -22,7 +22,7 @@ describe('IntegrationTestOverviewTab', () => {
       'https://quay.io/test-rep/test-bundle:test-1',
     ); // image bundle
     expect(screen.getAllByRole('link')[1].getAttribute('href')).toBe(
-      '/stonesoup/workspaces/test-ws/applications/test-app',
+      '/application-pipeline/workspaces/test-ws/applications/test-app',
     ); // application link
   });
 
@@ -36,7 +36,7 @@ describe('IntegrationTestOverviewTab', () => {
       'https://quay.io/test-rep/test-bundle:test-2',
     ); // image bundle
     expect(screen.getAllByRole('link')[1].getAttribute('href')).toBe(
-      '/stonesoup/workspaces/test-ws/applications/test-app',
+      '/application-pipeline/workspaces/test-ws/applications/test-app',
     ); // application link
   });
 

--- a/src/components/Overview/IntroBanner.tsx
+++ b/src/components/Overview/IntroBanner.tsx
@@ -88,7 +88,7 @@ const IntroBanner: React.FC = () => {
                 <ButtonWithAccessTooltip
                   className="intro-banner__cta"
                   component={(props) => (
-                    <Link {...props} to={`/stonesoup/workspaces/${workspace}/import`} />
+                    <Link {...props} to={`/application-pipeline/workspaces/${workspace}/import`} />
                   )}
                   variant="primary"
                   data-test="create-application"
@@ -101,7 +101,7 @@ const IntroBanner: React.FC = () => {
                 {applicationsLoaded && applications?.length > 0 ? (
                   <Button
                     className="intro-banner__cta"
-                    component={(props) => <Link {...props} to="/stonesoup/workspaces" />}
+                    component={(props) => <Link {...props} to="/application-pipeline/workspaces" />}
                     variant="primary"
                     data-test="view-my-applications"
                     isLarge

--- a/src/components/PageAccess/NoAccessState.tsx
+++ b/src/components/PageAccess/NoAccessState.tsx
@@ -49,7 +49,7 @@ const NoAccessState: React.FC<NoAccessStateProps> = ({
         <Button
           variant={ButtonVariant.primary}
           data-test="no-access-action"
-          onClick={() => navigate('/stonesoup/workspaces')}
+          onClick={() => navigate('/application-pipeline/workspaces')}
         >
           Go to applications list
         </Button>

--- a/src/components/PageAccess/__tests__/NoAccessState.spec.tsx
+++ b/src/components/PageAccess/__tests__/NoAccessState.spec.tsx
@@ -42,7 +42,7 @@ describe('NoAccessState', () => {
     render(<NoAccessState />);
     fireEvent.click(screen.queryByTestId('no-access-action'));
     await waitFor(() => {
-      expect(navigateMock).toHaveBeenCalledWith('/stonesoup/workspaces');
+      expect(navigateMock).toHaveBeenCalledWith('/application-pipeline/workspaces');
     });
   });
 

--- a/src/components/PipelineRunDetailsView/PipelineRunDetailsView.tsx
+++ b/src/components/PipelineRunDetailsView/PipelineRunDetailsView.tsx
@@ -80,11 +80,11 @@ export const PipelineRunDetailsView: React.FC<PipelineRunDetailsViewProps> = ({
         breadcrumbs={[
           ...applicationBreadcrumbs,
           {
-            path: `/stonesoup/workspaces/${workspace}/applications/${applicationName}/activity/pipelineruns`,
+            path: `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/activity/pipelineruns`,
             name: 'Pipeline runs',
           },
           {
-            path: `/stonesoup/workspaces/${workspace}/applications/${applicationName}/pipelineruns/${pipelineRunName}`,
+            path: `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/pipelineruns/${pipelineRunName}`,
             name: pipelineRunName,
           },
         ]}
@@ -104,7 +104,7 @@ export const PipelineRunDetailsView: React.FC<PipelineRunDetailsViewProps> = ({
             onClick: () => {
               startNewBuild(component).then(() =>
                 navigate(
-                  `/stonesoup/workspaces/${workspace}/applications/${component.spec.application}/activity/pipelineruns?name=${component.metadata.name}`,
+                  `/application-pipeline/workspaces/${workspace}/applications/${component.spec.application}/activity/pipelineruns?name=${component.metadata.name}`,
                 ),
               );
             },
@@ -115,7 +115,7 @@ export const PipelineRunDetailsView: React.FC<PipelineRunDetailsViewProps> = ({
           //   label: 'Rerun',
           //   onClick: () =>
           //     pipelineRunRerun(pipelineRun).then((data) => {
-          //       navigate(`/stonesoup/workspaces/${workspace}/applications/${applicationName}/pipelineruns/${data.metadata.name}`);
+          //       navigate(`/application-pipeline/workspaces/${workspace}/applications/${applicationName}/pipelineruns/${data.metadata.name}`);
           //     }),
           // },
           {
@@ -139,7 +139,7 @@ export const PipelineRunDetailsView: React.FC<PipelineRunDetailsViewProps> = ({
             onClick: () => pipelineRunCancel(pipelineRun),
           },
         ]}
-        baseURL={`/stonesoup/workspaces/${workspace}/applications/${applicationName}/pipelineruns/${pipelineRunName}`}
+        baseURL={`/application-pipeline/workspaces/${workspace}/applications/${applicationName}/pipelineruns/${pipelineRunName}`}
         tabs={[
           {
             key: 'detail',

--- a/src/components/PipelineRunDetailsView/PipelineRunEmptyState.tsx
+++ b/src/components/PipelineRunDetailsView/PipelineRunEmptyState.tsx
@@ -28,7 +28,7 @@ const PipelineRunEmptyState: React.FC<PipelineRunEmptyStateProps> = ({ applicati
           component={(props) => (
             <Link
               {...props}
-              to={`/stonesoup/workspaces/${workspace}/import?application=${applicationName}`}
+              to={`/application-pipeline/workspaces/${workspace}/import?application=${applicationName}`}
             />
           )}
           variant="secondary"

--- a/src/components/PipelineRunDetailsView/RelatedPipelineRuns.tsx
+++ b/src/components/PipelineRunDetailsView/RelatedPipelineRuns.tsx
@@ -46,7 +46,7 @@ const RelatedPipelineRuns = ({ pipelineRun }) => {
           : filteredRelatedPipelineruns?.map((relatedPipelineRun: PipelineRunKind) => (
               <div key={relatedPipelineRun?.metadata?.uid}>
                 <Link
-                  to={`/stonesoup/workspaces/${workspace}/applications/${applicationName}/pipelineruns/${relatedPipelineRun.metadata?.name}`}
+                  to={`/application-pipeline/workspaces/${workspace}/applications/${applicationName}/pipelineruns/${relatedPipelineRun.metadata?.name}`}
                   title={relatedPipelineRun.metadata?.name}
                 >
                   {relatedPipelineRun.metadata?.name}

--- a/src/components/PipelineRunDetailsView/__tests__/PipelineRunDetailsView.spec.tsx
+++ b/src/components/PipelineRunDetailsView/__tests__/PipelineRunDetailsView.spec.tsx
@@ -265,7 +265,7 @@ describe('PipelineRunDetailsView', () => {
 
     fireEvent.click(screen.queryByRole('menuitem', { name: 'Rerun' }));
     await waitFor(() => {
-      expect(navigateMock).toHaveBeenCalledWith(`/stonesoup/pipelineruns/${newPlrName}`);
+      expect(navigateMock).toHaveBeenCalledWith(`/application-pipeline/pipelineruns/${newPlrName}`);
     });
   });
 
@@ -287,7 +287,7 @@ describe('PipelineRunDetailsView', () => {
     fireEvent.click(startNewBuildButton);
     await waitFor(() =>
       expect(navigateMock).toHaveBeenCalledWith(
-        '/stonesoup/workspaces//applications/test-app/activity/pipelineruns?name=mock-component',
+        '/application-pipeline/workspaces//applications/test-app/activity/pipelineruns?name=mock-component',
       ),
     );
   });

--- a/src/components/PipelineRunDetailsView/__tests__/PipelineRunEmptyState.spec.tsx
+++ b/src/components/PipelineRunDetailsView/__tests__/PipelineRunEmptyState.spec.tsx
@@ -18,7 +18,7 @@ describe('PipelineRunEmptyState', () => {
   it('should render correct Link to Application Name', () => {
     render(<PipelineRunEmptyState applicationName="test" />);
     expect(screen.getByRole('link').getAttribute('href')).toBe(
-      '/stonesoup/workspaces/test-ws/import?application=test',
+      '/application-pipeline/workspaces/test-ws/import?application=test',
     );
     screen.getByText('Add component');
   });

--- a/src/components/PipelineRunDetailsView/sidepanels/TaskRunPanel.tsx
+++ b/src/components/PipelineRunDetailsView/sidepanels/TaskRunPanel.tsx
@@ -36,7 +36,7 @@ const TaskRunPanel: React.FC<Props> = ({ taskNode, onClose }) => {
           <span>
             {applicationName ? (
               <Link
-                to={`/stonesoup/workspaces/${workspace}/applications/${applicationName}/taskruns/${taskRun.metadata.name}`}
+                to={`/application-pipeline/workspaces/${workspace}/applications/${applicationName}/taskruns/${taskRun.metadata.name}`}
               >
                 {task.name}
               </Link>

--- a/src/components/PipelineRunDetailsView/tabs/ClairScanDescriptionListGroup.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/ClairScanDescriptionListGroup.tsx
@@ -55,7 +55,7 @@ const ClairScanDescriptionListGroup: React.FC<Props> = ({
         {scanTaskRun && showLogsLink ? (
           <div>
             <Link
-              to={`/stonesoup/workspaces/${workspace}/applications/${
+              to={`/application-pipeline/workspaces/${workspace}/applications/${
                 scanTaskRun.metadata.labels[PipelineRunLabel.APPLICATION]
               }/taskruns/${scanTaskRun.metadata.name}/logs`}
               className="pf-u-font-weight-normal"

--- a/src/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
@@ -150,7 +150,7 @@ const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({
                           component={(props) => (
                             <Link
                               {...props}
-                              to={`/stonesoup/workspaces/${workspace}/applications/${applicationName}/pipelineruns/${pipelineRun.metadata?.name}/logs`}
+                              to={`/application-pipeline/workspaces/${workspace}/applications/${applicationName}/pipelineruns/${pipelineRun.metadata?.name}/logs`}
                             />
                           )}
                         >
@@ -181,7 +181,7 @@ const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({
                   <DescriptionListDescription>
                     {pipelineRun.metadata?.labels?.[PipelineRunLabel.APPLICATION] ? (
                       <Link
-                        to={`/stonesoup/workspaces/${workspace}/applications/${
+                        to={`/application-pipeline/workspaces/${workspace}/applications/${
                           pipelineRun.metadata?.labels[PipelineRunLabel.APPLICATION]
                         }`}
                       >
@@ -199,7 +199,7 @@ const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({
                     {pipelineRun.metadata?.labels?.[PipelineRunLabel.COMPONENT] ? (
                       pipelineRun.metadata?.labels?.[PipelineRunLabel.APPLICATION] ? (
                         <Link
-                          to={`/stonesoup/workspaces/${workspace}/applications/${
+                          to={`/application-pipeline/workspaces/${workspace}/applications/${
                             pipelineRun.metadata.labels[PipelineRunLabel.APPLICATION]
                           }/components?name=${
                             pipelineRun.metadata.labels[PipelineRunLabel.COMPONENT]
@@ -221,7 +221,7 @@ const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({
                     <DescriptionListTerm>Commit</DescriptionListTerm>
                     <DescriptionListDescription>
                       <Link
-                        to={`/stonesoup/workspaces/${workspace}/applications/${
+                        to={`/application-pipeline/workspaces/${workspace}/applications/${
                           pipelineRun.metadata.labels[PipelineRunLabel.APPLICATION]
                         }/commit/${sha}`}
                       >

--- a/src/components/PipelineRunDetailsView/tabs/__tests__/ClairScanDescriptionListGroup.spec.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/__tests__/ClairScanDescriptionListGroup.spec.tsx
@@ -65,7 +65,7 @@ describe('ClairScanDescriptionListGroup', () => {
 
     expect(logsLink).toHaveAttribute(
       'href',
-      '/stonesoup/workspaces/test-ws/applications/test-app/taskruns/test-tr/logs',
+      '/application-pipeline/workspaces/test-ws/applications/test-app/taskruns/test-tr/logs',
     );
   });
 });

--- a/src/components/PipelineRunListView/PipelineRunListRow.tsx
+++ b/src/components/PipelineRunListView/PipelineRunListRow.tsx
@@ -26,7 +26,7 @@ const PipelineListRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({ obj }) =>
     <>
       <TableData className={pipelineRunTableColumnClasses.name}>
         <Link
-          to={`/stonesoup/workspaces/${workspace}/applications/${applicationName}/pipelineruns/${obj.metadata?.name}`}
+          to={`/application-pipeline/workspaces/${workspace}/applications/${applicationName}/pipelineruns/${obj.metadata?.name}`}
           title={obj.metadata?.name}
         >
           {obj.metadata?.name}
@@ -58,7 +58,7 @@ const PipelineListRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({ obj }) =>
         {obj.metadata?.labels[PipelineRunLabel.COMPONENT] ? (
           obj.metadata?.labels[PipelineRunLabel.APPLICATION] ? (
             <Link
-              to={`/stonesoup/workspaces/${workspace}/applications/${
+              to={`/application-pipeline/workspaces/${workspace}/applications/${
                 obj.metadata?.labels[PipelineRunLabel.APPLICATION]
               }/components`}
             >

--- a/src/components/PipelineRunListView/__tests__/PipelineRunListView.spec.tsx
+++ b/src/components/PipelineRunListView/__tests__/PipelineRunListView.spec.tsx
@@ -170,7 +170,7 @@ describe('Pipeline run List', () => {
     const button = screen.getByText('Add component');
     expect(button).toBeInTheDocument();
     expect(button.closest('a').href).toContain(
-      `http://localhost/stonesoup/workspaces/test-ws/import?application=my-test-app`,
+      `http://localhost/application-pipeline/workspaces/test-ws/import?application=my-test-app`,
     );
   });
 

--- a/src/components/TaskRunDetailsView/TaskRunDetailsView.tsx
+++ b/src/components/TaskRunDetailsView/TaskRunDetailsView.tsx
@@ -59,19 +59,19 @@ export const TaskRunDetailsView: React.FC<TaskRunDetailsViewProps> = ({ taskRunN
       breadcrumbs={[
         ...applicationBreadcrumbs,
         {
-          path: `/stonesoup/workspaces/${workspace}/applications/${applicationName}/activity/pipelineruns`,
+          path: `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/activity/pipelineruns`,
           name: 'Pipeline runs',
         },
         {
-          path: `/stonesoup/workspaces/${workspace}/applications/${applicationName}/pipelineruns/${plrName}`,
+          path: `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/pipelineruns/${plrName}`,
           name: plrName,
         },
         {
-          path: `/stonesoup/workspaces/${workspace}/applications/${applicationName}/pipelineruns/${plrName}/taskruns`,
+          path: `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/pipelineruns/${plrName}/taskruns`,
           name: `Task runs`,
         },
         {
-          path: `/stonesoup/workspaces/${workspace}/applications/${applicationName}/taskruns/${taskRunName}`,
+          path: `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/taskruns/${taskRunName}`,
           name: taskRunName,
         },
       ]}
@@ -81,7 +81,7 @@ export const TaskRunDetailsView: React.FC<TaskRunDetailsViewProps> = ({ taskRunN
           <StatusIconWithTextLabel status={trStatus} />
         </>
       }
-      baseURL={`/stonesoup/workspaces/${workspace}/applications/${applicationName}/taskruns/${taskRunName}`}
+      baseURL={`/application-pipeline/workspaces/${workspace}/applications/${applicationName}/taskruns/${taskRunName}`}
       tabs={[
         {
           key: 'details',

--- a/src/components/TaskRunDetailsView/tabs/TaskRunDetailsTab.tsx
+++ b/src/components/TaskRunDetailsView/tabs/TaskRunDetailsTab.tsx
@@ -147,7 +147,7 @@ const TaskRunDetailsTab: React.FC<TaskRunDetailsTabProps> = ({ taskRun, error })
                           component={(props) => (
                             <Link
                               {...props}
-                              to={`/stonesoup/workspaces/${workspace}/applications/${applicationName}/taskRuns/${taskRun.metadata.name}/logs`}
+                              to={`/application-pipeline/workspaces/${workspace}/applications/${applicationName}/taskRuns/${taskRun.metadata.name}/logs`}
                             />
                           )}
                         >
@@ -162,7 +162,7 @@ const TaskRunDetailsTab: React.FC<TaskRunDetailsTabProps> = ({ taskRun, error })
                   <DescriptionListDescription>
                     {plrName ? (
                       <Link
-                        to={`/stonesoup/workspaces/${workspace}/applications/${applicationName}/pipelineRuns/${plrName}`}
+                        to={`/application-pipeline/workspaces/${workspace}/applications/${applicationName}/pipelineRuns/${plrName}`}
                       >
                         {plrName}
                       </Link>
@@ -176,7 +176,7 @@ const TaskRunDetailsTab: React.FC<TaskRunDetailsTabProps> = ({ taskRun, error })
                   <DescriptionListDescription>
                     {applicationName ? (
                       <Link
-                        to={`/stonesoup/workspaces/${workspace}/applications/${applicationName}`}
+                        to={`/application-pipeline/workspaces/${workspace}/applications/${applicationName}`}
                       >
                         {taskRun.metadata?.labels[PipelineRunLabel.APPLICATION]}
                       </Link>
@@ -191,7 +191,7 @@ const TaskRunDetailsTab: React.FC<TaskRunDetailsTabProps> = ({ taskRun, error })
                     {taskRun.metadata?.labels?.[PipelineRunLabel.COMPONENT] ? (
                       applicationName ? (
                         <Link
-                          to={`/stonesoup/workspaces/${workspace}/applications/${applicationName}/components?name=${
+                          to={`/application-pipeline/workspaces/${workspace}/applications/${applicationName}/components?name=${
                             taskRun.metadata.labels[PipelineRunLabel.COMPONENT]
                           }`}
                         >

--- a/src/components/TaskRunListView/TaskRunListRow.tsx
+++ b/src/components/TaskRunListView/TaskRunListRow.tsx
@@ -16,7 +16,7 @@ const TaskRunListRow: React.FC<RowFunctionArgs<TaskRunKind>> = ({ obj }) => {
     <>
       <TableData className={taskRunTableColumnClasses.name}>
         <Link
-          to={`/stonesoup/workspaces/${workspace}/applications/${applicationName}/taskruns/${obj.metadata?.name}`}
+          to={`/application-pipeline/workspaces/${workspace}/applications/${applicationName}/taskruns/${obj.metadata?.name}`}
         >
           {obj.metadata.name}
         </Link>

--- a/src/hooks/__tests__/useStoneSoupGitHubApp.spec.ts
+++ b/src/hooks/__tests__/useStoneSoupGitHubApp.spec.ts
@@ -1,6 +1,9 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
-import { StoneSoupGitHubAppData, useStoneSoupGitHubApp } from '../useStoneSoupGitHubApp';
+import {
+  ApplicationPipelineGitHubAppData,
+  useApplicationPipelineGitHubApp,
+} from '../useApplicationPipelineGitHubApp';
 
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
   useChrome: jest.fn(),
@@ -8,36 +11,36 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
 
 const useChromeMock = useChrome as jest.Mock;
 
-describe('useStoneSoupGithubApp', () => {
+describe('useApplicationPipelineGithubApp', () => {
   it('should return stage github app for dev environment', () => {
     useChromeMock.mockReturnValue({
       getEnvironment: jest.fn().mockReturnValue('dev'),
     });
-    const { result } = renderHook(() => useStoneSoupGitHubApp());
-    expect(result.current).toBe(StoneSoupGitHubAppData.stage);
+    const { result } = renderHook(() => useApplicationPipelineGitHubApp());
+    expect(result.current).toBe(ApplicationPipelineGitHubAppData.stage);
   });
 
   it('should return stage github app for stage environment', () => {
     useChromeMock.mockReturnValue({
       getEnvironment: jest.fn().mockReturnValue('stage'),
     });
-    const { result } = renderHook(() => useStoneSoupGitHubApp());
-    expect(result.current).toBe(StoneSoupGitHubAppData.stage);
+    const { result } = renderHook(() => useApplicationPipelineGitHubApp());
+    expect(result.current).toBe(ApplicationPipelineGitHubAppData.stage);
   });
 
   it('should return prod github app for prod environment', () => {
     useChromeMock.mockReturnValue({
       getEnvironment: jest.fn().mockReturnValue('prod'),
     });
-    const { result } = renderHook(() => useStoneSoupGitHubApp());
-    expect(result.current).toBe(StoneSoupGitHubAppData.prod);
+    const { result } = renderHook(() => useApplicationPipelineGitHubApp());
+    expect(result.current).toBe(ApplicationPipelineGitHubAppData.prod);
   });
 
   it('should return dev github app for any other environment', () => {
     useChromeMock.mockReturnValue({
       getEnvironment: jest.fn().mockReturnValue('qa'),
     });
-    const { result } = renderHook(() => useStoneSoupGitHubApp());
-    expect(result.current).toBe(StoneSoupGitHubAppData.dev);
+    const { result } = renderHook(() => useApplicationPipelineGitHubApp());
+    expect(result.current).toBe(ApplicationPipelineGitHubAppData.dev);
   });
 });

--- a/src/hooks/useApplicationPipelineGitHubApp.ts
+++ b/src/hooks/useApplicationPipelineGitHubApp.ts
@@ -7,12 +7,14 @@ enum ConsoleDotEnvironments {
   prod = 'prod',
 }
 
-type StoneSoupGitHubAppDataType = {
+type ApplicationPipelineGitHubAppDataType = {
   url: string;
   name: string;
 };
 
-export const StoneSoupGitHubAppData: { [env: string]: StoneSoupGitHubAppDataType } = {
+export const ApplicationPipelineGitHubAppData: {
+  [env: string]: ApplicationPipelineGitHubAppDataType;
+} = {
   dev: { url: 'https://github.com/apps/rhtap-staging', name: 'rhtap-staging' },
   stage: {
     url: 'https://github.com/apps/rhtap-staging',
@@ -24,18 +26,18 @@ export const StoneSoupGitHubAppData: { [env: string]: StoneSoupGitHubAppDataType
   },
 };
 
-export const useStoneSoupGitHubApp = (): StoneSoupGitHubAppDataType => {
+export const useApplicationPipelineGitHubApp = (): ApplicationPipelineGitHubAppDataType => {
   const { getEnvironment } = useChrome();
 
   const environment = getEnvironment();
 
   switch (environment) {
     case ConsoleDotEnvironments.prod:
-      return StoneSoupGitHubAppData.prod;
+      return ApplicationPipelineGitHubAppData.prod;
     case ConsoleDotEnvironments.dev:
     case ConsoleDotEnvironments.stage:
-      return StoneSoupGitHubAppData.stage;
+      return ApplicationPipelineGitHubAppData.stage;
     default:
-      return StoneSoupGitHubAppData.dev;
+      return ApplicationPipelineGitHubAppData.dev;
   }
 };

--- a/src/pages/RedirectPage.tsx
+++ b/src/pages/RedirectPage.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 
 const OLD_APP = 'app-studio';
-const NEW_APP = 'stonesoup';
+const INTERIM_APP = 'stonesoup';
+const NEW_APP = 'application-pipeline';
 
 const RedirectPage: React.FunctionComponent = () => {
   const location = useLocation();
 
   const to = {
-    pathname: location.pathname.replace(OLD_APP, NEW_APP),
+    pathname: location.pathname.replace(OLD_APP, NEW_APP).replace(INTERIM_APP, NEW_APP),
     search: location.search,
     hash: location.hash,
   };

--- a/src/utils/__tests__/component-utils.spec.ts
+++ b/src/utils/__tests__/component-utils.spec.ts
@@ -1,13 +1,13 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { useStoneSoupGitHubApp } from '../../hooks/useStoneSoupGitHubApp';
+import { useApplicationPipelineGitHubApp } from '../../hooks/useApplicationPipelineGitHubApp';
 import { ComponentKind } from '../../types';
 import { isPACEnabled, PAC_ANNOTATION, useURLForComponentPRs } from '../component-utils';
 
-jest.mock('../../hooks/useStoneSoupGitHubApp', () => ({
-  useStoneSoupGitHubApp: jest.fn(),
+jest.mock('../../hooks/useApplicationPipelineGitHubApp', () => ({
+  useApplicationPipelineGitHubApp: jest.fn(),
 }));
 
-const useStoneSoupGitHubAppMock = useStoneSoupGitHubApp as jest.Mock;
+const useApplicationPipelineGitHubAppMock = useApplicationPipelineGitHubApp as jest.Mock;
 
 describe('component-utils', () => {
   it('should detect pac enabled state', () => {
@@ -32,7 +32,7 @@ describe('component-utils', () => {
   });
 
   it('should create github URL for component PRs', () => {
-    useStoneSoupGitHubAppMock.mockReturnValue({
+    useApplicationPipelineGitHubAppMock.mockReturnValue({
       name: 'appstudio-staging-ci',
       url: 'https://github.com/apps/appstudio-staging-ci.git',
     });

--- a/src/utils/__tests__/workspace-context-utils.spec.ts
+++ b/src/utils/__tests__/workspace-context-utils.spec.ts
@@ -81,7 +81,7 @@ describe('getHomeWorkspace', () => {
     expect(getHomeWorkspace(undefined)).toBeUndefined();
   });
 
-  it('should return home worksapce', () => {
+  it('should return home workspace', () => {
     expect(getHomeWorkspace(mockWorkspaces).metadata.name).toBe('workspace-one');
     expect(getHomeWorkspace(mockWorkspaces).status.type).toBe('home');
   });
@@ -92,7 +92,7 @@ describe('useActiveWorkspace', () => {
   beforeEach(() => {
     Object.defineProperty(window, 'location', {
       value: {
-        pathname: '/stonesoup/workspaces/test-ws/applications',
+        pathname: '/application-pipeline/workspaces/test-ws/applications',
       },
       writable: true,
     });
@@ -158,7 +158,7 @@ describe('useActiveWorkspace', () => {
   });
 
   it('should should select the workspace from url', async () => {
-    window.location.pathname = '/stonesoup/workspaces/workspace-two/applications';
+    window.location.pathname = '/application-pipeline/workspaces/workspace-two/applications';
     const { result, waitForNextUpdate } = renderHook(() => useActiveWorkspace());
     await waitForNextUpdate();
 
@@ -170,7 +170,7 @@ describe('useActiveWorkspace', () => {
       ...mockWorkspaces,
       { metadata: { name: 'test-ws' } },
     ]);
-    window.location.pathname = '/stonesoup/workspaces/workspace-invalid/applications';
+    window.location.pathname = '/application-pipeline/workspaces/workspace-invalid/applications';
     const { result, waitForNextUpdate } = renderHook(() => useActiveWorkspace());
 
     await waitForNextUpdate();
@@ -189,7 +189,7 @@ describe('useActiveWorkspace', () => {
   });
 
   it('should should not navigate to the selected workspace route if the user is in non workspace pages', async () => {
-    window.location.pathname = '/stonesoup/overview';
+    window.location.pathname = '/application-pipeline/overview';
     getActiveWorkspaceMock.mockReturnValue('');
     renderHook(() => useActiveWorkspace());
 
@@ -203,7 +203,9 @@ describe('useActiveWorkspace', () => {
     renderHook(() => useActiveWorkspace());
 
     await waitFor(() => {
-      expect(navigateMock).toHaveBeenCalledWith(`/stonesoup/workspaces/workspace-one/applications`);
+      expect(navigateMock).toHaveBeenCalledWith(
+        `/application-pipeline/workspaces/workspace-one/applications`,
+      );
     });
   });
 });

--- a/src/utils/breadcrumb-utils.tsx
+++ b/src/utils/breadcrumb-utils.tsx
@@ -20,7 +20,7 @@ export const useApplicationBreadcrumbs = (appDisplayName = null, withLink = true
     <BreadcrumbItem key="workspace-link" to="#" component="div">
       <Link
         className="pf-c-breadcrumb__link"
-        to={`/stonesoup/workspaces/${workspace}/applications`}
+        to={`/application-pipeline/workspaces/${workspace}/applications`}
       >
         {workspace}
       </Link>
@@ -34,7 +34,7 @@ export const useApplicationBreadcrumbs = (appDisplayName = null, withLink = true
         <Link
           data-test="applications-breadcrumb-link"
           className="pf-c-breadcrumb__link"
-          to={`/stonesoup/workspaces/${workspace}/applications`}
+          to={`/application-pipeline/workspaces/${workspace}/applications`}
         >
           Applications
         </Link>
@@ -46,7 +46,7 @@ export const useApplicationBreadcrumbs = (appDisplayName = null, withLink = true
       ? [
           {
             path: withLink
-              ? `/stonesoup/workspaces/${workspace}/applications/${applicationName}`
+              ? `/application-pipeline/workspaces/${workspace}/applications/${applicationName}`
               : '',
             name: appDisplayName || applicationName,
           },

--- a/src/utils/component-utils.ts
+++ b/src/utils/component-utils.ts
@@ -1,5 +1,5 @@
 import { k8sPatchResource } from '@openshift/dynamic-plugin-sdk-utils';
-import { useStoneSoupGitHubApp } from '../hooks/useStoneSoupGitHubApp';
+import { useApplicationPipelineGitHubApp } from '../hooks/useApplicationPipelineGitHubApp';
 import { ComponentModel } from '../models';
 import { ComponentKind } from '../types';
 
@@ -79,7 +79,7 @@ export const startNewBuild = (component: ComponentKind) =>
 const GIT_URL_PREFIX = 'https://github.com/';
 
 export const useURLForComponentPRs = (components: ComponentKind[]): string => {
-  const { name: PR_BOT_NAME } = useStoneSoupGitHubApp();
+  const { name: PR_BOT_NAME } = useApplicationPipelineGitHubApp();
   const repos = components.reduce((acc, component) => {
     const gitURL = component.spec.source?.git?.url;
     if (gitURL && isPACEnabled(component) && gitURL.startsWith('https://github.com/')) {

--- a/src/utils/workspace-context-utils.ts
+++ b/src/utils/workspace-context-utils.ts
@@ -96,9 +96,9 @@ export const useActiveWorkspace = (): WorkspaceContextData => {
         setWorkspace(ws);
         setWorkspaces(allWorkspaces);
         setWorkspacesLoaded(true);
-        const wsBasePath = generatePath('/stonesoup/workspaces/:ws', { ws });
+        const wsBasePath = generatePath('/application-pipeline/workspaces/:ws', { ws });
 
-        window.location.pathname.includes('/stonesoup/workspaces') &&
+        window.location.pathname.includes('/application-pipeline/workspaces') &&
           !window.location.pathname.includes(wsBasePath) &&
           navigate(`${wsBasePath}/applications`);
       }


### PR DESCRIPTION
## Fixes 
Fixes [HAC-3584](https://issues.redhat.com/browse/HAC-3584)

## Description
Changes the `stonesoup` segment of the URL to `application-pipeline`. Redirects any URLs with stonesoup to the new URL.

## Type of change
- [x] Refactoring (no functional changes, no api changes)

/cc @rohitkrai03 @karthikjeeyar 