### PR TITLE
Add ingressDomain for env create of non-OpenShift

### DIFF
--- a/src/components/Environment/create/CreateEnvironment.tsx
+++ b/src/components/Environment/create/CreateEnvironment.tsx
@@ -17,6 +17,7 @@ const CreateEnvironment: React.FC = () => {
     clusterType: '',
     kubeconfig: '',
     targetNamespace: '',
+    ingressDomain: '',
   };
 
   const handleSubmit = React.useCallback(

--- a/src/components/Environment/create/CreateEnvironmentForm.tsx
+++ b/src/components/Environment/create/CreateEnvironmentForm.tsx
@@ -18,6 +18,7 @@ import {
   environmentTypeItems,
 } from '../environment-utils';
 import './CreateEnvironmentForm.scss';
+import IngressDomainField from './IngressDomainField';
 import KubeconfigUploadField from './KubeconfigUploadField';
 
 export type CreateEnvironmentFormValues = {
@@ -28,6 +29,7 @@ export type CreateEnvironmentFormValues = {
   environmentType?: EnvironmentType;
   kubeconfig: string;
   targetNamespace: string;
+  ingressDomain: string;
 };
 
 type CreateEnvironmentFormProps = FormikProps<CreateEnvironmentFormValues>;
@@ -44,6 +46,7 @@ const CreateEnvironmentForm: React.FC<CreateEnvironmentFormProps> = ({
   isSubmitting,
   handleSubmit,
   handleReset,
+  values,
 }) => {
   const footer = (
     <FormFooter
@@ -100,6 +103,7 @@ const CreateEnvironmentForm: React.FC<CreateEnvironmentFormProps> = ({
               validateOnChange
               required
             />
+            <IngressDomainField clusterType={values.clusterType} />
             <KubeconfigUploadField name="kubeconfig" />
             <InputField
               label="Target namespace on the selected cluster"

--- a/src/components/Environment/create/IngressDomainField.tsx
+++ b/src/components/Environment/create/IngressDomainField.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { InputField } from '../../../shared';
+import { ClusterType, clusterTypeValues } from '../environment-utils';
+
+type IngressDomainFieldProps = {
+  clusterType: string;
+};
+
+const helpText =
+  `Enter the domain name to access the cluster's application and services. ` +
+  `For non-OpenShift clusters, it looks like $(minikube ip).nip.io and for OpenShift clusters, it looks like apps.xyz.rhcloud.com`;
+
+const IngressDomainField: React.FC<IngressDomainFieldProps> = ({ clusterType }) => {
+  if (clusterType !== clusterTypeValues[ClusterType.kubernetes]) {
+    return null;
+  }
+
+  return (
+    <InputField
+      label="Ingress domain"
+      aria-label="Ingress domain"
+      name="ingressDomain"
+      helpText={helpText}
+      required
+      placeholder="Enter the domain name"
+    />
+  );
+};
+
+export default IngressDomainField;

--- a/src/components/ImportForm/utils/validation-utils.ts
+++ b/src/components/ImportForm/utils/validation-utils.ts
@@ -11,6 +11,8 @@ export const resourceNameRegex = /^[a-z]([-a-z0-9]*[a-z0-9])?$/;
 export const filePathOrURLRegex =
   /^((^\.|^\.\.|^[\w-]+)(\/(?=[\w-])[\w-]+)*$)|(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/;
 
+export const dnsSubDomainRegex = /[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?/;
+
 const combineRegExps = (...regexps: RegExp[]) => {
   const regexStringsWithoutFlags = regexps.map((regex) => regex.source);
   return new RegExp(regexStringsWithoutFlags.join('|'));


### PR DESCRIPTION
## Fixes 
Fixes [HAC-3786](https://issues.redhat.com/browse/HAC-3786)

## Description
Adds an `Ingress domain` input when creating a non-OpenShift cluster environment.

## Type of change
- [x] Feature

## Screen shots / Gifs for design review 
![image](https://user-images.githubusercontent.com/11633780/234849231-e478989f-74c6-4e95-a9b9-a3f68ccd5676.png)

![image](https://user-images.githubusercontent.com/11633780/234849283-8d4b33c3-e984-43df-95df-750bd5f34731.png)

/cc @rohitkrai03 @karthikjeeyar 