### PR TITLE
Fix docker file path to allow extensions

### DIFF
--- a/src/components/ImportForm/utils/__tests__/validation-utils.spec.ts
+++ b/src/components/ImportForm/utils/__tests__/validation-utils.spec.ts
@@ -200,7 +200,7 @@ describe('Review form validation schema', () => {
       'Must be a valid relative file path or URL.',
     );
   });
-  it('should pass when dockerfileUrl is a relative pat', async () => {
+  it('should pass when dockerfileUrl is a relative path', async () => {
     const values = {
       application: 'my-app',
       components: [
@@ -223,16 +223,75 @@ describe('Review form validation schema', () => {
     };
     await expect(reviewValidationSchema.validate(values)).resolves.toBe(values);
 
+    values.components[0].componentStub.source.git.dockerfileUrl = 'Dockerfile';
+    await expect(reviewValidationSchema.validate(values)).resolves.toBe(values);
+
     values.components[0].componentStub.source.git.dockerfileUrl = '../Dockerfile';
     await expect(reviewValidationSchema.validate(values)).resolves.toBe(values);
 
     values.components[0].componentStub.source.git.dockerfileUrl = 'directory/Dockerfile';
     await expect(reviewValidationSchema.validate(values)).resolves.toBe(values);
 
+    values.components[0].componentStub.source.git.dockerfileUrl = 'directory/Dockerfile.prod';
+    await expect(reviewValidationSchema.validate(values)).resolves.toBe(values);
+
+    values.components[0].componentStub.source.git.dockerfileUrl = '.hidden/Dockerfile.prod';
+    await expect(reviewValidationSchema.validate(values)).resolves.toBe(values);
+
+    values.components[0].componentStub.source.git.dockerfileUrl = '.Dockerfile.prod';
+    await expect(reviewValidationSchema.validate(values)).resolves.toBe(values);
+
+    values.components[0].componentStub.source.git.dockerfileUrl = 'Dockerfile.prod.bad';
+    await expect(reviewValidationSchema.validate(values)).rejects.toThrow(
+      'Must be a valid relative file path or URL.',
+    );
+
     values.components[0].componentStub.source.git.dockerfileUrl = '/Dockerfile';
     await expect(reviewValidationSchema.validate(values)).rejects.toThrow(
       'Must be a valid relative file path or URL.',
     );
+  });
+
+  it('should pass when dockerfileUrl is a URL', async () => {
+    const values = {
+      application: 'my-app',
+      components: [
+        {
+          componentStub: {
+            componentName: 'test-comp',
+            resources: {
+              cpu: 1,
+              memory: 512,
+            },
+            source: {
+              git: {
+                dockerfileUrl: 'https://www.test.com/Dockerfile',
+              },
+            },
+          },
+        },
+      ],
+      isDetected: true,
+    };
+    await expect(reviewValidationSchema.validate(values)).resolves.toBe(values);
+
+    values.components[0].componentStub.source.git.dockerfileUrl =
+      'https://www.test.com/directory/Dockerfile';
+    await expect(reviewValidationSchema.validate(values)).resolves.toBe(values);
+
+    values.components[0].componentStub.source.git.dockerfileUrl =
+      'https://www.test.com/directory/Dockerfile.prod';
+    await expect(reviewValidationSchema.validate(values)).resolves.toBe(values);
+
+    values.components[0].componentStub.source.git.dockerfileUrl =
+      'https://www.test.com:4000/Dockerfile';
+    await expect(reviewValidationSchema.validate(values)).resolves.toBe(values);
+
+    values.components[0].componentStub.source.git.dockerfileUrl = 'http://www.test.com/Dockerfile';
+    await expect(reviewValidationSchema.validate(values)).resolves.toBe(values);
+
+    values.components[0].componentStub.source.git.dockerfileUrl = 'www.test.com/Dockerfile';
+    await expect(reviewValidationSchema.validate(values)).resolves.toBe(values);
   });
 });
 

--- a/src/components/ImportForm/utils/validation-utils.ts
+++ b/src/components/ImportForm/utils/validation-utils.ts
@@ -14,7 +14,7 @@ export const RESOURCE_NAME_REGEX_MSG =
   'Must start with a letter and end with a letter or number. Valid characters include lowercase letters from a to z, numbers from 0 to 9, and hyphens ( - ).';
 
 export const filePathOrURLRegex =
-  /^((^\.|^\.\.|^[\w-]+)(\/(?=[\w-])[\w-]+)*$)|(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/;
+  /^((^\.|^\.\.|^\.?[\w-]+)(\/\.?(?=[\w-])[\w-]+)*(\.[\w-]+)?$)|(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/;
 
 export const dnsSubDomainRegex = /[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?/;
 


### PR DESCRIPTION
## Fixes 
Fixes [RHTAPBUGS-234](https://issues.redhat.com/browse/RHTAPBUGS-234)

## Description
Allows extensions to dockerfile file name when importing a component.

## Type of change
- [x] Bugfix

/cc @christianvogt @rohitkrai03 
