### PR TITLE
Improve responsive layout of import wizard

### DIFF
--- a/integration-tests/support/pages/ComponentsPage.ts
+++ b/integration-tests/support/pages/ComponentsPage.ts
@@ -81,7 +81,9 @@ export class ComponentPage extends AbstractWizardPage {
 
   setRam(value: number, unit: MemoryUnit) {
     cy.get(ComponentsPagePO.memoryInput).clear().type(value.toString());
-    cy.contains('div[class="pf-c-form__group"]', 'Memory').find(ComponentsPagePO.dropdown).click();
+    cy.contains(`[data-test="resource-limit-field"]`, 'Memory')
+      .find(ComponentsPagePO.dropdown)
+      .click();
     cy.contains('li', unit).click();
   }
 

--- a/src/components/ImportForm/ReviewSection/ReviewComponentCard.scss
+++ b/src/components/ImportForm/ReviewSection/ReviewComponentCard.scss
@@ -4,4 +4,19 @@
 
     margin-left: var(--pf-global--spacer--lg);
   }
+  &__limits {
+    display: grid;
+    gap: var(--pf-global--spacer--md);
+    grid-template-columns: auto;
+    justify-content: start;
+    @media (min-width: 600px) {
+      grid-template-columns: auto auto;
+    }
+    @media (min-width: 769px) {
+      grid-template-columns: auto auto auto;
+    }
+    .resource-limit-field {
+      max-width: 270px;
+    }
+  }
 }

--- a/src/components/ImportForm/ReviewSection/ReviewComponentCard.tsx
+++ b/src/components/ImportForm/ReviewSection/ReviewComponentCard.tsx
@@ -163,36 +163,30 @@ export const ReviewComponentCard: React.FC<ReviewComponentCardProps> = ({
                 </GridItem>
               )}
             </Grid>
-            <Grid hasGutter>
-              <GridItem sm={12} lg={4}>
-                <ResourceLimitField
-                  name={`${fieldPrefix}.resources.cpu`}
-                  unitName={`${fieldPrefix}.resources.cpuUnit`}
-                  label="CPU"
-                  minValue={0}
-                  unitOptions={CPUUnits}
-                  helpText="The amount of CPU the container is guaranteed"
-                />
-              </GridItem>
-              <GridItem sm={12} lg={4}>
-                <ResourceLimitField
-                  name={`${fieldPrefix}.resources.memory`}
-                  unitName={`${fieldPrefix}.resources.memoryUnit`}
-                  label="Memory"
-                  minValue={0}
-                  unitOptions={MemoryUnits}
-                  helpText="The amount of memory the container is guaranteed"
-                />
-              </GridItem>
-              <GridItem sm={12} lg={4}>
-                <NumberSpinnerField
-                  name={`${fieldPrefix}.replicas`}
-                  label="Instances"
-                  min={0}
-                  helpText="Number of instances of your image"
-                />
-              </GridItem>
-            </Grid>
+            <div className="review-component-card__limits">
+              <ResourceLimitField
+                name={`${fieldPrefix}.resources.cpu`}
+                unitName={`${fieldPrefix}.resources.cpuUnit`}
+                label="CPU"
+                minValue={0}
+                unitOptions={CPUUnits}
+                helpText="The amount of CPU the container is guaranteed"
+              />
+              <ResourceLimitField
+                name={`${fieldPrefix}.resources.memory`}
+                unitName={`${fieldPrefix}.resources.memoryUnit`}
+                label="Memory"
+                minValue={0}
+                unitOptions={MemoryUnits}
+                helpText="The amount of memory the container is guaranteed"
+              />
+              <NumberSpinnerField
+                name={`${fieldPrefix}.replicas`}
+                label="Instances"
+                min={0}
+                helpText="Number of instances of your image"
+              />
+            </div>
             <EnvironmentField
               name={`${fieldPrefix}.env`}
               envs={component.env}

