### PR TITLE
Fix secrets creation for admins in other workspaces.

### DIFF
--- a/src/components/ComponentSettingsForm/ComponentSettingsView.tsx
+++ b/src/components/ComponentSettingsForm/ComponentSettingsView.tsx
@@ -82,7 +82,7 @@ const ComponentSettingsView: React.FunctionComponent<ComponentSettingsViewProps>
     });
 
     try {
-      await createSecrets(values.importSecrets, namespace, true);
+      await createSecrets(values.importSecrets, workspace, namespace, true);
     } catch (e) {
       // eslint-disable-next-line no-console
       console.warn('Error while submitting secret:', e);
@@ -90,7 +90,7 @@ const ComponentSettingsView: React.FunctionComponent<ComponentSettingsViewProps>
       actions.setStatus({ submitError: e.message });
     }
 
-    await createSecrets(values.importSecrets, namespace, false);
+    await createSecrets(values.importSecrets, workspace, namespace, false);
 
     return createComponent(
       transformedComponentValues,

--- a/src/components/ImportForm/GitImportForm.tsx
+++ b/src/components/ImportForm/GitImportForm.tsx
@@ -62,7 +62,7 @@ const GitImportForm: React.FunctionComponent<GitImportFormProps> = ({
   const handleSubmit = React.useCallback(
     (values: ImportFormValues, formikHelpers) => {
       track(TrackEvents.ButtonClicked, { link_name: 'import-submit', workspace });
-      return createResources(values, ImportStrategy.GIT)
+      return createResources(values, ImportStrategy.GIT, workspace)
         .then(({ applicationName: appName, application, components, componentNames }) => {
           if (application) {
             track('Application Create', {

--- a/src/components/ImportForm/SampleImportForm.tsx
+++ b/src/components/ImportForm/SampleImportForm.tsx
@@ -53,7 +53,7 @@ const SampleImportForm: React.FunctionComponent<SampleImportFormProps> = ({ appl
         namespace,
       };
 
-      createResources(values, ImportStrategy.SAMPLE)
+      createResources(values, ImportStrategy.SAMPLE, workspace)
         .then(({ applicationName: appName, application, components }) => {
           if (application) {
             track('Application Create', {

--- a/src/components/ImportForm/__tests__/SampleImportForm.spec.tsx
+++ b/src/components/ImportForm/__tests__/SampleImportForm.spec.tsx
@@ -97,6 +97,7 @@ describe('SampleImportForm', () => {
         },
       },
       ImportStrategy.SAMPLE,
+      'test-ws',
     );
 
     expect(navigateMock).toHaveBeenCalledWith(

--- a/src/components/ImportForm/utils/__tests__/submit-utils.spec.ts
+++ b/src/components/ImportForm/utils/__tests__/submit-utils.spec.ts
@@ -43,6 +43,7 @@ describe('Submit Utils: createResources', () => {
         },
       },
       ImportStrategy.GIT,
+      'test-ws',
     );
     expect(createApplicationMock).toHaveBeenCalledTimes(2);
     expect(createComponentMock).toHaveBeenCalledTimes(2);
@@ -70,6 +71,7 @@ describe('Submit Utils: createResources', () => {
         },
       },
       ImportStrategy.GIT,
+      'test-ws',
     );
     expect(createApplicationMock).toHaveBeenCalledTimes(0);
     expect(createComponentMock).toHaveBeenCalledTimes(2);
@@ -98,6 +100,7 @@ describe('Submit Utils: createResources', () => {
           },
         },
         ImportStrategy.GIT,
+        'test-ws',
       ),
     ).rejects.toThrow();
     expect(createApplicationMock).toHaveBeenLastCalledWith('test-app', 'test-ns', true);
@@ -128,6 +131,7 @@ describe('Submit Utils: createResources', () => {
           },
         },
         ImportStrategy.GIT,
+        'test-ws',
       ),
     ).rejects.toThrow();
     expect(createApplicationMock).toHaveBeenLastCalledWith('test-app', 'test-ns', true);
@@ -151,6 +155,7 @@ describe('Submit Utils: createResources', () => {
         },
       },
       ImportStrategy.SAMPLE,
+      'test-ws',
     );
     expect(detectComponentsMock).toHaveBeenCalledWith(
       'https://github.com/example/repo',

--- a/src/components/ImportForm/utils/submit-utils.ts
+++ b/src/components/ImportForm/utils/submit-utils.ts
@@ -4,7 +4,7 @@ import { SAMPLE_ANNOTATION } from '../../../utils/component-utils';
 import { createApplication, createComponent, createSecret } from '../../../utils/create-utils';
 import { detectComponents } from './cdq-utils';
 import { transformResources, transformComponentValues } from './transform-utils';
-import { DetectedFormComponent, ImportFormValues, ImportStrategy } from './types';
+import { DetectedFormComponent, ImportFormValues, ImportSecret, ImportStrategy } from './types';
 
 export const createComponents = async (
   components: DetectedFormComponent[],
@@ -38,10 +38,18 @@ export const createComponents = async (
   return Promise.all(createComponentPromises);
 };
 
-export const createSecrets = async (secrets, namespace, dryRun) =>
-  Promise.all(secrets.map((secret) => createSecret(secret, namespace, dryRun)));
+export const createSecrets = async (
+  secrets: ImportSecret[],
+  workspace: string,
+  namespace: string,
+  dryRun: boolean,
+) => Promise.all(secrets.map((secret) => createSecret(secret, workspace, namespace, dryRun)));
 
-export const createResources = async (formValues: ImportFormValues, strategy: ImportStrategy) => {
+export const createResources = async (
+  formValues: ImportFormValues,
+  strategy: ImportStrategy,
+  workspace: string,
+) => {
   const {
     source,
     application,
@@ -86,7 +94,7 @@ export const createResources = async (formValues: ImportFormValues, strategy: Im
     applicationData = await createApplication(application, namespace);
     applicationName = applicationData.metadata.name;
   }
-  await createSecrets(importSecrets, namespace, true);
+  await createSecrets(importSecrets, workspace, namespace, true);
 
   const createdComponents = await createComponents(
     detectedComponents,
@@ -97,7 +105,7 @@ export const createResources = async (formValues: ImportFormValues, strategy: Im
     componentAnnotations,
   );
 
-  await createSecrets(importSecrets, namespace, false);
+  await createSecrets(importSecrets, workspace, namespace, false);
 
   return {
     applicationName,

--- a/src/utils/__tests__/create-utils.spec.ts
+++ b/src/utils/__tests__/create-utils.spec.ts
@@ -456,6 +456,7 @@ describe('Create Utils', () => {
 
     createSecret(
       { secretName: 'my-snyk-secret', keyValues: [{ key: 'token', value: 'my-token-data' }] },
+      'test-ws',
       'test-ns',
       true,
     );
@@ -463,7 +464,7 @@ describe('Create Utils', () => {
     expect(commonFetchMock).toHaveBeenCalledTimes(1);
 
     expect(commonFetchMock).toHaveBeenCalledWith(
-      '/api/v1/namespaces/test-ns/secrets?dryRun=All',
+      '/workspaces/test-ws/api/v1/namespaces/test-ns/secrets?dryRun=All',
       expect.objectContaining({
         body: expect.stringContaining('"kind":"Secret"'),
       }),
@@ -476,6 +477,7 @@ describe('Create Utils', () => {
 
     createSecret(
       { secretName: 'my-snyk-secret', keyValues: [{ key: 'token', value: 'my-token-data' }] },
+      'test-ws',
       'test-ns',
       false,
     );
@@ -483,7 +485,7 @@ describe('Create Utils', () => {
     expect(commonFetchMock).toHaveBeenCalledTimes(1);
 
     expect(commonFetchMock).toHaveBeenCalledWith(
-      '/api/v1/namespaces/test-ns/secrets',
+      '/workspaces/test-ws/api/v1/namespaces/test-ns/secrets',
       expect.objectContaining({
         body: expect.stringContaining('"kind":"Secret"'),
       }),
@@ -498,6 +500,7 @@ describe('Create Utils', () => {
 
     createSecret(
       { secretName: 'snyk-secret', keyValues: [{ key: 'token', value: 'my-token-data' }] },
+      'test-ws',
       'test-ns',
       false,
     );

--- a/src/utils/create-utils.ts
+++ b/src/utils/create-utils.ts
@@ -367,7 +367,12 @@ export const createSupportedPartnerSecret = async (
   return Promise.all(resourcePromises);
 };
 
-export const createSecret = async (secret: ImportSecret, namespace: string, dryRun: boolean) => {
+export const createSecret = async (
+  secret: ImportSecret,
+  workspace: string,
+  namespace: string,
+  dryRun: boolean,
+) => {
   const partnerTask = Object.values(supportedPartnerTasksSecrets).find(
     (s) => s.name === secret.secretName,
   );
@@ -390,9 +395,12 @@ export const createSecret = async (secret: ImportSecret, namespace: string, dryR
   };
   //Todo: K8sCreateResource appends the resource name and errors out.
   // Fix the below code when this sdk-utils issue is resolved https://issues.redhat.com/browse/RHCLOUD-21655.
-  return commonFetch(`/api/v1/namespaces/${namespace}/secrets${dryRun ? '?dryRun=All' : ''}`, {
-    method: 'POST',
-    body: JSON.stringify(secretResource),
-    headers: { 'Content-type': 'application/json' },
-  });
+  return commonFetch(
+    `/workspaces/${workspace}/api/v1/namespaces/${namespace}/secrets${dryRun ? '?dryRun=All' : ''}`,
+    {
+      method: 'POST',
+      body: JSON.stringify(secretResource),
+      headers: { 'Content-type': 'application/json' },
+    },
+  );
 };


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/RHTAPBUGS-316

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

As workspace owner, I can create all secrets I want from the UI, but as admin in another workspace, I can't do it. This is because of the api call not having workspace context in it.


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:

<img width="1790" alt="Screenshot 2023-05-29 at 2 06 36 PM" src="https://github.com/openshift/hac-dev/assets/9964343/6f87683f-bca1-493a-8c24-412d1746ebf3">


After:

<img width="1786" alt="Screenshot 2023-05-29 at 2 07 33 PM" src="https://github.com/openshift/hac-dev/assets/9964343/018d75f8-c6ed-4bda-b767-fd97c5a4624b">

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->


1. You have to be an admin in other workspace.
2. Try to create build secrets while adding components in the shared workspace.

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
