### PR TITLE
Rebuild e2e runner image when dockerfile changes

### DIFF
--- a/integration-tests/Dockerfile
+++ b/integration-tests/Dockerfile
@@ -1,14 +1,9 @@
-ARG NODE_VERSION='16.20.0'
-ARG CHROME_VERSION='110.0.5481.177-1'
-
-FROM cypress/factory
+FROM quay.io/hacdev/hac-tests:base
 
 ENV OC_DOWNLOAD_URL="https://downloads-openshift-console.apps.hac-devsandbox.5unc.p1.openshiftapps.com/amd64/linux/oc.tar" \
     CYPRESS_CACHE_FOLDER="/tmp/.cache"
 
-RUN apt update && \
-    apt install curl jq python3 python3-venv xauth skopeo -y && \
-    curl -L -o /tmp/oc.tar ${OC_DOWNLOAD_URL} && \
+RUN curl -L -o /tmp/oc.tar ${OC_DOWNLOAD_URL} && \
     tar -xf /tmp/oc.tar -C /usr/bin
 
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-4007


## Description
In case a PR makes changes to the dockerfile, run the PR check with the updated image
