### PR TITLE
add margin between secret key/value form groups

### DIFF
--- a/src/shared/components/formik-fields/key-value-file-input-field/KeyValueFileInputField.scss
+++ b/src/shared/components/formik-fields/key-value-file-input-field/KeyValueFileInputField.scss
@@ -5,5 +5,6 @@
 }
 .key-value--wrapper + .key-value--wrapper {
   border-top: 1px solid var(--pf-global--BorderColor--100);
+  margin-top: var(--pf-global--spacer--md);
   padding-top: var(--pf-global--spacer--sm);
 }


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/RHTAPBUGS-251

## Description
Secrets form lacked spacing between key/value groups and line separating the two.

Added margin to create a gap.

The styling mimics from OpenShift console.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
before:
![image](https://github.com/openshift/hac-dev/assets/14068621/2073a610-7f43-4e26-85f7-1be3ac148d49)

after:

![image](https://github.com/openshift/hac-dev/assets/14068621/5bbdd563-a4af-4ba5-9f54-70814601b2b2)


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

