### PR TITLE
Improve responsiveness of name & runtime fields

### DIFF
--- a/src/components/ImportForm/ReviewSection/ReviewComponentCard.tsx
+++ b/src/components/ImportForm/ReviewSection/ReviewComponentCard.tsx
@@ -66,8 +66,8 @@ export const ReviewComponentCard: React.FC<ReviewComponentCardProps> = ({
           'data-test': `${name}-toggle-button`,
         }}
       >
-        <Flex style={{ flex: 1 }}>
-          <FlexItem flex={{ default: 'flex_4' }}>
+        <Flex className="pf-u-flex-1" direction={{ default: 'column', sm: 'row' }}>
+          <FlexItem flex={{ default: 'flex_4', md: 'flex_3' }}>
             <InputField
               name={`${fieldPrefix}.componentName`}
               label="Component name"


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/RHTAPBUGS-243
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
Make the name and runtime section use vertical flex layout on smaller screens.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

https://github.com/openshift/hac-dev/assets/20013884/cfd238c9-3223-42b2-961d-29b5075ffad5

<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

/cc @christianvogt 