### PR TITLE
Set signup flag to false if any error

### DIFF
--- a/config/remotePlugin.js
+++ b/config/remotePlugin.js
@@ -127,7 +127,7 @@ const routeExtensions = [
     },
   },
 
-  // application-pipeline overview
+  // application-pipeline overview (use exact if user has signup)
   {
     type: 'core.page/route',
     properties: {
@@ -137,27 +137,15 @@ const routeExtensions = [
         $codeRef: 'OverviewPage',
       },
     },
-  },
-  // If user is not signed up, take user to overview page even for applications and environments nav item.
-  // Remove this once we have navigation filtering based on feature flags.
-  {
-    type: 'core.page/route',
-    properties: {
-      path: '/application-pipeline/workspaces',
-      exact: true,
-      component: {
-        $codeRef: 'OverviewPage',
-      },
-    },
     flags: {
-      disallowed: ['SIGNUP'],
+      required: ['SIGNUP'],
     },
   },
+  // If user doesn't have signup flag enabled redirect the user allways to Overview (exact: false)
   {
     type: 'core.page/route',
     properties: {
-      path: '/application-pipeline/environments',
-      exact: true,
+      path: '/application-pipeline',
       component: {
         $codeRef: 'OverviewPage',
       },

--- a/src/utils/__tests__/flag-utils.spec.ts
+++ b/src/utils/__tests__/flag-utils.spec.ts
@@ -31,4 +31,11 @@ describe('setSignupFeatureFlags', () => {
     await setSignupFeatureFlags(setFlag);
     expect(setFlag).toHaveBeenCalledWith(SIGNUP_FLAG, false);
   });
+
+  it('sets signup flag on any error', async () => {
+    fetchMock.mockRejectedValue({ code: 401 });
+    const setFlag = jest.fn();
+    await setSignupFeatureFlags(setFlag);
+    expect(setFlag).toHaveBeenCalledWith(SIGNUP_FLAG, false);
+  });
 });

--- a/src/utils/flag-utils.ts
+++ b/src/utils/flag-utils.ts
@@ -18,6 +18,8 @@ export const setSignupFeatureFlags = async (setFlag: SetFeatureFlag) => {
       setFlag(SIGNUP_FLAG, false);
       break;
     default:
+      // let's disable the signup if something breaks
+      setFlag(SIGNUP_FLAG, false);
       // eslint-disable-next-line no-console
       console.error('Unable to determine signup status.');
   }


### PR DESCRIPTION
## Fixes 

Not able to navigate if signup request fails.

Align the usage of routes, we can gate all routes behind overview if signup returns false.


## Description

If signup URL returns error (401 for instance) the navigation is shown, however none of the routes are properly working as we are not setting the signup to false. This can happen if user tries to access the UI on console.stage.redhat.com environment as this environment is not setup with prod SSO.

Since we can utilize `exact: false` when routing we can hide behind disallowed flag default overview page which'll consume all requests.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):