### PR TITLE
Fix scan results view in pipeline run task list

### DIFF
--- a/src/components/PipelineRunDetailsView/tabs/ScanDetailStatus.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/ScanDetailStatus.tsx
@@ -21,12 +21,17 @@ export const MediumIcon = () => <EqualsIcon title="Medium" color={goldColor.valu
 
 export const LowIcon = () => <AngleDoubleDownIcon title="Low" color={blueColor.value} />;
 
-export const ScanDetailStatus: React.FC<{ scanResults: ScanResults }> = ({ scanResults }) => (
+type ScanDetailStatusProps = {
+  scanResults: ScanResults;
+  condensed?: boolean;
+};
+
+export const ScanDetailStatus: React.FC<ScanDetailStatusProps> = ({ scanResults, condensed }) => (
   <div className="scan-detail-status">
     <div className="scan-detail-status__severity" data-testid="scan-status-critical-test-id">
       <span className="scan-detail-status__severity-status">
         <CriticalIcon />
-        Critical
+        {!condensed ? 'Critical' : null}
       </span>
       <span className="scan-detail-status__severity-count">
         {scanResults.vulnerabilities.critical}
@@ -35,14 +40,14 @@ export const ScanDetailStatus: React.FC<{ scanResults: ScanResults }> = ({ scanR
     <div className="scan-detail-status__severity" data-testid="scan-status-high-test-id">
       <span className="scan-detail-status__severity-status">
         <HighIcon />
-        High
+        {!condensed ? 'High' : null}
       </span>
       <span className="scan-detail-status__severity-count">{scanResults.vulnerabilities.high}</span>
     </div>
     <div className="scan-detail-status__severity" data-testid="scan-status-medium-test-id">
       <span className="scan-detail-status__severity-status">
         <MediumIcon />
-        Medium
+        {!condensed ? 'Medium' : null}
       </span>
       <span className="scan-detail-status__severity-count">
         {scanResults.vulnerabilities.medium}
@@ -51,7 +56,7 @@ export const ScanDetailStatus: React.FC<{ scanResults: ScanResults }> = ({ scanR
     <div className="scan-detail-status__severity" data-testid="scan-status-low-test-id">
       <span className="scan-detail-status__severity-status">
         <LowIcon />
-        Low
+        {!condensed ? 'Low' : null}
       </span>
       <span className="scan-detail-status__severity-count">{scanResults.vulnerabilities.low}</span>
     </div>

--- a/src/components/PipelineRunListView/PipelineRunListRow.tsx
+++ b/src/components/PipelineRunListView/PipelineRunListRow.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { PipelineRunLabel } from '../../consts/pipelinerun';
+import { ScanResults } from '../../hooks/useScanResults';
 import ActionMenu from '../../shared/components/action-menu/ActionMenu';
 import { RowFunctionArgs, TableData } from '../../shared/components/table';
 import { Timestamp } from '../../shared/components/timestamp/Timestamp';
@@ -12,7 +13,9 @@ import { usePipelinerunActions } from './pipelinerun-actions';
 import { pipelineRunTableColumnClasses } from './PipelineRunListHeader';
 import { ScanStatus } from './ScanStatus';
 
-const PipelineListRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({ obj }) => {
+type PipelineListRowProps = RowFunctionArgs<PipelineRunKind & { scanResults: ScanResults }>;
+
+const PipelineListRow: React.FC<PipelineListRowProps> = ({ obj }) => {
   const capitalize = (label: string) => {
     return label && label.charAt(0).toUpperCase() + label.slice(1);
   };
@@ -38,7 +41,7 @@ const PipelineListRow: React.FC<RowFunctionArgs<PipelineRunKind>> = ({ obj }) =>
         />
       </TableData>
       <TableData className={pipelineRunTableColumnClasses.vulnerabilities}>
-        <ScanStatus pipelineRunName={obj.metadata?.name} />
+        <ScanStatus scanResults={obj.scanResults} />
       </TableData>
       <TableData className={pipelineRunTableColumnClasses.duration}>
         {status !== 'Pending'

--- a/src/components/PipelineRunListView/ScanStatus.tsx
+++ b/src/components/PipelineRunListView/ScanStatus.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import { Skeleton } from '@patternfly/react-core';
-import { useScanResults } from '../../hooks/useScanResults';
+import { ScanResults } from '../../hooks/useScanResults';
 import { ScanDetailStatus } from '../PipelineRunDetailsView/tabs/ScanDetailStatus';
 
-export const ScanStatus: React.FC<{ pipelineRunName: string }> = ({ pipelineRunName }) => {
-  const [scanResults, loaded] = useScanResults(pipelineRunName);
-
-  if (!loaded) {
+export const ScanStatus: React.FC<{ scanResults?: ScanResults }> = ({ scanResults }) => {
+  if (scanResults === undefined) {
     return <Skeleton screenreaderText="Loading Vulnerability Scan status" />;
   }
 
@@ -14,5 +12,5 @@ export const ScanStatus: React.FC<{ pipelineRunName: string }> = ({ pipelineRunN
     return <>-</>;
   }
 
-  return <ScanDetailStatus scanResults={scanResults} />;
+  return <ScanDetailStatus scanResults={scanResults} condensed />;
 };

--- a/src/components/PipelineRunListView/__tests__/ScanStatus.spec.tsx
+++ b/src/components/PipelineRunListView/__tests__/ScanStatus.spec.tsx
@@ -1,34 +1,23 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { useScanResults } from '../../../hooks/useScanResults';
 import { ScanStatus } from '../ScanStatus';
-
-jest.mock('../../../hooks/useScanResults', () => ({
-  useScanResults: jest.fn(),
-}));
-
-const mockScanResults = useScanResults as jest.Mock;
 
 describe('ScanStatus', () => {
   it('shows loading indicator if results are not fetched', () => {
-    mockScanResults.mockReturnValue([null, false]);
-    const { container } = render(<ScanStatus pipelineRunName="test" />);
+    const { container } = render(<ScanStatus scanResults={undefined} />);
     expect(container).toHaveTextContent('Loading Vulnerability Scan status');
   });
 
   it('shows empty state if results are not available', () => {
-    mockScanResults.mockReturnValue([null, true]);
-    const { container } = render(<ScanStatus pipelineRunName="test" />);
+    const { container } = render(<ScanStatus scanResults={null} />);
     expect(container).toHaveTextContent('-');
   });
 
   it('shows scan results after values are fetched', () => {
-    mockScanResults.mockReturnValue([
-      { vulnerabilities: { critical: 1, high: 2, medium: 3, low: 4 } },
-      true,
-    ]);
-    render(<ScanStatus pipelineRunName="test" />);
+    render(
+      <ScanStatus scanResults={{ vulnerabilities: { critical: 1, high: 2, medium: 3, low: 4 } }} />,
+    );
     expect(screen.getByTestId('scan-status-critical-test-id')).toHaveTextContent('Critical1');
     expect(screen.getByTestId('scan-status-high-test-id')).toHaveTextContent('High2');
     expect(screen.getByTestId('scan-status-medium-test-id')).toHaveTextContent('Medium3');


### PR DESCRIPTION
## Fixes 
Fixes [RHTAPBUGS-232](https://issues.redhat.com/browse/RHTAPBUGS-232)

## Description
Fixes vulnerabilities column in task run list for the pipeline run details view. Remove text from list row cell. Update view when all task runs have been retrieved to size cells correctly.

## Type of change
- [x] Bugfix

## Screen shots / Gifs for design review 
![image](https://user-images.githubusercontent.com/11633780/236902522-7adce7f1-1621-438b-b1f6-9aa1d7dcb018.png)

/cc @christianvogt @rohitkrai03 