### PR TITLE
Support dockerfile path with more than one extension

### DIFF
--- a/src/components/ImportForm/utils/__tests__/validation-utils.spec.ts
+++ b/src/components/ImportForm/utils/__tests__/validation-utils.spec.ts
@@ -241,7 +241,13 @@ describe('Review form validation schema', () => {
     values.components[0].componentStub.source.git.dockerfileUrl = '.Dockerfile.prod';
     await expect(reviewValidationSchema.validate(values)).resolves.toBe(values);
 
-    values.components[0].componentStub.source.git.dockerfileUrl = 'Dockerfile.prod.bad';
+    values.components[0].componentStub.source.git.dockerfileUrl = 'Dockerfile.something.prod';
+    await expect(reviewValidationSchema.validate(values)).resolves.toBe(values);
+
+    values.components[0].componentStub.source.git.dockerfileUrl = 'Dockerfile.something.else.prod';
+    await expect(reviewValidationSchema.validate(values)).resolves.toBe(values);
+
+    values.components[0].componentStub.source.git.dockerfileUrl = 'Dockerfile.bad.';
     await expect(reviewValidationSchema.validate(values)).rejects.toThrow(
       'Must be a valid relative file path or URL.',
     );

--- a/src/components/ImportForm/utils/validation-utils.ts
+++ b/src/components/ImportForm/utils/validation-utils.ts
@@ -14,7 +14,7 @@ export const RESOURCE_NAME_REGEX_MSG =
   'Must start with a letter and end with a letter or number. Valid characters include lowercase letters from a to z, numbers from 0 to 9, and hyphens ( - ).';
 
 export const filePathOrURLRegex =
-  /^((^\.|^\.\.|^\.?[\w-]+)(\/\.?(?=[\w-])[\w-]+)*(\.[\w-]+)?$)|(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/;
+  /^((^\.|^\.\.|^\.?[\w-]+)(\/\.?(?=[\w-])[\w-]+)*(\.[\w-]+)*$)|(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/;
 
 export const dnsSubDomainRegex = /[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?/;
 


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
- https://issues.redhat.com/browse/RHTAPBUGS-252

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- Support dockerfile paths with more than one extensions.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

<img width="2275" alt="Screenshot 2023-05-10 at 4 47 34 PM" src="https://github.com/openshift/hac-dev/assets/6041994/de32f896-53e4-4f09-9253-81c1ec493fb8">


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
