### PR TITLE
Set scrollbar on tasks list in build logs modal

### DIFF
--- a/src/components/LogViewer/BuildLogViewer.scss
+++ b/src/components/LogViewer/BuildLogViewer.scss
@@ -1,3 +1,8 @@
 .build-log-viewer {
   height: 70%;
+  display: flex;
+  flex-direction: column;
+  &__body {
+    height: 100%;
+  }
 }

--- a/src/components/LogViewer/BuildLogViewer.tsx
+++ b/src/components/LogViewer/BuildLogViewer.tsx
@@ -49,7 +49,7 @@ export const BuildLogViewer: React.FC<BuildLogViewerProps> = ({ component }) => 
           </span>
         )}
       </StackItem>
-      <StackItem isFilled>
+      <StackItem isFilled className="build-log-viewer__body">
         {pipelineRun && taskRuns && tloaded ? (
           <PipelineRunLogs obj={pipelineRun} taskRuns={taskRuns} />
         ) : (

--- a/src/shared/components/pipeline-run-logs/PipelineRunLogs.scss
+++ b/src/shared/components/pipeline-run-logs/PipelineRunLogs.scss
@@ -38,6 +38,7 @@
     max-width: 30%;
     min-width: 208px;
     margin-top: var(--pf-global--spacer--lg);
+    overflow-y: auto;
   }
   &__container {
     flex: 1;

--- a/src/shared/components/pipeline-run-logs/PipelineRunLogs.tsx
+++ b/src/shared/components/pipeline-run-logs/PipelineRunLogs.tsx
@@ -128,6 +128,12 @@ class PipelineRunLogs extends React.Component<PipelineRunLogsProps, PipelineRunL
       taskRunFromYaml?.[activeItem]?.metadata?.labels?.[TektonResourceLabel.pipelineTask] || '-';
     const pipelineRunFinished = pipelineStatus !== runStatus.Running;
 
+    const selectedItemRef = (item: HTMLSpanElement) => {
+      if (item?.scrollIntoView) {
+        item.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      }
+    };
+
     return (
       <div className="pipeline-run-logs">
         <div className="pipeline-run-logs__tasklist" data-testid="logs-tasklist">
@@ -143,7 +149,7 @@ class PipelineRunLogs extends React.Component<PipelineRunLogsProps, PipelineRunL
                       isActive={activeItem === task}
                       className="pipeline-run-logs__navitem"
                     >
-                      <span>
+                      <span ref={activeItem === task ? selectedItemRef : undefined}>
                         <ColoredStatusIcon status={taskRunStatus(taskRun)} />
                         <span className="pipeline-run-logs__namespan">
                           {taskRunFromYaml[task]?.metadata?.labels?.[

--- a/src/shared/components/pipeline-run-logs/__tests__/PipelineRunLogs.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/__tests__/PipelineRunLogs.spec.tsx
@@ -34,6 +34,10 @@ describe('PipelineRunLogs', () => {
 
   beforeEach(() => {
     watchResourceMock.mockReturnValue([{ metadata: { name: 'test-pod' } }, true]);
+    (window.HTMLSpanElement as any).prototype.scrollIntoView = () => {};
+  });
+  afterEach(() => {
+    (window.HTMLSpanElement as any).prototype.scrollIntoView = undefined;
   });
 
   it('should render task list and log window', () => {


### PR DESCRIPTION
## Fixes 
Fixes [HAC-2966](https://issues.redhat.com/browse/HAC-2966)

## Description
Sets the task run list to be scrollable rather than the entire build logs modal. Scroll the active item into view if it is not.

## Type of change
- [x] Bugfix

## Screen shots / Gifs for design review 
![image](https://user-images.githubusercontent.com/11633780/230947599-685e09a0-28fe-4218-97be-500199b59f4e.png)

/cc @rohitkrai03 @karthikjeeyar 