### PR TITLE
Hide logs link when there are no vulnerabilities

### DIFF
--- a/src/components/PipelineRunDetailsView/tabs/ScanDescriptionListGroup.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/ScanDescriptionListGroup.tsx
@@ -106,7 +106,7 @@ const ScanDescriptionListGroup: React.FC<Props> = ({
       <DescriptionListTerm>Vulnerabilities scan</DescriptionListTerm>
       <DescriptionListDescription>
         {scanResults?.vulnerabilities ? <ScanDetailStatus scanResults={scanResults} /> : '-'}
-        {renderLogsLink()}
+        {scanResults?.vulnerabilities ? renderLogsLink() : null}
       </DescriptionListDescription>
     </DescriptionListGroup>
   );


### PR DESCRIPTION
## Fixes 
Fixes [RHTAPBUGS-210](https://issues.redhat.com/browse/RHTAPBUGS-210)

## Description
Hide the `View logs` link when there are no vulnerabilities

## Type of change
- [x] Bugfix

## Screen shots / Gifs for design review 
![image](https://user-images.githubusercontent.com/11633780/236298538-5ed24fd2-4036-47f5-b509-2e6d581d60f6.png)

/cc @christianvogt @rohitkrai03 
