### PR TITLE
Add route for environments when no workspace

### DIFF
--- a/config/remotePlugin.js
+++ b/config/remotePlugin.js
@@ -408,6 +408,19 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
+      path: '/application-pipeline/environments/workspaces',
+      exact: true,
+      component: {
+        $codeRef: 'EnvironmentsListPage',
+      },
+    },
+    flags: {
+      required: ['SIGNUP'],
+    },
+  },
+  {
+    type: 'core.page/route',
+    properties: {
       path: '/application-pipeline/environments/workspaces/:workspaceName/create',
       exact: true,
       component: {


### PR DESCRIPTION
## Fixes 
Fixes [RHTAPBUGS-240](https://issues.redhat.com/browse/RHTAPBUGS-240)

## Description
Handles the route to environments when no workspace is set. The environments page uses the last used workspace.

## Type of change
- [x] Bugfix

/cc @christianvogt @rohitkrai03 