### PR TITLE
fix dockerfile icon size in runtime selector dropdown

### DIFF
--- a/src/components/ImportForm/ReviewSection/RuntimeSelector.tsx
+++ b/src/components/ImportForm/ReviewSection/RuntimeSelector.tsx
@@ -29,7 +29,7 @@ const patchSourceUrl = (stub: any, url: string) => {
 const dockerFileSample = {
   key: 'docker-build',
   value: 'Dockerfile',
-  icon: <DockerIcon color="#2496ed" />,
+  icon: <DockerIcon width={24} height={24} color="#2496ed" />,
   name: 'Dockerfile',
 };
 


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/RHTAPBUGS-261

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

we use a PF Docker icon in runtime selector, and that has to match the size of other icons (24px)

Note: Other smaller icons `Node and Go` is fetched dynamically from  https://registry.devfile.io/index/sample and it needs to be fixed from HAS team. cc: @elsony 

Before:
<img width="401" alt="Screen Shot 2023-05-11 at 10 57 18 AM" src="https://github.com/openshift/hac-dev/assets/9964343/4b9f76f8-fd45-44c9-9031-94c303d9f8f7">

After:

<img width="378" alt="Screenshot 2023-05-31 at 11 23 06 AM" src="https://github.com/openshift/hac-dev/assets/9964343/167cb473-67ab-4bad-b7f0-04a33aa85aef">



## Type of change
<!-- Please delete options that are not relevant. -->


- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->




## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
