### PR TITLE
return users to last used sub tab on activity tab selection

### DIFF
--- a/src/components/Activity/ActivityTab.tsx
+++ b/src/components/Activity/ActivityTab.tsx
@@ -1,28 +1,41 @@
 import * as React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Tab, Tabs, TabTitleText, Title } from '@patternfly/react-core';
+import { useLocalStorage } from '../../hooks';
 import { useWorkspaceInfo } from '../../utils/workspace-context-utils';
 import PipelineRunsTab from '../ApplicationDetails/tabs/PipelineRunsTab';
 import CommitsListView from '../Commits/CommitsListView';
 
 import './ActivityTab.scss';
 
+export const ACTIVITY_SECONDARY_TAB_KEY = 'activity-secondary-tab';
+
 export const ActivityTab: React.FC<{ applicationName?: string }> = ({ applicationName }) => {
   const params = useParams();
   const { workspace } = useWorkspaceInfo();
   const { activeTab: parentTab, activity: activeTab } = params;
+  const [lastSelectedTab, setLocalStorageItem] = useLocalStorage<string>(
+    ACTIVITY_SECONDARY_TAB_KEY,
+  );
+  const currentTab = activeTab || lastSelectedTab || 'latest-commits';
 
   const navigate = useNavigate();
   const setActiveTab = React.useCallback(
     (newTab: string) => {
-      if (activeTab !== newTab) {
+      if (currentTab !== newTab) {
         navigate(
           `/stonesoup/workspaces/${workspace}/applications/${applicationName}/${parentTab}/${newTab}`,
         );
       }
     },
-    [applicationName, activeTab, navigate, parentTab, workspace],
+    [applicationName, currentTab, navigate, parentTab, workspace],
   );
+
+  React.useEffect(() => {
+    if (activeTab !== lastSelectedTab) {
+      setLocalStorageItem(currentTab);
+    }
+  }, [activeTab, lastSelectedTab, currentTab, setLocalStorageItem]);
 
   return (
     <>
@@ -34,7 +47,7 @@ export const ActivityTab: React.FC<{ applicationName?: string }> = ({ applicatio
           width: 'fit-content',
           marginBottom: 'var(--pf-global--spacer--md)',
         }}
-        activeKey={activeTab || 'latest-commits'}
+        activeKey={currentTab}
         onSelect={(_, k: string) => {
           setActiveTab(k);
         }}

--- a/src/components/Activity/__tests__/ActivityTab.spec.tsx
+++ b/src/components/Activity/__tests__/ActivityTab.spec.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom';
 import { useNavigate, useParams } from 'react-router-dom';
 import { act, fireEvent, screen } from '@testing-library/react';
 import { routerRenderer } from '../../../utils/test-utils';
-import { ActivityTab } from '../ActivityTab';
+import { ACTIVITY_SECONDARY_TAB_KEY, ActivityTab } from '../ActivityTab';
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   useK8sWatchResource: () => [[], false],
@@ -70,6 +70,17 @@ describe('Activity Tab', () => {
     tabs = activitiesPage.getByTestId('activities-tabs-id');
     activeTab = tabs.querySelector('.pf-c-tabs__item.pf-m-current .pf-c-tabs__item-text');
     expect(activeTab).toHaveTextContent('Latest commits');
+    activitiesPage.unmount();
+  });
+
+  it('should read from localstorage and display the last used tab', async () => {
+    localStorage.setItem(ACTIVITY_SECONDARY_TAB_KEY, 'pipelineruns');
+
+    useParamsMock.mockReturnValue({ activeTab: 'activity', activity: null });
+    const activitiesPage = routerRenderer(<ActivityTab applicationName="abcd" />);
+    const tabs = activitiesPage.getByTestId('activities-tabs-id');
+    const activeTab = tabs.querySelector('.pf-c-tabs__item.pf-m-current .pf-c-tabs__item-text');
+    expect(activeTab).toHaveTextContent('Pipeline runs');
     activitiesPage.unmount();
   });
 });

--- a/src/components/ApplicationDetails/ApplicationDetails.tsx
+++ b/src/components/ApplicationDetails/ApplicationDetails.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useFeatureFlag } from '@openshift/dynamic-plugin-sdk';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { useApplication } from '../../hooks/useApplications';
+import { useLocalStorage } from '../../hooks/useLocalStorage';
 import {
   ApplicationModel,
   ComponentModel,
@@ -15,7 +16,7 @@ import { useApplicationBreadcrumbs } from '../../utils/breadcrumb-utils';
 import { MVP_FLAG } from '../../utils/flag-utils';
 import { useAccessReviewForModel } from '../../utils/rbac';
 import { useWorkspaceInfo } from '../../utils/workspace-context-utils';
-import { ActivityTab } from '../Activity/ActivityTab';
+import { ACTIVITY_SECONDARY_TAB_KEY, ActivityTab } from '../Activity/ActivityTab';
 import { createCustomizeAllPipelinesModalLauncher } from '../CustomizedPipeline/CustomizePipelinesModal';
 import ErrorEmptyState from '../EmptyState/ErrorEmptyState';
 import { useModalLauncher } from '../modal/ModalProvider';
@@ -43,6 +44,9 @@ const ApplicationDetails: React.FC<HacbsApplicationDetailsProps> = ({ applicatio
     'create',
   );
   const [canDeleteApplication] = useAccessReviewForModel(ApplicationModel, 'delete');
+  const { activity: subTab } = useParams();
+  const [lastActivitySubTab] = useLocalStorage<string>(ACTIVITY_SECONDARY_TAB_KEY);
+  const activitySubTab = subTab || lastActivitySubTab || 'latest-commits';
 
   const navigate = useNavigate();
   const { quickStarts } = useChrome();
@@ -176,7 +180,7 @@ const ApplicationDetails: React.FC<HacbsApplicationDetailsProps> = ({ applicatio
             component: <ApplicationOverviewTab applicationName={applicationName} />,
           },
           {
-            key: 'activity',
+            key: `activity/${activitySubTab}`,
             label: 'Activity',
             isFilled: true,
             className: 'application-details__activity',

--- a/src/components/ApplicationDetails/DetailsPage.tsx
+++ b/src/components/ApplicationDetails/DetailsPage.tsx
@@ -68,9 +68,10 @@ const DetailsPage: React.FC<DetailsPageProps> = ({
 }) => {
   const [isOpen, setIsOpen] = React.useState(false);
   const params = useParams();
-  const { activeTab: tab } = params;
+  const { activeTab: tab, activity: subTab } = params;
+  const currentTab = tab && subTab ? `${tab}/${subTab}` : tab;
 
-  const activeTabKey = React.useMemo(() => tab || tabs?.[0]?.key, [tab, tabs]);
+  const activeTabKey = React.useMemo(() => currentTab || tabs?.[0]?.key, [currentTab, tabs]);
   const navigate = useNavigate();
   const setActiveTab = React.useCallback(
     (newTab: string) => {

--- a/src/components/ApplicationDetails/DetailsPage.tsx
+++ b/src/components/ApplicationDetails/DetailsPage.tsx
@@ -133,7 +133,7 @@ const DetailsPage: React.FC<DetailsPageProps> = ({
   const tabComponents = tabs?.map(({ key, label, component, isFilled = true, ...rest }) => {
     return (
       <Tab
-        data-test={`details__tabItem ${key}`}
+        data-test={`details__tabItem ${label.toLocaleLowerCase().replace(/\s/g, '')}`}
         key={key}
         eventKey={key}
         title={<TabTitleText>{label}</TabTitleText>}

--- a/src/components/ApplicationDetails/__tests__/ApplicationDetails.spec.tsx
+++ b/src/components/ApplicationDetails/__tests__/ApplicationDetails.spec.tsx
@@ -144,7 +144,7 @@ describe('ApplicationDetails', () => {
     expect(activeTab).toHaveTextContent('Overview');
     detailsPage.unmount();
 
-    useParamsMock.mockReturnValue({ activeTab: 'activity' });
+    useParamsMock.mockReturnValue({ activeTab: 'activity', activity: 'latest-commits' });
     detailsPage = routerRenderer(<ApplicationDetails applicationName="test" />);
     appDetails = detailsPage.getByTestId('details');
     activeTab = appDetails.querySelector('.pf-c-tabs__item.pf-m-current .pf-c-tabs__item-text');

--- a/src/components/ApplicationDetails/__tests__/DetailsPage.spec.tsx
+++ b/src/components/ApplicationDetails/__tests__/DetailsPage.spec.tsx
@@ -56,7 +56,7 @@ describe('DetailsPage', () => {
         baseURL="/"
         tabs={[
           { key: 'tab1', label: 'Tab 1', component: <div>Tab1 content</div> },
-          { key: 'tab2', label: 'Tab 1', component: <div>Tab1 content</div> },
+          { key: 'tab2', label: 'Tab 2', component: <div>Tab2 content</div> },
         ]}
       />,
     );
@@ -177,7 +177,7 @@ describe('DetailsPage', () => {
         baseURL="/"
         tabs={[
           { key: 'tab1', label: 'Tab 1', component: <div>Tab1 content</div> },
-          { key: 'tab2', label: 'Tab 1', component: <div>Tab1 content</div> },
+          { key: 'tab2', label: 'Tab 2', component: <div>Tab2 content</div> },
         ]}
       />,
     );

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -15,7 +15,7 @@ const tryJSONParse = <T = any>(data: string): string | T => {
  *
  * @returns setter and JSON value if parseable, or else `string`.
  */
-export const useLocalStorage = <T extends object>(key: string): [T | string, React.Dispatch<T>] => {
+export const useLocalStorage = <T>(key: string): [T | string, React.Dispatch<T>] => {
   const [value, setValue] = React.useState(tryJSONParse<T>(window.localStorage.getItem(key)));
 
   useEventListener(window, 'storage', () => {


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/RHTAPBUGS-161

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

I often want to visit the pipeline runs within the activity tab. However every time I visit the activity tab, it displays the commits sub tab by default. It would be useful if clicking the activity tab brought the user back to the previously viewed sub tab.



## Type of change
<!-- Please delete options that are not relevant. -->


- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


https://user-images.githubusercontent.com/9964343/233547956-9f0d7509-54be-4027-8ccf-638628ea443b.mov






## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

1. Select Activity tab, and select pipelineruns tab 
2. Go to any other tab and return back to activity tab, the pipelineruns tab should be pre selected


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

cc: @christianvogt 