### PR TITLE
Move sample card onlick handler to galleryitem

### DIFF
--- a/src/components/ImportForm/SampleSection/SampleSection.tsx
+++ b/src/components/ImportForm/SampleSection/SampleSection.tsx
@@ -131,7 +131,7 @@ const SampleSection = ({ onStrategyChange }) => {
             <div>
               <Gallery className="hac-catalog" hasGutter>
                 {filteredSamples.map((sample) => (
-                  <GalleryItem key={sample.uid}>
+                  <GalleryItem key={sample.uid} onClick={() => handleSelect(sample)}>
                     <CatalogTile
                       className="hac-catalog__tile"
                       id={sample.uid}
@@ -144,7 +144,6 @@ const SampleSection = ({ onStrategyChange }) => {
                         </Badge>
                       ))}
                       {...getIconProps(sample)}
-                      onClick={() => handleSelect(sample)}
                       footer={
                         <Button
                           variant="link"
@@ -163,7 +162,7 @@ const SampleSection = ({ onStrategyChange }) => {
                                 (sample.attributes.git as { remotes: { [key: string]: string } })
                                   .remotes.origin
                               }
-                              target={'_blank'}
+                              target="_blank"
                               rel="noreferrer"
                             />
                           )}


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-3099
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
If an onclick handler is provided to CatalogTile, it uses an `a` tag by default. Removing the handler makes it use `div`.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

https://user-images.githubusercontent.com/20013884/230939891-a216dfc2-5546-4b46-a37e-68f152f3d9cb.mp4

<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
