### PR TITLE
Restrict resource name entries to 63 characters

### DIFF
--- a/src/components/Environment/EnvironmentCard.tsx
+++ b/src/components/Environment/EnvironmentCard.tsx
@@ -7,7 +7,6 @@ import {
   CardActions,
   CardBody,
   Text,
-  TextContent,
   TextVariants,
   Label,
   DescriptionList,
@@ -76,11 +75,9 @@ const EnvironmentCard: React.FC<EnvironmentCardProps> = ({ environment, readOnly
     <Card isFlat>
       <CardHeader>
         <CardTitle>
-          <TextContent>
-            <Text component={TextVariants.h3}>
-              {environment.spec?.displayName ?? environment.metadata.name}
-            </Text>
-          </TextContent>
+          <div className="environment-list__card-title">
+            {environment.spec?.displayName ?? environment.metadata.name}
+          </div>
           <EnvConnectionStatus environment={environment} />
         </CardTitle>
         {!readOnly && actions?.length ? (

--- a/src/components/Environment/EnvironmentList.scss
+++ b/src/components/Environment/EnvironmentList.scss
@@ -1,5 +1,15 @@
 .environment-list {
   &_card .pf-c-card {
     height: 100%;
+
+    .pf-c-card__title {
+      overflow-x: hidden;
+      white-space: nowrap;
+    }
+  }
+  &__card-title {
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+    margin-bottom: var(--pf-global--spacer--xs);
   }
 }

--- a/src/components/Environment/create/__tests__/CreateEnvironment.spec.tsx
+++ b/src/components/Environment/create/__tests__/CreateEnvironment.spec.tsx
@@ -63,7 +63,7 @@ users:
 
 describe('CreateEnvironment', () => {
   const fillEnvironmentForm = () => {
-    fireEvent.input(screen.getByLabelText('Environment name'), { target: { value: 'Env 1' } });
+    fireEvent.input(screen.getByLabelText('Environment name'), { target: { value: 'env-1' } });
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Select' })[0]);
     fireEvent.click(screen.getByText('I want to bring my own cluster'));
@@ -137,7 +137,7 @@ describe('CreateEnvironment', () => {
           },
           spec: {
             deploymentStrategy: 'AppStudioAutomated',
-            displayName: 'Env 1',
+            displayName: 'env-1',
             tags: ['managed'],
             unstableConfigurationFields: {
               clusterType: 'OpenShift',
@@ -210,7 +210,7 @@ describe('CreateEnvironment', () => {
           },
           spec: {
             deploymentStrategy: 'AppStudioAutomated',
-            displayName: 'Env 1',
+            displayName: 'env-1',
             tags: ['managed'],
             unstableConfigurationFields: {
               clusterType: 'Kubernetes',

--- a/src/components/Environment/environment-utils.ts
+++ b/src/components/Environment/environment-utils.ts
@@ -10,7 +10,13 @@ import {
 } from '../../models';
 import { GitOpsDeploymentManagedEnvironmentKind, EnvironmentKind, SecretKind } from '../../types';
 import { ReleasePlanKind } from '../../types/coreBuildService';
-import { dnsSubDomainRegex, resourceNameRegex } from '../ImportForm/utils/validation-utils';
+import {
+  dnsSubDomainRegex,
+  MAX_RESOURCE_NAME_LENGTH,
+  RESOURCE_NAME_LENGTH_ERROR_MSG,
+  RESOURCE_NAME_REGEX_MSG,
+  resourceNameRegex,
+} from '../ImportForm/utils/validation-utils';
 import { CreateEnvironmentFormValues } from './create/CreateEnvironmentForm';
 
 export enum EnvironmentDeploymentStrategy {
@@ -57,7 +63,11 @@ export const clusterTypeItems = [
 ];
 
 export const environmentFormSchema = yup.object({
-  name: yup.string().trim().min(1).required('Required'),
+  name: yup
+    .string()
+    .matches(resourceNameRegex, RESOURCE_NAME_REGEX_MSG)
+    .max(MAX_RESOURCE_NAME_LENGTH, RESOURCE_NAME_LENGTH_ERROR_MSG)
+    .required('Required'),
   deploymentStrategy: yup.string().required('Required'),
   environmentType: yup.string().required('Required'),
   clusterType: yup.string().required('Required'),
@@ -90,10 +100,7 @@ export const environmentFormSchema = yup.object({
     ),
   targetNamespace: yup
     .string()
-    .matches(
-      resourceNameRegex,
-      'Must start with a letter and end with a letter or number. Valid characters include lowercase letters from a to z, numbers from 0 to 9, and hyphens ( - ).',
-    )
+    .matches(resourceNameRegex, RESOURCE_NAME_REGEX_MSG)
     .required('Required'),
 });
 

--- a/src/components/ImportForm/utils/__tests__/validation-utils.spec.ts
+++ b/src/components/ImportForm/utils/__tests__/validation-utils.spec.ts
@@ -1,5 +1,6 @@
 import {
   containerImageRegex,
+  RESOURCE_NAME_REGEX_MSG,
   resourceNameRegex,
   reviewValidationSchema,
 } from '../validation-utils';
@@ -34,25 +35,15 @@ describe('Review form validation schema', () => {
       ],
       isDetected: true,
     };
-    await expect(reviewValidationSchema.validate(values)).rejects.toThrow(
-      'Must start with a letter and end with a letter or number. Valid characters include lowercase letters from a to z, numbers from 0 to 9, and hyphens ( - ).',
-    );
+    await expect(reviewValidationSchema.validate(values)).rejects.toThrow(RESOURCE_NAME_REGEX_MSG);
     values.components[0].componentStub.componentName = 'Test-';
-    await expect(reviewValidationSchema.validate(values)).rejects.toThrow(
-      'Must start with a letter and end with a letter or number. Valid characters include lowercase letters from a to z, numbers from 0 to 9, and hyphens ( - ).',
-    );
+    await expect(reviewValidationSchema.validate(values)).rejects.toThrow(RESOURCE_NAME_REGEX_MSG);
     values.components[0].componentStub.componentName = 'test-@!';
-    await expect(reviewValidationSchema.validate(values)).rejects.toThrow(
-      'Must start with a letter and end with a letter or number. Valid characters include lowercase letters from a to z, numbers from 0 to 9, and hyphens ( - ).',
-    );
+    await expect(reviewValidationSchema.validate(values)).rejects.toThrow(RESOURCE_NAME_REGEX_MSG);
     values.components[0].componentStub.componentName = '-test';
-    await expect(reviewValidationSchema.validate(values)).rejects.toThrow(
-      'Must start with a letter and end with a letter or number. Valid characters include lowercase letters from a to z, numbers from 0 to 9, and hyphens ( - ).',
-    );
+    await expect(reviewValidationSchema.validate(values)).rejects.toThrow(RESOURCE_NAME_REGEX_MSG);
     values.components[0].componentStub.componentName = '1-test';
-    await expect(reviewValidationSchema.validate(values)).rejects.toThrow(
-      'Must start with a letter and end with a letter or number. Valid characters include lowercase letters from a to z, numbers from 0 to 9, and hyphens ( - ).',
-    );
+    await expect(reviewValidationSchema.validate(values)).rejects.toThrow(RESOURCE_NAME_REGEX_MSG);
   });
 
   it('should pass when target port is not provided', async () => {

--- a/src/components/ImportForm/utils/validation-utils.ts
+++ b/src/components/ImportForm/utils/validation-utils.ts
@@ -6,7 +6,12 @@ export const gitUrlRegex =
 // generic regex to validate container image /^[^/]+\.[^/.]+\/([a-z0-9-_]+\/)?[^/.]+(:.+)?$/
 export const containerImageRegex = /^(https:\/\/)?quay.io\/([a-z0-9-_]+\/)?[^/.]+(:.+)?$/;
 
+export const MAX_RESOURCE_NAME_LENGTH = 63;
+export const RESOURCE_NAME_LENGTH_ERROR_MSG = `Must be no more than ${MAX_RESOURCE_NAME_LENGTH} characters.`;
+
 export const resourceNameRegex = /^[a-z]([-a-z0-9]*[a-z0-9])?$/;
+export const RESOURCE_NAME_REGEX_MSG =
+  'Must start with a letter and end with a letter or number. Valid characters include lowercase letters from a to z, numbers from 0 to 9, and hyphens ( - ).';
 
 export const filePathOrURLRegex =
   /^((^\.|^\.\.|^[\w-]+)(\/(?=[\w-])[\w-]+)*$)|(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/;
@@ -52,20 +57,16 @@ export const sampleValidationSchema = yup.object({
 export const reviewValidationSchema = yup.object({
   application: yup
     .string()
-    .matches(
-      resourceNameRegex,
-      'Must start with a letter and end with a letter or number. Valid characters include lowercase letters from a to z, numbers from 0 to 9, and hyphens ( - ).',
-    )
+    .matches(resourceNameRegex, RESOURCE_NAME_REGEX_MSG)
+    .max(MAX_RESOURCE_NAME_LENGTH, RESOURCE_NAME_LENGTH_ERROR_MSG)
     .required('Required'),
   components: yup.array().of(
     yup.object({
       componentStub: yup.object({
         componentName: yup
           .string()
-          .matches(
-            resourceNameRegex,
-            'Must start with a letter and end with a letter or number. Valid characters include lowercase letters from a to z, numbers from 0 to 9, and hyphens ( - ).',
-          )
+          .matches(resourceNameRegex, RESOURCE_NAME_REGEX_MSG)
+          .max(MAX_RESOURCE_NAME_LENGTH, RESOURCE_NAME_LENGTH_ERROR_MSG)
           .required('Required'),
         targetPort: yup
           .number()
@@ -105,10 +106,8 @@ export const SecretFromSchema = yup.object({
   secretName: yup
     .string()
     .required('Required')
-    .matches(
-      resourceNameRegex,
-      'Must start with a letter and end with a letter or number. Valid characters include lowercase letters from a to z, numbers from 0 to 9, and hyphens ( - ).',
-    )
+    .matches(resourceNameRegex, RESOURCE_NAME_REGEX_MSG)
+    .max(MAX_RESOURCE_NAME_LENGTH, RESOURCE_NAME_LENGTH_ERROR_MSG)
     .test(
       'existing-secret-test',
       'Secret already exists',

--- a/src/components/IntegrationTest/IntegrationTestForm/IntegrationTestSection.tsx
+++ b/src/components/IntegrationTest/IntegrationTestForm/IntegrationTestSection.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { FormSection, Text, TextContent, TextVariants } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
 import { CheckboxField, InputField } from '../../../shared';
+import { RESOURCE_NAME_REGEX_MSG } from '../../ImportForm/utils/validation-utils';
 import { FormValues } from './types';
 
 type Props = { isInPage?: boolean; edit?: boolean };
@@ -33,11 +34,7 @@ const IntegrationTestSection: React.FC<Props> = ({ isInPage, edit }) => {
         <InputField
           label="Integration test name"
           name="integrationTest.name"
-          helpText={
-            edit
-              ? ''
-              : 'Must start with a letter and end with a letter or number. Valid characters include lowercase letters from a to z, numbers from 0 to 9, and hyphens ( - ).'
-          }
+          helpText={edit ? '' : RESOURCE_NAME_REGEX_MSG}
           data-test="display-name-input"
           isReadOnly={edit}
           required

--- a/src/components/IntegrationTest/IntegrationTestForm/utils/validation-utils.ts
+++ b/src/components/IntegrationTest/IntegrationTestForm/utils/validation-utils.ts
@@ -1,5 +1,9 @@
 import * as yup from 'yup';
-import { containerImageRegex } from '../../../ImportForm/utils/validation-utils';
+import {
+  containerImageRegex,
+  MAX_RESOURCE_NAME_LENGTH,
+  RESOURCE_NAME_LENGTH_ERROR_MSG,
+} from '../../../ImportForm/utils/validation-utils';
 
 const k8sResourceNameRegex =
   /^\s*?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\s*?$/;
@@ -12,7 +16,8 @@ export const integrationTestValidationSchema = yup.object({
       .matches(
         k8sResourceNameRegex,
         'Must start with a letter or number and end with a letter or number. Valid characters include lowercase letters from a to z, numbers from 0 to 9, and hyphens ( - ).',
-      ),
+      )
+      .max(MAX_RESOURCE_NAME_LENGTH, RESOURCE_NAME_LENGTH_ERROR_MSG),
     pipeline: yup.string().required('Required'),
     bundle: yup
       .string()


### PR DESCRIPTION
## Fixes 
Fixes [RHTAPBUGS-215](https://issues.redhat.com/browse/RHTAPBUGS-215)

## Description
Limits user entry of resource names to 64 characters. Also fixes a text overflow issue for environment cards when the environment name is very long (env names are not restricted in length).

## Type of change
- [x] Bugfix

/cc @christianvogt @rohitkrai03 