### PR TITLE
add sbom download to PLR details

### DIFF
--- a/src/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
@@ -56,10 +56,12 @@ const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({
       : '',
   );
   const sha =
-    pipelineRun?.metadata?.labels[PipelineRunLabel.COMMIT_LABEL] ||
-    pipelineRun?.metadata?.labels[PipelineRunLabel.TEST_SERVICE_COMMIT];
+    pipelineRun.metadata?.labels[PipelineRunLabel.COMMIT_LABEL] ||
+    pipelineRun.metadata?.labels[PipelineRunLabel.TEST_SERVICE_COMMIT];
   const applicationName = pipelineRun.metadata?.labels[PipelineRunLabel.APPLICATION];
-  const buildImage = pipelineRun.metadata?.annotations?.[PipelineRunLabel.BUILD_IMAGE_ANNOTATION];
+  const buildImage =
+    pipelineRun.metadata?.annotations?.[PipelineRunLabel.BUILD_IMAGE_ANNOTATION] ||
+    pipelineRun.status?.pipelineResults?.find(({ name }) => name === `IMAGE_URL`)?.value;
   const sourceUrl = getSourceUrl(pipelineRun);
   const pipelineStatus = !error ? pipelineRunStatus(pipelineRun) : null;
   const sbomTaskRun = React.useMemo(() => getSbomTaskRun(taskRuns), [taskRuns]);
@@ -71,9 +73,9 @@ const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({
       </Title>
       <PipelineRunVisualization pipelineRun={pipelineRun} error={error} taskRuns={taskRuns} />
       {!error && (
-        <Flex>
-          <Flex flex={{ default: 'flex_3' }}>
-            <FlexItem>
+        <>
+          <Flex direction={{ default: 'row' }}>
+            <FlexItem style={{ flex: 1 }}>
               <DescriptionList
                 data-test="pipelinerun-details"
                 columnModifier={{
@@ -116,10 +118,7 @@ const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({
                 </DescriptionListGroup>
               </DescriptionList>
             </FlexItem>
-          </Flex>
-
-          <Flex flex={{ default: 'flex_3' }}>
-            <FlexItem>
+            <FlexItem style={{ flex: 1 }}>
               <DescriptionList
                 data-test="pipelinerun-details"
                 columnModifier={{
@@ -271,6 +270,7 @@ const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({
               </DescriptionList>
             </FlexItem>
           </Flex>
+
           {pipelineRun.status?.pipelineResults ? (
             <>
               <Divider style={{ padding: 'var(--pf-global--spacer--lg) 0' }} />
@@ -280,7 +280,7 @@ const PipelineRunDetailsTab: React.FC<PipelineRunDetailsTabProps> = ({
               />
             </>
           ) : null}
-        </Flex>
+        </>
       )}
     </>
   );

--- a/src/components/PipelineRunDetailsView/tabs/__tests__/PipelineRunDetailsTab.spec.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/__tests__/PipelineRunDetailsTab.spec.tsx
@@ -303,6 +303,33 @@ describe('PipelineRunDetailsTab', () => {
     expect(screen.queryByText('Download SBOM')).toBeInTheDocument();
   });
 
+  it('should render the download SBOM section for a pipelinerun with IMAGE_URL result', () => {
+    watchResourceMock.mockReturnValue([[], true]);
+    const simplePipelineRun = {
+      ...testPipelineRun,
+      status: {
+        ...testPipelineRun.status,
+        pipelineResults: [
+          {
+            name: 'IMAGE_URL',
+            value: 'quay.io/test/user-workload:test-image',
+          },
+        ],
+      },
+    };
+    render(
+      <PipelineRunDetailsTab
+        pipelineRun={simplePipelineRun}
+        taskRuns={getTaskRunsFromPLR(simplePipelineRun)}
+        error={null}
+      />,
+      {
+        wrapper: BrowserRouter,
+      },
+    );
+    expect(screen.queryByText('Download SBOM')).toBeInTheDocument();
+  });
+
   it('should not render the download SBOM section for a pipelinerun without any image annotation', () => {
     watchResourceMock.mockReturnValue([[], true]);
 


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/RHTAPBUGS-235

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Ensure download SBOM section is available by looking for the `IMAGE_URL` pipeline run result.

Also adjusted flex layout because the copy sbom input wasn't spanning the full width

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

![image](https://github.com/openshift/hac-dev/assets/14068621/a3a04ddd-2a20-4eb9-9aa5-360253cd66ea)

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Create a component with the default build pipeline.
Create another component with the custom build pipeline.

Go to the PLR details page for the builds related to each component.

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
