### PR TITLE
Fix for sample icon alt text size

### DIFF
--- a/src/components/ImportForm/SampleSection/SampleCard.tsx
+++ b/src/components/ImportForm/SampleSection/SampleCard.tsx
@@ -45,7 +45,7 @@ const SampleCard: React.FC<SampleCardProps> = ({ sample, onSampleImport }) => {
             className="catalog-tile-pf-icon"
             src={icon.url}
             alt={name}
-            style={{ maxWidth: '60px' }}
+            style={{ maxWidth: '60px', fontSize: 'var(--pf-global--FontSize--md)' }}
           />
         )}
         {badges.length > 0 && <CardActions>{badges}</CardActions>}


### PR DESCRIPTION
## Fixes 
Fixes [RHTAPBUGS-275](https://issues.redhat.com/browse/RHTAPBUGS-275)

## Description
Sets the correct font size on the sample card icon.

## Type of change
- [x] Bugfix

## Screen shots / Gifs for design review 
![image](https://github.com/openshift/hac-dev/assets/11633780/610694a7-be75-4e05-8868-fd2dc6165971)

## Browser conformance: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
