### PR TITLE
fix Add component button text

### DIFF
--- a/src/components/ImportForm/GitImportActions.tsx
+++ b/src/components/ImportForm/GitImportActions.tsx
@@ -12,8 +12,14 @@ const GitImportActions: React.FunctionComponent<GitImportActionsProps> = ({
   reviewMode,
   onBack,
 }) => {
-  const { isValid, dirty, isSubmitting, isValidating, setErrors } =
-    useFormikContext<ImportFormValues>();
+  const {
+    values: { inAppContext },
+    isValid,
+    dirty,
+    isSubmitting,
+    isValidating,
+    setErrors,
+  } = useFormikContext<ImportFormValues>();
 
   const handleBack = () => {
     setErrors({});
@@ -29,7 +35,7 @@ const GitImportActions: React.FunctionComponent<GitImportActionsProps> = ({
             isDisabled={!isValid || !dirty || isSubmitting || isValidating}
             isLoading={isSubmitting || isValidating}
           >
-            {reviewMode ? 'Create application' : 'Import code'}
+            {reviewMode ? (inAppContext ? 'Add component' : 'Create application') : 'Import code'}
           </Button>
         </ActionListItem>
         {reviewMode && (

--- a/src/components/ImportForm/__tests__/GitImportActions.spec.tsx
+++ b/src/components/ImportForm/__tests__/GitImportActions.spec.tsx
@@ -22,7 +22,7 @@ describe('GitImportActions', () => {
   });
 
   it('should render only Import code action if not in review mode', () => {
-    useFormikContextMock.mockReturnValue({});
+    useFormikContextMock.mockReturnValue({ values: { inAppContext: false } });
 
     render(<GitImportActions reviewMode={false} onBack={handleBack} />);
 
@@ -30,7 +30,7 @@ describe('GitImportActions', () => {
   });
 
   it('should render all the actions if in review mode', () => {
-    useFormikContextMock.mockReturnValue({});
+    useFormikContextMock.mockReturnValue({ values: { inAppContext: false } });
 
     render(<GitImportActions reviewMode={true} onBack={handleBack} />);
 
@@ -39,8 +39,17 @@ describe('GitImportActions', () => {
     screen.getByRole('button', { name: 'Cancel' });
   });
 
+  it('should render Add Component button', () => {
+    useFormikContextMock.mockReturnValue({ values: { inAppContext: true } });
+
+    render(<GitImportActions reviewMode={true} onBack={handleBack} />);
+
+    screen.getByRole('button', { name: 'Add component' });
+    screen.getByRole('button', { name: 'Cancel' });
+  });
+
   it('should render disabled actions if form is not valid', () => {
-    useFormikContextMock.mockReturnValue({ isValid: false });
+    useFormikContextMock.mockReturnValue({ values: { inAppContext: false }, isValid: false });
 
     render(<GitImportActions reviewMode={false} onBack={handleBack} />);
 
@@ -48,7 +57,7 @@ describe('GitImportActions', () => {
   });
 
   it('should render disabled action with spinner if form is submitting', () => {
-    useFormikContextMock.mockReturnValue({ isSubmitting: true });
+    useFormikContextMock.mockReturnValue({ values: { inAppContext: false }, isSubmitting: true });
 
     render(<GitImportActions reviewMode={true} onBack={handleBack} />);
 
@@ -57,7 +66,7 @@ describe('GitImportActions', () => {
   });
 
   it('should call handleBack function when back button is clicked', async () => {
-    useFormikContextMock.mockReturnValue({ setErrors: jest.fn() });
+    useFormikContextMock.mockReturnValue({ values: { inAppContext: false }, setErrors: jest.fn() });
 
     render(<GitImportActions reviewMode={true} onBack={handleBack} />);
 


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/RHTAPBUGS-283

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

In Add component flow the final submit button should read `Add component`

## Type of change
<!-- Please delete options that are not relevant. -->


- [x] Bugfix

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


**Before:**

<img width="1443" alt="image" src="https://github.com/openshift/hac-dev/assets/9964343/d3b4b6f1-d00b-4757-8c71-f7442605a204">


**After:**

![Add_component_button](https://github.com/openshift/hac-dev/assets/9964343/ff9736db-2e1a-4b85-b02d-103b1a112156)


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

1. Add new component in an application, the final submit button should read `Add component`

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

cc: @misjohns