### PR TITLE
Fix environments list view sort order

### DIFF
--- a/src/utils/__tests__/environment-utils.spec.ts
+++ b/src/utils/__tests__/environment-utils.spec.ts
@@ -84,6 +84,23 @@ describe('environment-utils', () => {
     expect(sortEnvironmentsBasedonParent([a, b, c])).toEqual([a, b, c]);
   });
 
+  it('should alphabettically sort environments without parentEnvironment', () => {
+    const bRootEnvironment = {
+      metadata: {
+        name: 'b_root_env',
+      },
+      spec: {},
+    } as EnvironmentKind;
+
+    expect(sortEnvironmentsBasedonParent([bRootEnvironment, a])).toEqual([a, bRootEnvironment]);
+    expect(sortEnvironmentsBasedonParent([bRootEnvironment, a, b, c])).toEqual([
+      a,
+      bRootEnvironment,
+      b,
+      c,
+    ]);
+  });
+
   it('should sort environments alphabetically as well', () => {
     expect(sortEnvironmentsBasedonParent([cb, c, ba, b, bc, bb, a])).toEqual([
       a,

--- a/src/utils/environment-utils.tsx
+++ b/src/utils/environment-utils.tsx
@@ -83,7 +83,9 @@ export const sortEnvironmentsBasedonParent = (
   if (!environments || !environments.length) {
     return [];
   }
-  const sortedEnvs = environments.filter((env) => !isPositionedEnvironment(env, environments));
+  const sortedEnvs = environments
+    .filter((env) => !isPositionedEnvironment(env, environments))
+    .sort((a, b) => a.metadata.name.localeCompare(b.metadata.name));
   const positionedEnvs = environments.filter((env) => isPositionedEnvironment(env, environments));
   insertPositionedEnvironments(positionedEnvs, sortedEnvs);
   return sortedEnvs;


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/RHTAPBUGS-313

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Environments list is alphabetically sorted on the first visit, but after deleting any environment before a default type environment (Development) the cards become unsorted.



## Type of change
<!-- Please delete options that are not relevant. -->


- [x] Bugfix

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

**Before:**

https://github.com/openshift/hac-dev/assets/9964343/75ded679-d2b2-403f-8aaa-977e4dc53e16




**After:**

https://github.com/openshift/hac-dev/assets/9964343/301c48da-f3cb-4c82-939c-7e483d7bc00c




## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

1.  You need to have multiple self managed environments
2. Delete an environment that is before default environment (Development) environment.

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
