### PR TITLE
fix UI crashing when taskrun contains taskspec

### DIFF
--- a/src/components/TaskRunDetailsView/tabs/TaskRunDetailsTab.tsx
+++ b/src/components/TaskRunDetailsView/tabs/TaskRunDetailsTab.tsx
@@ -103,7 +103,7 @@ const TaskRunDetailsTab: React.FC<TaskRunDetailsTabProps> = ({ taskRun, error })
                   default: '1Col',
                 }}
               >
-                {taskRun.spec.taskRef.name && (
+                {taskRun.spec.taskRef?.name && (
                   <DescriptionListGroup>
                     <DescriptionListTerm>Task</DescriptionListTerm>
                     <DescriptionListDescription>

--- a/src/components/TaskRunDetailsView/tabs/__tests__/TaskRunDetailsTab.spec.tsx
+++ b/src/components/TaskRunDetailsView/tabs/__tests__/TaskRunDetailsTab.spec.tsx
@@ -29,6 +29,28 @@ describe('TaskRunDetailsTab', () => {
     expect(screen.queryByText('Task run details')).toBeInTheDocument();
   });
 
+  it('should render the taskrun details tab for embeddedt taskrun', () => {
+    watchResourceMock.mockReturnValue([[], true]);
+    const taskRunWithSpec = {
+      ...testTaskRuns[0],
+      spec: {
+        taskSpec: {
+          steps: [
+            {
+              image: 'ubuntu',
+              name: 'echo',
+              script: '#!/usr/bin/env bash\necho "Hello world!"\n',
+            },
+          ],
+        },
+      },
+    };
+    render(<TaskRunDetailsTab taskRun={taskRunWithSpec} error={null} />, {
+      wrapper: BrowserRouter,
+    });
+    expect(screen.queryByText('Task run details')).toBeInTheDocument();
+  });
+
   it('should render the taskrun and task name and description', () => {
     watchResourceMock.mockReturnValue([[], true]);
     render(<TaskRunDetailsTab taskRun={testTaskRuns[0]} error={null} />, {


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/RHTAPBUGS-253

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

UI crashes when you visit taskrun details page which contains embedded taskspec.



## Type of change
<!-- Please delete options that are not relevant. -->


- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:
<img width="1791" alt="Screenshot 2023-05-10 at 1 29 51 PM" src="https://github.com/openshift/hac-dev/assets/9964343/7ed3cb3e-d0be-490d-a0f4-9c0a3b70eaa9">

After:
<img width="1792" alt="Screenshot 2023-05-10 at 1 45 19 PM" src="https://github.com/openshift/hac-dev/assets/9964343/4d1ec013-a2a0-4d81-baa7-b03bfe6f9ad2">

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->


Add a custom task (with taskspec) in your build pipeline
eg:

```
  - name: echo-message
      taskSpec:
        steps:
          - name: echo
            image: ubuntu
            script: |
              #!/usr/bin/env bash
              echo "Hello world!"
```

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

cc: @rohitkrai03 