### PR TITLE
Fix to show CVE_SCAN_RESULT status in nodes

### DIFF
--- a/src/components/PipelineRunDetailsView/__data__/mockVisualizationData.ts
+++ b/src/components/PipelineRunDetailsView/__data__/mockVisualizationData.ts
@@ -2723,7 +2723,7 @@ export const mockPipelineRun = {
             ],
             taskResults: [
               {
-                name: 'CLAIR_SCAN_RESULT',
+                name: 'CVE_SCAN_RESULT',
                 type: 'string',
                 value: '{"vulnerabilities":{"critical":1,"high":1,"medium":1,"low":1}}\n',
               },
@@ -3952,7 +3952,7 @@ export const mockPipelineRun = {
           ],
           taskResults: [
             {
-              name: 'CLAIR_SCAN_RESULT',
+              name: 'CVE_SCAN_RESULT',
               type: 'string',
               value: '{"vulnerabilities":{"critical":1,"high":1,"medium":1,"low":1}}\n',
             },
@@ -6221,7 +6221,7 @@ export const mockTaskRuns = [
             exitCode: 0,
             finishedAt: '2023-03-16T01:01:11Z',
             message:
-              '[{"key":"CLAIR_SCAN_RESULT","value":"{\\"vulnerabilities\\":{\\"critical\\":1,\\"high\\":1,\\"medium\\":1,\\"low\\":1}}\\n","type":1},{"key":"TEST_OUTPUT","value":"{\\"result\\":\\"SUCCESS\\",\\"timestamp\\":\\"1678928471\\",\\"note\\":\\"Please refer to result CLAIR_SCAN_RESULT for the vulnerabilities scanned by clair\\",\\"namespace\\":\\"default\\",\\"successes\\":0,\\"failures\\":0,\\"warnings\\":0}\\n","type":1}]',
+              '[{"key":"CVE_SCAN_RESULT","value":"{\\"vulnerabilities\\":{\\"critical\\":1,\\"high\\":1,\\"medium\\":1,\\"low\\":1}}\\n","type":1},{"key":"TEST_OUTPUT","value":"{\\"result\\":\\"SUCCESS\\",\\"timestamp\\":\\"1678928471\\",\\"note\\":\\"Please refer to result CLAIR_SCAN_RESULT for the vulnerabilities scanned by clair\\",\\"namespace\\":\\"default\\",\\"successes\\":0,\\"failures\\":0,\\"warnings\\":0}\\n","type":1}]',
             reason: 'Completed',
             startedAt: '2023-03-16T01:01:11Z',
           },
@@ -6229,7 +6229,7 @@ export const mockTaskRuns = [
       ],
       taskResults: [
         {
-          name: 'CLAIR_SCAN_RESULT',
+          name: 'CVE_SCAN_RESULT',
           type: 'string',
           value: '{"vulnerabilities":{"critical":1,"high":1,"medium":1,"low":1}}\n',
         },
@@ -6237,7 +6237,7 @@ export const mockTaskRuns = [
           name: 'TEST_OUTPUT',
           type: 'string',
           value:
-            '{"result":"SUCCESS","timestamp":"1678928471","note":"Please refer to result CLAIR_SCAN_RESULT for the vulnerabilities scanned by clair","namespace":"default","successes":0,"failures":0,"warnings":0}\n',
+            '{"result":"SUCCESS","timestamp":"1678928471","note":"Please refer to result CVE_SCAN_RESULT for the vulnerabilities scanned by clair","namespace":"default","successes":0,"failures":0,"warnings":0}\n',
         },
       ],
       taskSpec: {
@@ -6267,7 +6267,7 @@ export const mockTaskRuns = [
           },
           {
             description: 'clair scan result',
-            name: 'CLAIR_SCAN_RESULT',
+            name: 'CVE_SCAN_RESULT',
             type: 'string',
           },
         ],

--- a/src/components/PipelineRunDetailsView/tabs/__tests__/ScanDescriptionListGroup.spec.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/__tests__/ScanDescriptionListGroup.spec.tsx
@@ -28,7 +28,7 @@ const mockTaskRun = {
   status: {
     taskResults: [
       {
-        name: 'CLAIR_SCAN_RESULT',
+        name: 'CVE_SCAN_RESULT',
         value: '{"vulnerabilities":{"critical":1,"high":2,"medium":3,"low":4}}',
       },
     ],
@@ -47,7 +47,7 @@ const mockTaskRun2 = {
   status: {
     taskResults: [
       {
-        name: 'CLAIR_SCAN_RESULT',
+        name: 'CVE_SCAN_RESULT',
         value: '{"vulnerabilities":{"critical":1,"high":2,"medium":3,"low":4}}',
       },
     ],

--- a/src/components/PipelineRunDetailsView/visualization/utils/pipelinerun-graph-utils.ts
+++ b/src/components/PipelineRunDetailsView/visualization/utils/pipelinerun-graph-utils.ts
@@ -10,7 +10,7 @@ import {
   WhenStatus,
 } from '@patternfly/react-topology';
 import { PipelineNodeModel } from '@patternfly/react-topology/src/pipelines/types';
-import { SCAN_RESULT } from '../../../../hooks/useScanResults';
+import { isCVEScanResult } from '../../../../hooks/useScanResults';
 import { formatPrometheusDuration } from '../../../../shared/components/timestamp/datetime';
 import {
   TaskRunKind,
@@ -210,9 +210,7 @@ export const appendStatus = (
           // ignore
         }
       }
-      const scanResult = taskRun?.status?.taskResults?.find(
-        (result) => result.name === SCAN_RESULT,
-      );
+      const scanResult = taskRun?.status?.taskResults?.find((result) => isCVEScanResult(result));
 
       if (scanResult) {
         try {

--- a/src/hooks/__tests__/useScanResults.spec.ts
+++ b/src/hooks/__tests__/useScanResults.spec.ts
@@ -36,7 +36,7 @@ describe('useScanResults', () => {
           status: {
             taskResults: [
               {
-                name: 'CLAIR_SCAN_RESULT',
+                name: 'CVE_SCAN_RESULT',
                 value: '{ "vulnerabilities": { "critical": 1, "high": 2, "medium": 3, "low": 4 } }',
               },
             ],

--- a/src/hooks/useScanResults.ts
+++ b/src/hooks/useScanResults.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { TektonResourceLabel, TaskRunKind } from '../types';
+import { TektonResourceLabel, TaskRunKind, TektonResultsRun } from '../types';
 import { useWorkspaceInfo } from '../utils/workspace-context-utils';
 import { useTaskRuns } from './useTaskRuns';
 
@@ -7,6 +7,16 @@ export const SCAN_RESULT = 'CLAIR_SCAN_RESULT';
 export const SCAN_RESULTS = 'CLAIR_SCAN_RESULTS';
 export const CVE_SCAN_RESULT = 'CVE_SCAN_RESULT';
 export const TEKTON_SCAN_RESULTS = 'TEKTON_SCAN_RESULTS';
+
+export const CVE_SCAN_RESULT_FIELDS = [
+  SCAN_RESULT,
+  SCAN_RESULTS,
+  CVE_SCAN_RESULT,
+  TEKTON_SCAN_RESULTS,
+];
+
+export const isCVEScanResult = (taskRunResults: TektonResultsRun) =>
+  CVE_SCAN_RESULT_FIELDS.includes(taskRunResults?.name);
 
 export type ScanResults = {
   vulnerabilities: {
@@ -20,12 +30,8 @@ export type ScanResults = {
 export const getScanResults = (taskRuns: TaskRunKind[]): [ScanResults, TaskRunKind[]] => {
   const scanResults = taskRuns.reduce(
     (acc, scanTaskRun) => {
-      const taskScanResult = scanTaskRun?.status?.taskResults?.find(
-        (result) =>
-          result.name === SCAN_RESULT ||
-          result.name === SCAN_RESULTS ||
-          result.name === CVE_SCAN_RESULT ||
-          result.name === TEKTON_SCAN_RESULTS,
+      const taskScanResult = scanTaskRun?.status?.taskResults?.find((result) =>
+        isCVEScanResult(result),
       );
       if (taskScanResult) {
         acc[1].push(scanTaskRun);

--- a/src/utils/pipeline-utils.ts
+++ b/src/utils/pipeline-utils.ts
@@ -1,6 +1,6 @@
 import merge from 'lodash/merge';
 import { preferredNameAnnotation } from '../consts/pipeline';
-import { ScanResults, SCAN_RESULT } from '../hooks/useScanResults';
+import { ScanResults, isCVEScanResult } from '../hooks/useScanResults';
 import { PipelineRunModel } from '../models';
 import {
   Condition,
@@ -235,7 +235,7 @@ export const taskResultsStatus = (taskResults: TektonResultsRun[]): runStatus =>
       // ignore
     }
   }
-  const scanResult = taskResults?.find((result) => result.name === SCAN_RESULT);
+  const scanResult = taskResults?.find((result) => isCVEScanResult(result));
   if (scanResult) {
     try {
       const resultObj: ScanResults = JSON.parse(scanResult.value);


### PR DESCRIPTION
## Fixes 
Fixes [RHTAPBUGS-230](https://issues.redhat.com/browse/RHTAPBUGS-230)

## Description
Include any of the various names for CVE scan results when determining task run results status.

## Type of change
- [x] Bugfix

/cc @christianvogt @karthikjeeyar 