### PR TITLE
Allow component instances to be scaled to 0

### DIFF
--- a/src/components/Components/ComponentListItem.tsx
+++ b/src/components/Components/ComponentListItem.tsx
@@ -179,7 +179,7 @@ export const ComponentListItem: React.FC<ComponentListViewItemProps> = ({
               </DescriptionListDescription>
             </DescriptionListGroup>
           )}
-          {replicas && (
+          {replicas !== undefined && (
             <DescriptionListGroup>
               <DescriptionListTerm>Instances</DescriptionListTerm>
               <DescriptionListDescription>{replicas}</DescriptionListDescription>

--- a/src/components/ImportForm/utils/__tests__/transform-utils.spec.ts
+++ b/src/components/ImportForm/utils/__tests__/transform-utils.spec.ts
@@ -1,3 +1,4 @@
+import { DetectedComponents } from '../../../../types';
 import { mockDetectedComponent } from '../__data__/mock-cdq';
 import { createResourceData, transformComponentValues } from '../transform-utils';
 import { CPUUnits, DetectedFormComponent, MemoryUnits } from '../types';
@@ -109,5 +110,24 @@ describe('Transform Utils', () => {
       userModifiedComponent,
     );
     expect(transformedComponentValues[0].componentStub.componentName).toBe('my-component-name');
+  });
+
+  it('should allow for 0 instances', () => {
+    const detectedFormComponent: DetectedComponents = {
+      ...mockDetectedComponent,
+      nodejs: {
+        ...mockDetectedComponent.nodejs,
+        componentStub: {
+          ...mockDetectedComponent.nodejs.componentStub,
+          replicas: 0,
+        },
+      },
+    };
+
+    const transformedComponentValues = transformComponentValues(
+      detectedFormComponent,
+      mockComponent,
+    );
+    expect(transformedComponentValues[0].componentStub.replicas).toBe(0);
   });
 });

--- a/src/components/ImportForm/utils/submit-utils.ts
+++ b/src/components/ImportForm/utils/submit-utils.ts
@@ -20,8 +20,6 @@ export const createComponents = async (
     const componentValues = {
       ...componentData,
       resources: componentData.resources && transformResources(componentData.resources),
-      replicas: componentData.replicas && Number(componentData.replicas),
-      targetPort: componentData.targetPort && Number(componentData.targetPort),
     };
     return createComponent(
       componentValues,

--- a/src/components/ImportForm/utils/transform-utils.ts
+++ b/src/components/ImportForm/utils/transform-utils.ts
@@ -57,7 +57,7 @@ export const transformComponentValues = (
             : component.componentName,
         }),
         resources: createResourceData(component?.resources || {}),
-        replicas: component?.replicas || 1,
+        replicas: component?.replicas === undefined ? 1 : component.replicas,
         targetPort: component?.targetPort || 8080,
       },
     };


### PR DESCRIPTION
## Fixes 
Addresses [RHTAPBUGS-12](https://issues.redhat.com/browse/RHTAPBUGS-12)

## Description
Fixes the UI side for setting and showing instances that are scaled to zero. However, the backend is clearing the replicas field when it is set to zero so the UI will still not show the scaling to zero.

## Type of change
- [x] Bugfix

/cc @karthikjeeyar @rohitkrai03 