### PR TITLE
Hide dockerfile field for non-dockerfile runtimes

### DIFF
--- a/src/components/ImportForm/ReviewSection/ReviewComponentCard.tsx
+++ b/src/components/ImportForm/ReviewSection/ReviewComponentCard.tsx
@@ -16,6 +16,7 @@ import {
   TitleSizes,
   ValidatedOptions,
 } from '@patternfly/react-core';
+import { useField } from 'formik';
 import {
   EnvironmentField,
   InputField,
@@ -53,6 +54,9 @@ export const ReviewComponentCard: React.FC<ReviewComponentCardProps> = ({
   const fieldPrefix = `components[${detectedComponentIndex}].componentStub`;
   const [expandedComponent, setExpandedComponent] = React.useState(isExpanded);
   const [targetPortTouched, setTargetPortTouched] = React.useState(false);
+  const [, { value: language }] = useField<string>(
+    `components[${detectedComponentIndex}].language`,
+  );
 
   return (
     <Card isFlat isCompact isSelected={expandedComponent} isExpanded={expandedComponent}>
@@ -134,17 +138,19 @@ export const ReviewComponentCard: React.FC<ReviewComponentCardProps> = ({
                   }
                 />
               </GridItem>
-              <GridItem sm={12} lg={4}>
-                <InputField
-                  name={`${fieldPrefix}.source.git.dockerfileUrl`}
-                  label="Dockerfile"
-                  type={TextInputTypes.text}
-                  placeholder="Dockerfile"
-                  labelIcon={
-                    <HelpPopover bodyContent="You can modify this path to point to your Dockerfile." />
-                  }
-                />
-              </GridItem>
+              {language === 'Dockerfile' && (
+                <GridItem sm={12} lg={4}>
+                  <InputField
+                    name={`${fieldPrefix}.source.git.dockerfileUrl`}
+                    label="Dockerfile"
+                    type={TextInputTypes.text}
+                    placeholder="Dockerfile"
+                    labelIcon={
+                      <HelpPopover bodyContent="You can modify this path to point to your Dockerfile." />
+                    }
+                  />
+                </GridItem>
+              )}
               {!editMode && (
                 <GridItem sm={12} lg={4} style={{ display: 'flex', alignItems: 'center' }}>
                   <SwitchField

--- a/src/components/ImportForm/ReviewSection/__tests__/ReviewComponentCard.spec.tsx
+++ b/src/components/ImportForm/ReviewSection/__tests__/ReviewComponentCard.spec.tsx
@@ -128,7 +128,6 @@ describe('ReviewComponentCard', () => {
 
     expect(screen.getByText('Build & deploy configuration')).toBeInTheDocument();
 
-    expect(screen.queryByText('Dockerfile')).toBeVisible();
     expect(screen.queryByText('Target port')).toBeVisible();
     expect(screen.queryByText('Instances')).toBeVisible();
   });
@@ -211,5 +210,37 @@ describe('ReviewComponentCard', () => {
     expect(
       screen.queryByText(`We can't detect your target port. Check if it's correct.`),
     ).not.toBeInTheDocument();
+  });
+
+  it('should show dockerfile field if dockerfile runtime is selected', async () => {
+    useComponentDetectionMock.mockReturnValue([]);
+    useFieldMock.mockReturnValue([{}, { value: 'Dockerfile' }]);
+    formikRenderer(
+      <ReviewComponentCard
+        detectedComponent={gitRepoComponent}
+        detectedComponentIndex={0}
+        showRuntimeSelector
+      />,
+      { isDetected: true, source: { git: {} } },
+    );
+    await act(async () => screen.getByTestId(`${componentName}-toggle-button`).click());
+
+    expect(screen.queryByText('Dockerfile')).toBeVisible();
+  });
+
+  it('should not show dockerfile field if other runtimes are selected', async () => {
+    useComponentDetectionMock.mockReturnValue([]);
+    useFieldMock.mockReturnValue([{}, { value: 'JavaScript' }]);
+    formikRenderer(
+      <ReviewComponentCard
+        detectedComponent={gitRepoComponent}
+        detectedComponentIndex={0}
+        showRuntimeSelector
+      />,
+      { isDetected: true, source: { git: {} } },
+    );
+    await act(async () => screen.getByTestId(`${componentName}-toggle-button`).click());
+
+    expect(screen.queryByText('Dockerfile')).toBeNull();
   });
 });


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/RHTAPBUGS-287
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
Show dockerfile field only when dockerfile runtime is selected
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

https://github.com/openshift/hac-dev/assets/20013884/b0b74399-30dd-4788-9db7-b1d4143437e9

<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
