### PR TITLE
Use partial path for activity tab

### DIFF
--- a/src/components/Activity/ActivityTab.tsx
+++ b/src/components/Activity/ActivityTab.tsx
@@ -37,6 +37,15 @@ export const ActivityTab: React.FC<{ applicationName?: string }> = ({ applicatio
     }
   }, [activeTab, lastSelectedTab, currentTab, setLocalStorageItem]);
 
+  React.useEffect(() => {
+    if (!activeTab && lastSelectedTab) {
+      navigate(
+        `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/${parentTab}/${lastSelectedTab}`,
+        { replace: true },
+      );
+    }
+  }, [activeTab, applicationName, lastSelectedTab, navigate, parentTab, workspace]);
+
   return (
     <>
       <Title size="xl" headingLevel="h3" className="pf-c-title pf-u-mt-lg pf-u-mb-sm">

--- a/src/components/Activity/__tests__/ActivityTab.spec.tsx
+++ b/src/components/Activity/__tests__/ActivityTab.spec.tsx
@@ -26,7 +26,7 @@ const useNavigateMock = useNavigate as jest.Mock;
 const useParamsMock = useParams as jest.Mock;
 
 describe('Activity Tab', () => {
-  let navigateMock;
+  let navigateMock: jest.Mock;
 
   beforeEach(() => {
     navigateMock = jest.fn();
@@ -82,5 +82,16 @@ describe('Activity Tab', () => {
     const activeTab = tabs.querySelector('.pf-c-tabs__item.pf-m-current .pf-c-tabs__item-text');
     expect(activeTab).toHaveTextContent('Pipeline runs');
     activitiesPage.unmount();
+  });
+
+  it('should replace url if full path was not used', () => {
+    localStorage.setItem(ACTIVITY_SECONDARY_TAB_KEY, 'pipelineruns');
+
+    useParamsMock.mockReturnValue({ activeTab: 'activity' });
+    routerRenderer(<ActivityTab applicationName="abcd" />);
+    expect(navigateMock).toHaveBeenCalledWith(
+      '/application-pipeline/workspaces/test-ws/applications/abcd/activity/pipelineruns',
+      { replace: true },
+    );
   });
 });

--- a/src/components/ApplicationDetails/ApplicationDetails.tsx
+++ b/src/components/ApplicationDetails/ApplicationDetails.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useFeatureFlag } from '@openshift/dynamic-plugin-sdk';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { useApplication } from '../../hooks/useApplications';
-import { useLocalStorage } from '../../hooks/useLocalStorage';
 import {
   ApplicationModel,
   ComponentModel,
@@ -17,7 +16,7 @@ import { useApplicationBreadcrumbs } from '../../utils/breadcrumb-utils';
 import { MVP_FLAG } from '../../utils/flag-utils';
 import { useAccessReviewForModel } from '../../utils/rbac';
 import { useWorkspaceInfo } from '../../utils/workspace-context-utils';
-import { ACTIVITY_SECONDARY_TAB_KEY, ActivityTab } from '../Activity/ActivityTab';
+import { ActivityTab } from '../Activity/ActivityTab';
 import { createCustomizeAllPipelinesModalLauncher } from '../CustomizedPipeline/CustomizePipelinesModal';
 import ErrorEmptyState from '../EmptyState/ErrorEmptyState';
 import { useModalLauncher } from '../modal/ModalProvider';
@@ -46,9 +45,6 @@ const ApplicationDetails: React.FC<HacbsApplicationDetailsProps> = ({ applicatio
     'create',
   );
   const [canDeleteApplication] = useAccessReviewForModel(ApplicationModel, 'delete');
-  const { activity: subTab } = useParams();
-  const [lastActivitySubTab] = useLocalStorage<string>(ACTIVITY_SECONDARY_TAB_KEY);
-  const activitySubTab = subTab || lastActivitySubTab || 'latest-commits';
 
   const navigate = useNavigate();
   const { quickStarts } = useChrome();
@@ -217,9 +213,10 @@ const ApplicationDetails: React.FC<HacbsApplicationDetailsProps> = ({ applicatio
             component: <ApplicationOverviewTab applicationName={applicationName} />,
           },
           {
-            key: `activity/${activitySubTab}`,
+            key: 'activity',
             label: 'Activity',
             isFilled: true,
+            partial: true,
             className: 'application-details__activity',
             component: <ActivityTab applicationName={applicationName} />,
           },

--- a/src/components/ApplicationDetails/DetailsPage.tsx
+++ b/src/components/ApplicationDetails/DetailsPage.tsx
@@ -22,6 +22,8 @@ import { CaretDownIcon } from '@patternfly/react-icons/dist/esm/icons/caret-down
 import cx from 'classnames';
 import { FULL_APPLICATION_TITLE } from '../../consts/labels';
 import BreadCrumbs from '../../shared/components/breadcrumbs/BreadCrumbs';
+import { HttpError } from '../../shared/utils/error/http-error';
+import ErrorEmptyState from '../EmptyState/ErrorEmptyState';
 import { HeadTitle } from '../HeadTitle';
 
 import './DetailsPage.scss';
@@ -39,6 +41,7 @@ type DetailsPageTabProps = {
   label: string;
   component: React.ReactNode;
   isDisabled?: true;
+  partial?: boolean;
   className?: string;
   isFilled?: boolean;
 };
@@ -158,13 +161,17 @@ const DetailsPage: React.FC<DetailsPageProps> = ({
   };
 
   const activeTab: DetailsPageTabProps = React.useMemo(
-    () => tabs?.filter((t) => t.key === activeTabKey)[0],
+    () => tabs?.find((t) => (t.partial ? activeTabKey.startsWith(t.key) : t.key === activeTabKey)),
     [activeTabKey, tabs],
   );
 
+  if (!activeTab) {
+    return <ErrorEmptyState httpError={HttpError.fromCode(404)} />;
+  }
+
   return (
     <PageGroup data-test="details" className="app-details">
-      <HeadTitle>{`${headTitle} - ${activeTab?.label} | ${FULL_APPLICATION_TITLE}`}</HeadTitle>
+      <HeadTitle>{`${headTitle} - ${activeTab.label} | ${FULL_APPLICATION_TITLE}`}</HeadTitle>
       <PageSection type="breadcrumb">
         {breadcrumbs && <BreadCrumbs data-test="details__breadcrumbs" breadcrumbs={breadcrumbs} />}
         <Flex style={{ paddingTop: 'var(--pf-global--spacer--lg)' }}>
@@ -205,7 +212,7 @@ const DetailsPage: React.FC<DetailsPageProps> = ({
               onTabSelect && onTabSelect(k);
             }}
             unmountOnExit
-            activeKey={activeTabKey}
+            activeKey={activeTab.key}
           >
             {tabComponents}
           </Tabs>

--- a/src/components/ApplicationDetails/__tests__/DetailsPage.spec.tsx
+++ b/src/components/ApplicationDetails/__tests__/DetailsPage.spec.tsx
@@ -18,14 +18,12 @@ configure({ testIdAttribute: 'data-test' });
 describe('DetailsPage', () => {
   it('should render the DetailsPage', () => {
     const { getByTestId } = routerRenderer(
-      <DetailsPage headTitle="test" title="Details" baseURL="/" tabs={[]} />,
-    );
-    expect(getByTestId('details')).toBeInTheDocument();
-  });
-
-  it('should render the DetailsPage', () => {
-    const { getByTestId } = routerRenderer(
-      <DetailsPage headTitle="test" title="Details" baseURL="/" tabs={[]} />,
+      <DetailsPage
+        headTitle="test"
+        title="Details"
+        baseURL="/test"
+        tabs={[{ key: 'test', label: 'test', component: 'test' }]}
+      />,
     );
     expect(getByTestId('details')).toBeInTheDocument();
   });
@@ -33,6 +31,7 @@ describe('DetailsPage', () => {
   it('should not render the tabs if invalid values are passed', () => {
     routerRenderer(<DetailsPage headTitle="test" title="Details" baseURL="/" tabs={null} />);
     expect(screen.queryByTestId('app-details__tabs')).not.toBeInTheDocument();
+    expect(screen.getByText('404: Page not found')).toBeInTheDocument();
   });
 
   it('should render the tabs', () => {
@@ -88,7 +87,7 @@ describe('DetailsPage', () => {
         headTitle="test"
         title="Details"
         baseURL="/"
-        tabs={[]}
+        tabs={[{ key: 'test', label: 'test', component: 'test' }]}
         actions={[
           {
             type: 'section-label',
@@ -111,7 +110,7 @@ describe('DetailsPage', () => {
         headTitle="test"
         title="Details"
         baseURL="/"
-        tabs={[]}
+        tabs={[{ key: 'test', label: 'test', component: 'test' }]}
         actions={[
           {
             key: 'disabled-section',
@@ -143,7 +142,7 @@ describe('DetailsPage', () => {
         headTitle="test"
         title="Details"
         baseURL="/"
-        tabs={[]}
+        tabs={[{ key: 'test', label: 'test', component: 'test' }]}
         actions={[
           {
             key: 'disabled-section',


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/RHTAPBUGS-262
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
- Add support for using partial path keys in details page tabs
- Use partial key for activity tab subitems, and replace with full path if sub path is not available
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

https://github.com/openshift/hac-dev/assets/20013884/a68a4649-3a76-486a-830e-bf32d9177754

<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