--- a/src/shared/components/formik-fields/ResourceLimitField.tsx
+++ b/src/shared/components/formik-fields/ResourceLimitField.tsx
@@ -21,7 +21,9 @@ const ResourceLimitField: React.FC<ResourceLimitFieldProps> = ({
 
   return (
     <FormGroup
+      className="resource-limit-field"
       fieldId={fieldId}
+      data-test="resource-limit-field"
       label={label}
       helperText={helpText}
       helperTextInvalid={errorMessage}

--- a/src/shared/components/name-value-editor/BasicNameValueEditor.scss
+++ b/src/shared/components/name-value-editor/BasicNameValueEditor.scss
@@ -6,11 +6,43 @@ $drag-column-width: 28px;
 }
 
 .pairs-list__heading {
+  display: none;
   margin-bottom: 5px;
 }
 
+.pairs-list__elements {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pf-global--spacer--md);
+  margin-bottom: var(--pf-global--spacer--md);
+}
 .pairs-list__row {
-  padding-bottom: 15px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-areas:
+    "name remove"
+    "value .";
+  gap: var(--pf-global--spacer--md);
+  padding-bottom: var(--pf-global--spacer--md);
+  border-bottom: 1px solid var(--pf-global--BorderColor--100);
+  &--name {
+    align-items: center;
+    display: flex;
+    gap: var(--pf-global--spacer--sm);
+    grid-area: name;
+  }
+  &--value {
+    align-items: center;
+    display: flex;
+    gap: var(--pf-global--spacer--sm);
+    grid-area: value;
+  }
+  &--remove {
+    grid-area: remove;
+    .pf-c-button {
+      margin-left: calc(-1 * var(--pf-global--spacer--md));
+    }
+  }
 }
 
 .pairs-list__side-btn {
@@ -19,4 +51,20 @@ $drag-column-width: 28px;
 
 .pairs-list__add-icon {
   margin-right: 0.25em;
+}
+
+@media (min-width: 575px) {
+  .pairs-list__heading {
+    display: flex;
+  }
+  .pairs-list__row {
+    grid-template-columns: 1fr 1fr auto;
+    grid-template-areas:
+      "name value remove";
+    padding-bottom: 0;
+    border-bottom: none;
+  }
+  .pairs-list__row--label {
+    display: none;
+  }
 }

--- a/src/shared/components/name-value-editor/BasicNameValueEditor.tsx
+++ b/src/shared/components/name-value-editor/BasicNameValueEditor.tsx
@@ -47,35 +47,33 @@ const PairElement: React.FC<PairElementProps> = ({
   );
 
   return (
-    <Flex className="pairs-list__row" data-test="pairs-list-row" direction={{ default: 'row' }}>
-      <Flex flex={{ default: 'flex_1' }}>
-        <FlexItem fullWidth={{ default: 'fullWidth' }}>
-          <input
-            type="text"
-            data-test="pairs-list-name"
-            className="pf-c-form-control"
-            placeholder={nameString}
-            value={pair[NameValueEditorPair.Name]}
-            onChange={onChangeName}
-            disabled={readOnly}
-          />
-        </FlexItem>
-      </Flex>
-      <Flex spacer={{ default: 'spacerNone' }} flex={{ default: 'flex_1' }}>
-        <FlexItem fullWidth={{ default: 'fullWidth' }}>
-          <input
-            type="text"
-            data-test="pairs-list-value"
-            className="pf-c-form-control"
-            placeholder={valueString}
-            value={pair[NameValueEditorPair.Value] || ''}
-            onChange={onChangeValue}
-            disabled={readOnly}
-          />
-        </FlexItem>
-      </Flex>
+    <div className="pairs-list__row" data-test="pairs-list-row">
+      <div className="pairs-list__row--name">
+        <span className="pairs-list__row--label">Name</span>
+        <input
+          type="text"
+          data-test="pairs-list-name"
+          className="pf-c-form-control"
+          placeholder={nameString}
+          value={pair[NameValueEditorPair.Name]}
+          onChange={onChangeName}
+          disabled={readOnly}
+        />
+      </div>
+      <div className="pairs-list__row--value">
+        <span className="pairs-list__row--label">Value</span>
+        <input
+          type="text"
+          data-test="pairs-list-value"
+          className="pf-c-form-control"
+          placeholder={valueString}
+          value={pair[NameValueEditorPair.Value] || ''}
+          onChange={onChangeValue}
+          disabled={readOnly}
+        />
+      </div>
       {!readOnly && (
-        <FlexItem>
+        <span className="pairs-list__row--remove">
           <Tooltip content={toolTip || 'Remove'}>
             <Button
               type="button"
@@ -87,9 +85,9 @@ const PairElement: React.FC<PairElementProps> = ({
               {deleteIcon}
             </Button>
           </Tooltip>
-        </FlexItem>
+        </span>
       )}
-    </Flex>
+    </div>
   );
 };
 
@@ -173,7 +171,7 @@ const BasicNameValueEditor: React.FC<NameValueEditorProps> = ({
         </Flex>
         <FlexItem className="empty__header" />
       </Flex>
-      {pairElems}
+      <div className="pairs-list__elements">{pairElems}</div>
       <Flex direction={{ default: 'row' }} justifyContent={{ default: 'justifyContentFlexStart' }}>
         {readOnly ? null : (
           <FlexItem>


### PR DESCRIPTION
## Fixes 
Fixes [RHTAPBUGS-247](https://issues.redhat.com/browse/RHTAPBUGS-247)
Fixes [RHTAPBUGS-248](https://issues.redhat.com/browse/RHTAPBUGS-248)

## Description
Updates layout of the environment name/value pairs at low resolutions to provide more space for entries of name and value.
Updates the layout for the cpu/memory/instances settings at low resolutions to prevent overlap and maintain spacing.

## Type of change
- [x] Bugfix

## Screen shots / Gifs for design review 

![image](https://github.com/openshift/hac-dev/assets/11633780/82ae0be6-1aba-4829-a52c-7843c2ba9876)

![image](https://github.com/openshift/hac-dev/assets/11633780/5407d6f0-aa9b-4947-8446-f1e4a4a2bbba)

![image](https://github.com/openshift/hac-dev/assets/11633780/7009ef58-3d95-4778-82ab-dc5a7bc69b59)

![image](https://github.com/openshift/hac-dev/assets/11633780/bb6b990d-c415-4344-bc92-2da011795e44)

