### PR TITLE
do not pass git revision in cdq when the runtime is changed

### DIFF
--- a/src/components/ImportForm/ReviewSection/RuntimeSelector.tsx
+++ b/src/components/ImportForm/ReviewSection/RuntimeSelector.tsx
@@ -92,7 +92,7 @@ export const RuntimeSelector: React.FC<RuntimeSelectorProps> = ({ detectedCompon
     runtimeSource,
     secret,
     sourceUrl !== runtimeSource ? undefined : context,
-    revision,
+    sourceUrl !== runtimeSource ? undefined : revision,
   );
 
   const isDetectingRuntime =

--- a/src/components/ImportForm/ReviewSection/__tests__/RuntimeSelector.spec.tsx
+++ b/src/components/ImportForm/ReviewSection/__tests__/RuntimeSelector.spec.tsx
@@ -263,4 +263,61 @@ describe('RuntimeSelector', () => {
     expect(setFieldValueMock).toHaveBeenCalledWith('detectionFailed', false);
     expect(setFieldValueMock).toHaveBeenCalledWith('isDetected', true);
   });
+
+  it('should not pass the git revision in cdq call when the runtime is changed', async () => {
+    useDevfileSamplesMock.mockReturnValue([
+      [
+        {
+          name: 'Python',
+          attributes: {
+            projectType: 'python',
+            git: {
+              remotes: {
+                origin: 'https://github.com/devfile-samples/devfile-sample-python-basic',
+              },
+            },
+          },
+          icon: {},
+        },
+      ],
+      true,
+    ]);
+    useComponentDetectionMock.mockReturnValue([]);
+    formikRenderer(<RuntimeSelector detectedComponentIndex={0} />, {
+      source: {
+        git: {
+          url: 'https://github.com/sclorg/nodejs-ex',
+          context: '/testDirectory',
+          revision: 'master',
+        },
+      },
+      isDetected: false,
+      initialDetectionLoaded: true,
+      detectionFailed: false,
+      components: [
+        {
+          projectType: 'nodejs',
+        },
+      ],
+    });
+
+    expect(screen.getByText(detectingRuntime)).toBeVisible();
+    await act(async () => screen.getByText(detectingRuntime).click());
+
+    useComponentDetectionMock.mockReturnValue([
+      { node: { componentStub: { source: { source: { git: {} } } } } },
+      true,
+    ]);
+    await act(async () => screen.getByText('Python').click());
+
+    expect(screen.getByText('Python')).toBeVisible();
+    expect(useComponentDetectionMock).toHaveBeenLastCalledWith(
+      'https://github.com/devfile-samples/devfile-sample-python-basic',
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(setFieldValueMock).toHaveBeenCalledWith('detectionFailed', false);
+    expect(setFieldValueMock).toHaveBeenCalledWith('isDetected', true);
+  });
 });


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/RHTAPBUGS-372

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

A user has encountered an issue wherein they changed the runtime from the recommendation and the UI won't let them proceed to create the component. There are no errors or any feedback of any kind provided to the user. The button to create is simply disabled. Specifically the workflow got broken because they supplied a git reference.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

![create-button-enabled](https://github.com/openshift/hac-dev/assets/9964343/b11d9301-7d46-4d10-bcc8-925068a8ca00)


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->



- create a new application / component for https://github.com/redhat-gamedev/shipwars-move-server
- make sure to set the git reference to `master` even though this is the default
- Observe the recommendation is Dockerfile. Although this Dockerfile is NOT meant for build.
- Since this is a python project, change the runtime to python
- The `Create application/component` button remains disabled

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
