### PR TITLE
fix build logs autoscroll performance issue

### DIFF
--- a/src/shared/components/pipeline-run-logs/__tests__/Logs.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/__tests__/Logs.spec.tsx
@@ -1,0 +1,127 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { WebSocketFactory, commonFetchText } from '@openshift/dynamic-plugin-sdk-utils';
+import { render, screen, waitFor } from '@testing-library/react';
+import { samplePod } from '../../../../__data__/pod-data';
+import Logs from '../logs/Logs';
+import { getRenderContainers } from '../logs/logs-utils';
+import { LOG_SOURCE_RUNNING, LOG_SOURCE_TERMINATED } from '../utils';
+
+jest.mock('../../../hooks/scroll', () => {
+  const actual = jest.requireActual('../../../hooks/scroll');
+
+  return {
+    ...actual,
+    useScrollDirection: jest.fn(),
+  };
+});
+jest.mock('react-i18next', () => ({
+  useTranslation: jest.fn(() => ({ t: (x) => x })),
+}));
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => {
+  const actual = jest.requireActual('@openshift/dynamic-plugin-sdk-utils');
+  return {
+    ...actual,
+    commonFetchText: jest.fn(),
+    WebSocketFactory: jest.fn(),
+  };
+});
+
+const mockCommonFetchText = commonFetchText as jest.Mock;
+const mockWebSocketFactory = WebSocketFactory as jest.Mock;
+const ws = {
+  onMessage: () => ws,
+  onClose: () => ws,
+  onError: () => ws,
+  destroy: () => ws,
+};
+
+describe('Logs', () => {
+  beforeEach(() => {
+    mockCommonFetchText.mockReturnValue(Promise.resolve());
+    mockWebSocketFactory.mockImplementation(() => ws);
+  });
+
+  it('should not render logs component if the render is set to false', async () => {
+    const { containers } = getRenderContainers(samplePod);
+
+    render(
+      <Logs
+        resourceStatus={LOG_SOURCE_TERMINATED}
+        resource={samplePod}
+        errorMessage={''}
+        container={containers[0]}
+        onComplete={() => {}}
+        render={false}
+        autoScroll={true}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId('logs-container')).toHaveStyle({ display: 'none' });
+    });
+  });
+
+  it('should render logs component', async () => {
+    const { containers } = getRenderContainers(samplePod);
+
+    render(
+      <Logs
+        resourceStatus={LOG_SOURCE_TERMINATED}
+        resource={samplePod}
+        errorMessage={''}
+        container={containers[0]}
+        onComplete={() => {}}
+        render={true}
+        autoScroll={true}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('step-init')).toBeInTheDocument();
+      expect(screen.queryByTestId('logs-content')).toBeInTheDocument();
+    });
+  });
+
+  it('should show the error alert', async () => {
+    mockCommonFetchText.mockImplementation(() => Promise.reject('failed to retrieving logs'));
+    const { containers } = getRenderContainers(samplePod);
+
+    render(
+      <Logs
+        resourceStatus={LOG_SOURCE_TERMINATED}
+        resource={null}
+        errorMessage={'test'}
+        container={containers[0]}
+        onComplete={() => {}}
+        render={true}
+        autoScroll={true}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('error-message')).toBeInTheDocument();
+    });
+  });
+
+  it('should fetch data from web sockets', async () => {
+    const { containers } = getRenderContainers(samplePod);
+
+    render(
+      <Logs
+        resourceStatus={LOG_SOURCE_RUNNING}
+        resource={samplePod}
+        errorMessage={''}
+        container={containers[0]}
+        onComplete={() => {}}
+        render={true}
+        autoScroll={true}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('step-init')).toBeInTheDocument();
+      expect(screen.queryByTestId('logs-content')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/shared/components/pipeline-run-logs/__tests__/MultiStreamLogs.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/__tests__/MultiStreamLogs.spec.tsx
@@ -1,0 +1,188 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { commonFetchText } from '@openshift/dynamic-plugin-sdk-utils';
+import { screen, render, waitFor, configure, fireEvent, act } from '@testing-library/react';
+import { debounce, throttle } from 'lodash-es';
+import { samplePod } from '../../../../__data__/pod-data';
+import { ScrollDirection, useScrollDirection } from '../../../hooks/scroll';
+import { MultiStreamLogs } from '../logs/MultiStreamLogs';
+
+jest.mock('../logs/Logs', () => (props) => {
+  React.useEffect(() => {
+    props.onComplete(props.container.name);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return <div>{`Logs - ${props.container.name}`}</div>;
+});
+
+jest.mock('../../../hooks/scroll', () => {
+  const actual = jest.requireActual('../../../hooks/scroll');
+
+  return {
+    ...actual,
+    useScrollDirection: jest.fn(),
+  };
+});
+jest.mock('react-i18next', () => ({
+  useTranslation: jest.fn(() => ({ t: (x) => x })),
+}));
+
+jest.mock('lodash-es', () => {
+  const actual = jest.requireActual('lodash-es');
+  return {
+    ...actual,
+    debounce: jest.fn(),
+    throttle: jest.fn(),
+  };
+});
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => {
+  const actual = jest.requireActual('@openshift/dynamic-plugin-sdk-utils');
+  return {
+    ...actual,
+    commonFetchText: jest.fn(),
+  };
+});
+
+const mockCommmonFetchText = commonFetchText as jest.Mock;
+const mockDebounce = debounce as jest.Mock;
+const mockThrottle = throttle as jest.Mock;
+const mockUseScrollDirection = useScrollDirection as jest.Mock;
+
+describe('MultiStreamLogs', () => {
+  let downloadAllCallback;
+  beforeEach(() => {
+    downloadAllCallback = jest.fn();
+    jest.spyOn(console, 'warn').mockImplementation(jest.fn());
+
+    configure({ testIdAttribute: 'data-testid' });
+    mockCommmonFetchText.mockReturnValue(Promise.resolve());
+    mockDebounce.mockImplementation((fn) => fn);
+    mockThrottle.mockImplementation((fn) => fn);
+    mockUseScrollDirection.mockReturnValue([null, () => {}]);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render loading indicator', async () => {
+    configure({ testIdAttribute: 'data-test' });
+    const { getByTestId } = render(
+      <MultiStreamLogs
+        resourceName={'invalid-pod'}
+        resource={samplePod}
+        errorMessage={''}
+        taskName={'step-init'}
+        onDownloadAll={downloadAllCallback}
+      />,
+    );
+
+    await waitFor(() => {
+      getByTestId('loading-indicator');
+    });
+  });
+
+  it('should render the logs control buttons and container', () => {
+    render(
+      <MultiStreamLogs
+        resourceName={samplePod.metadata.name}
+        resource={samplePod}
+        errorMessage={''}
+        taskName={'step-init'}
+        downloadAllLabel={'Download all task logs'}
+        onDownloadAll={downloadAllCallback}
+      />,
+    );
+
+    waitFor(() => {
+      screen.getByTestId('logs-task-container');
+      screen.getByText('Download');
+      screen.getByText('Download all task logs');
+      screen.getByText('Expand');
+    });
+  });
+
+  it('should render resume log stream button when user scrolls up and removed when users scrolls to the bottom of the logs', async () => {
+    mockUseScrollDirection.mockReturnValue([ScrollDirection.scrollingUp, () => {}]);
+    const { getByTestId, rerender } = render(
+      <MultiStreamLogs
+        resourceName={samplePod.metadata.name}
+        resource={samplePod}
+        errorMessage={''}
+        taskName={'step-init'}
+        downloadAllLabel={'Download all task logs'}
+        onDownloadAll={downloadAllCallback}
+      />,
+    );
+
+    let resumeLogStream: HTMLElement;
+
+    await waitFor(() => {
+      resumeLogStream = getByTestId('resume-log-stream');
+    });
+
+    act(() => {
+      fireEvent.click(resumeLogStream);
+    });
+
+    mockUseScrollDirection.mockReturnValue([ScrollDirection.scrolledToBottom, () => {}]);
+    rerender(
+      <MultiStreamLogs
+        resourceName={samplePod.metadata.name}
+        resource={samplePod}
+        errorMessage={''}
+        taskName={'step-init'}
+        downloadAllLabel={'Download all task logs'}
+        onDownloadAll={downloadAllCallback}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('resume-log-stream')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should call onDownload callback when download button is pressed', async () => {
+    downloadAllCallback.mockReturnValue(Promise.resolve());
+
+    render(
+      <MultiStreamLogs
+        resourceName={samplePod.metadata.name}
+        resource={samplePod}
+        errorMessage={''}
+        taskName={'step-init'}
+        downloadAllLabel={'Download all task logs'}
+        onDownloadAll={downloadAllCallback}
+      />,
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByText('Download all task logs'));
+    });
+    await waitFor(() => {
+      expect(downloadAllCallback).toHaveBeenCalled();
+    });
+  });
+
+  it('should handle if the download fails', async () => {
+    downloadAllCallback.mockImplementation(() => Promise.reject(new Error('Download Failed')));
+    render(
+      <MultiStreamLogs
+        resourceName={samplePod.metadata.name}
+        resource={samplePod}
+        errorMessage={''}
+        taskName={'step-init'}
+        downloadAllLabel={'Download all task logs'}
+        onDownloadAll={downloadAllCallback}
+      />,
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByText('Download all task logs'));
+    });
+    await waitFor(() => {
+      expect(downloadAllCallback).rejects.toThrowError();
+    });
+  });
+});

--- a/src/shared/components/pipeline-run-logs/logs/Logs.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/Logs.tsx
@@ -8,6 +8,7 @@ import {
 } from '@openshift/dynamic-plugin-sdk-utils';
 import { Alert } from '@patternfly/react-core';
 import { Base64 } from 'js-base64';
+import { throttle } from 'lodash-es';
 import { PodModel } from '../../../../models/pod';
 import { ContainerSpec, PodKind } from '../../types';
 import { LOG_SOURCE_TERMINATED } from '../utils';
@@ -46,16 +47,24 @@ const Logs: React.FC<LogsProps> = ({
 
   const appendMessage = React.useRef<(blockContent) => void>();
 
+  const safeScroll = throttle(
+    () =>
+      requestAnimationFrame(() => {
+        scrollToRef.current.scrollIntoView({ behavior: 'smooth' });
+      }),
+    300,
+  );
+
   appendMessage.current = React.useCallback(
     (blockContent: string) => {
       if (contentRef.current && blockContent) {
         contentRef.current.innerText += blockContent;
       }
       if (scrollToRef.current && blockContent && render && autoScroll) {
-        scrollToRef.current.scrollIntoView({ behavior: 'smooth' });
+        safeScroll();
       }
     },
-    [autoScroll, render],
+    [autoScroll, render, safeScroll],
   );
 
   if (resourceStatusRef.current !== resourceStatus) {
@@ -114,9 +123,9 @@ const Logs: React.FC<LogsProps> = ({
 
   React.useEffect(() => {
     if (scrollToRef.current && render && autoScroll) {
-      scrollToRef.current.scrollIntoView({ behavior: 'smooth' });
+      safeScroll();
     }
-  }, [autoScroll, render]);
+  }, [autoScroll, render, safeScroll]);
 
   return (
     <div className="logs" style={{ display: render ? '' : 'none' }}>


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/RHTAPBUGS-107

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Autoscrolling is not working for larger logs data stream (eg: build-container task).

**Root Cause Analysis**

The performance bottleneck is caused when a large dataset is streamed, the `scrollIntoView` method is being called multiple times continuously which blocks the javascript thread and the browser becomes unresponsive.


**Solution:**

Throttling `scrollIntoView` method and made the function call asynchronous by wrapping in setTimeout function.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

**Before:**

https://user-images.githubusercontent.com/9964343/231555950-cc55a47f-3bff-484a-9731-3e6104363c22.mov



**After:**


https://user-images.githubusercontent.com/9964343/231555969-92527e72-00a0-4415-8844-906c545916d5.mov


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

1. Add a quarkus or spring boot application from samples.
2. view build logs (build-container task)

## Unit tests

```
Logs
    ✓ should not render logs component if the render is set to false (48 ms)
    ✓ should render logs component (15 ms)
    ✓ should show the error alert (13 ms)
    ✓ should fetch data from web sockets (5 ms)
```    

```
  MultiStreamLogs
    ✓ should render loading indicator (38 ms)
    ✓ should render the logs control buttons and container (17 ms)
    ✓ should render resume log stream button when user scrolls up and removed when users scrolls to the bottom of the logs (31 ms)
    ✓ should call onDownload callback when download button is pressed (12 ms)
    ✓ should handle if the download fails (28 ms)
 ```  

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

cc: @mattreid @rohitkrai03 


