### PR TITLE
change width for message and component column for enterprise contract table

### DIFF
--- a/src/components/EnterpriseContractView/EnterpriseContractTable/EnterpriseContractTable.tsx
+++ b/src/components/EnterpriseContractView/EnterpriseContractTable/EnterpriseContractTable.tsx
@@ -77,8 +77,8 @@ export const EnterpriseContractTable: React.FC<EnterpriseContractTableProps> = (
           <Th width={10} sort={getSortParams(2)}>
             Status
           </Th>
-          <Th width={20}>Message</Th>
-          <Th width={30} sort={getSortParams(4)}>
+          <Th width={30}>Message</Th>
+          <Th width={20} sort={getSortParams(4)}>
             Component
           </Th>
         </Tr>


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/HAC-3760

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
change the width of message column

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
**Before**
![image](https://user-images.githubusercontent.com/9278015/235191047-00824f0a-a345-4745-b8c6-3641c7dbb1d3.png)
**After**
![image (1)](https://user-images.githubusercontent.com/9278015/235191150-dd734d2f-8779-4fdb-9cf9-de6c267c5d61.png)


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
