### PR TITLE
Hide application URL in managed environment card

### DIFF
--- a/src/components/Environment/EnvironmentCard.tsx
+++ b/src/components/Environment/EnvironmentCard.tsx
@@ -146,7 +146,7 @@ const EnvironmentCard: React.FC<EnvironmentCardProps> = ({
         </DescriptionList>
       </CardBody>
 
-      {applicationName && applicationRoute && (
+      {applicationName && applicationRoute && type !== EnvironmentType.managed && (
         <CardFooter>
           <DescriptionList columnModifier={{ default: '2Col' }}>
             <DescriptionListGroup>

--- a/src/components/Environment/__tests__/EnvironmentCard.spec.tsx
+++ b/src/components/Environment/__tests__/EnvironmentCard.spec.tsx
@@ -6,6 +6,7 @@ import { render, screen } from '@testing-library/react';
 import { useLatestApplicationRouteURL } from '../../../hooks';
 import { EnvironmentModel } from '../../../models';
 import { EnvironmentKind } from '../../../types';
+import { EnvironmentType } from '../environment-utils';
 import EnvironmentCard from '../EnvironmentCard';
 
 jest.mock('@openshift/dynamic-plugin-sdk', () => ({
@@ -124,5 +125,22 @@ describe('', () => {
     render(<EnvironmentCard environment={env} applicationName="test" />);
     expect(screen.getByText('View URL')).toBeVisible();
     expect(screen.getByText('View URL')).toHaveProperty('href', 'https://example.com/');
+  });
+
+  it('should not render Application Route URL for managed environment', () => {
+    const env = {
+      ...testEnv,
+      spec: {
+        ...testEnv.spec,
+        tags: [EnvironmentType.managed],
+
+        displayName: undefined,
+      },
+    };
+    useK8sWatchMock.mockReturnValue([[{ metadata: { name: 'test-app' } }], true]);
+    useLatestApplicationRouteURLMock.mockReturnValue('https://example.com/');
+    render(<EnvironmentCard environment={env} applicationName="test" />);
+    screen.debug();
+    expect(screen.queryByText('View URL')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/RHTAPBUGS-274

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When an environment is configured for BYOC, the URL provided to the user is incorrect in the deployment card. 

Note: We dont have a way to show the managed environment deployment route at the moment, so we need to hide this url instead of misleading the users.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

**Before:**

<img width="1788" alt="Screenshot 2023-05-29 at 11 48 49 AM" src="https://github.com/openshift/hac-dev/assets/9964343/10e78d8f-46cc-492d-b168-9a65eca7fd17">

**After:**

<img width="1792" alt="Screenshot 2023-05-29 at 11 47 57 AM" src="https://github.com/openshift/hac-dev/assets/9964343/7a835243-d891-4e88-a145-f50a2c82515f">

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

