### PR TITLE
Create EC Integration when creating an Application

### DIFF
--- a/src/components/ImportForm/__tests__/GitImportForm.actions.spec.tsx
+++ b/src/components/ImportForm/__tests__/GitImportForm.actions.spec.tsx
@@ -19,6 +19,10 @@ jest.mock('../../../utils/create-utils', () => ({
   createApplication: jest.fn(),
 }));
 
+jest.mock('../../IntegrationTest/IntegrationTestForm/utils/create-utils', () => ({
+  createIntegrationTest: jest.fn(),
+}));
+
 jest.mock('../../../utils/workspace-context-utils', () => ({
   useWorkspaceInfo: jest.fn(() => ({ namespace: 'test-ns', workspace: 'test-ws' })),
 }));

--- a/src/components/ImportForm/utils/__tests__/submit-utils.spec.ts
+++ b/src/components/ImportForm/utils/__tests__/submit-utils.spec.ts
@@ -1,4 +1,5 @@
 import { createApplication, createComponent } from '../../../../utils/create-utils';
+import { createIntegrationTest } from '../../../IntegrationTest/IntegrationTestForm/utils/create-utils';
 import { detectComponents } from '../cdq-utils';
 import { createResources, checkApplicationName } from '../submit-utils';
 import { ImportFormValues, ImportStrategy } from './../types';
@@ -11,6 +12,10 @@ jest.mock('../../../../utils/create-utils', () => ({
   createComponent: jest.fn(),
 }));
 
+jest.mock('../../../IntegrationTest/IntegrationTestForm/utils/create-utils', () => ({
+  createIntegrationTest: jest.fn(),
+}));
+
 jest.mock('../cdq-utils', () => ({
   detectComponents: jest.fn(),
 }));
@@ -18,6 +23,7 @@ jest.mock('../cdq-utils', () => ({
 const createApplicationMock = createApplication as jest.Mock;
 const createComponentMock = createComponent as jest.Mock;
 const detectComponentsMock = detectComponents as jest.Mock;
+const createIntegrationTestMock = createIntegrationTest as jest.Mock;
 
 describe('Submit Utils: createResources', () => {
   it('should create application and components', async () => {
@@ -46,6 +52,7 @@ describe('Submit Utils: createResources', () => {
       'test-ws',
     );
     expect(createApplicationMock).toHaveBeenCalledTimes(2);
+    expect(createIntegrationTestMock).toHaveBeenCalledTimes(2);
     expect(createComponentMock).toHaveBeenCalledTimes(2);
   });
 
@@ -74,6 +81,7 @@ describe('Submit Utils: createResources', () => {
       'test-ws',
     );
     expect(createApplicationMock).toHaveBeenCalledTimes(0);
+    expect(createIntegrationTestMock).toHaveBeenCalledTimes(0);
     expect(createComponentMock).toHaveBeenCalledTimes(2);
   });
 
@@ -105,6 +113,7 @@ describe('Submit Utils: createResources', () => {
     ).rejects.toThrow();
     expect(createApplicationMock).toHaveBeenLastCalledWith('test-app', 'test-ns', true);
     expect(createComponentMock).toHaveBeenCalledTimes(0);
+    expect(createIntegrationTestMock).toHaveBeenCalledTimes(0);
   });
 
   it('should not create any resources if component dry run fails', async () => {

--- a/src/components/ImportForm/utils/submit-utils.ts
+++ b/src/components/ImportForm/utils/submit-utils.ts
@@ -2,6 +2,13 @@ import { FormikHelpers } from 'formik';
 import { ApplicationKind } from '../../../types';
 import { SAMPLE_ANNOTATION } from '../../../utils/component-utils';
 import { createApplication, createComponent, createSecret } from '../../../utils/create-utils';
+import {
+  EC_INTEGRATION_TEST_URL,
+  EC_INTEGRATION_TEST_REVISION,
+  EC_INTEGRATION_TEST_PATH,
+} from '../../IntegrationTest/IntegrationTestForm/const';
+import { IntegrationTestFormValues } from '../../IntegrationTest/IntegrationTestForm/types';
+import { createIntegrationTest } from '../../IntegrationTest/IntegrationTestForm/utils/create-utils';
 import { detectComponents } from './cdq-utils';
 import { transformResources, transformComponentValues } from './transform-utils';
 import { DetectedFormComponent, ImportFormValues, ImportSecret, ImportStrategy } from './types';
@@ -76,8 +83,17 @@ export const createResources = async (
     componentAnnotations = { [SAMPLE_ANNOTATION]: 'true' };
   }
 
+  const integrationTestValues: IntegrationTestFormValues = {
+    name: `${applicationName}-enterprise-contract`,
+    url: EC_INTEGRATION_TEST_URL,
+    revision: EC_INTEGRATION_TEST_REVISION,
+    path: EC_INTEGRATION_TEST_PATH,
+    optional: false,
+  };
+
   if (shouldCreateApplication) {
     await createApplication(application, namespace, true);
+    await createIntegrationTest(integrationTestValues, applicationName, namespace, true);
   }
 
   await createComponents(
@@ -93,6 +109,7 @@ export const createResources = async (
   if (shouldCreateApplication) {
     applicationData = await createApplication(application, namespace);
     applicationName = applicationData.metadata.name;
+    await createIntegrationTest(integrationTestValues, applicationName, namespace);
   }
   await createSecrets(importSecrets, workspace, namespace, true);
 

--- a/src/components/IntegrationTest/IntegrationTestForm/const.ts
+++ b/src/components/IntegrationTest/IntegrationTestForm/const.ts
@@ -1,0 +1,3 @@
+export const EC_INTEGRATION_TEST_URL = 'https://github.com/redhat-appstudio/build-definitions';
+export const EC_INTEGRATION_TEST_REVISION = 'main';
+export const EC_INTEGRATION_TEST_PATH = 'pipelines/enterprise-contract.yaml';


### PR DESCRIPTION
## Description

When an IntegrationTestScenario running the Enterprise Contract executes, the UI for the corresponding Application is populated with various security results. This is valuable information to users.

This change makes it so when an Application is created, the EC IntegrationTestScenario is automatically created with default values. This lowers the entrybarrier to accessing the security results.

In the future, this auto creation may move to another RHTAP component, e.g. a new EC controller. Or, it may be desireable to introduce UI controls to customize its initial creation, e.g. different Tekton bundle. It's unclear at this point what our users will prefer.  For this reason, we make the most minimal change possible to introduce the feature to users without investing too much in a certain solution right now.

https://issues.redhat.com/browse/HACBS-2191

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## How to test or reproduce?

Simply create a new application from a sample or other source. The `IntegrationTestScenario` is created automatically.



<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
