### PR TITLE
Check taskrun status when displaying logs

### DIFF
--- a/src/components/NamespacedPage/NamespacedPage.tsx
+++ b/src/components/NamespacedPage/NamespacedPage.tsx
@@ -31,12 +31,12 @@ const NamespacedPage: React.FunctionComponent<NamespacedPageProps> = ({ children
   }
 
   return (
-    <ModalProvider>
-      <AppBanner />
-      <div className="main-layout-container">
-        <ErrorBoundary>{children}</ErrorBoundary>
-      </div>
-    </ModalProvider>
+    <ErrorBoundary>
+      <ModalProvider>
+        <AppBanner />
+        <div className="main-layout-container">{children}</div>
+      </ModalProvider>
+    </ErrorBoundary>
   );
 };
 

--- a/src/shared/components/pipeline-run-logs/PipelineRunLogs.tsx
+++ b/src/shared/components/pipeline-run-logs/PipelineRunLogs.tsx
@@ -141,7 +141,7 @@ class PipelineRunLogs extends React.Component<PipelineRunLogsProps, PipelineRunL
             <Nav onSelect={this.onNavSelect} theme="light">
               <NavList className="pipeline-run-logs__nav">
                 {taskRuns.map((task) => {
-                  const taskRun = obj.status.taskRuns[task];
+                  const taskRun = taskRunFromYaml?.[task];
                   return (
                     <NavItem
                       key={task}


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/RHTAPBUGS-126
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
Page crash happens when pipelinerun.status is not available.
This results in another error when the modal tries to update itself but the modal provider is removed from the tree.

- Add null check for status.taskRuns of pipelinerun when displaying logs modal.
- Move error boundary up the tree to cover modal provider.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

https://user-images.githubusercontent.com/20013884/233167332-85f41be2-0bf6-4250-8948-faf40b1e28c4.mp4

<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
