### PR TITLE
e2e: BYOC automation

### DIFF
--- a/integration-tests/cypress.config.ts
+++ b/integration-tests/cypress.config.ts
@@ -56,7 +56,7 @@ export default defineConfig({
     excludeSpecPattern:
       process.env.CYPRESS_PERIODIC_RUN || process.env.GH_COMMENTBODY?.toLowerCase() == '[test]'
         ? 'tests/*-private-git-*' // TODO: remove once https://issues.redhat.com/browse/RHTAPBUGS-111 is resolved
-        : 'tests/{advanced-happy-path*,*-private-git-*}',
+        : 'tests/{advanced-happy-path*,environments-tests*,*-private-git-*}',
     setupNodeEvents(on, config) {
       require('cypress-mochawesome-reporter/plugin')(on);
       require('@cypress/grep/src/plugin')(config);

--- a/integration-tests/support/constants/PageTitle.ts
+++ b/integration-tests/support/constants/PageTitle.ts
@@ -9,6 +9,7 @@ export const pageTitles = {
 export enum NavItem {
   applications = 'Applications',
   settings = 'Settings',
+  environments = 'Environments',
 }
 
 export const FULL_APPLICATION_TITLE = 'Red Hat Trusted Application Pipeline';

--- a/integration-tests/support/pageObjects/pages-po.ts
+++ b/integration-tests/support/pageObjects/pages-po.ts
@@ -71,3 +71,14 @@ export const addIntegrationTestStepPO = {
   displayNameInput: '[data-test="display-name-input"]',
   optionalreleaseCheckbox: '[data-test="optional-release-checkbox"]',
 };
+
+export const environmentsPagePO = {
+  kubconfigTextArea: 'textarea[id="text-file-kubeconfig"]',
+  kubeconfigValidationMsg: 'div[id="form-input-kubeconfig-field-helper"]',
+  envCard: '[data-ouia-component-type="PF4/Card"]',
+  label: 'div[class*="list__group"]',
+  kebabButton: 'button[data-testid="kebab-button"]',
+  envDropdownDeleteBtn: 'li[data-testid="Delete"]',
+  envDeleteBtn: 'button[data-testid="delete-resource"]',
+  envCardConnectionLabel: 'div[class="pf-c-card__title"] span[class="pf-c-label__content"]',
+};

--- a/integration-tests/support/pages/EnvironmentsPage.ts
+++ b/integration-tests/support/pages/EnvironmentsPage.ts
@@ -1,0 +1,99 @@
+import { Common } from '../../utils/Common';
+import { UIhelper } from '../../utils/UIhelper';
+import { environmentsPagePO } from '../pageObjects/pages-po';
+
+export class EnvironmentsPage {
+  static createEnvironment(
+    envName: string,
+    selectCluster: string,
+    clusterType: string,
+    ingressDomain: string,
+    kubeconfig: string,
+    targetNamespace: string,
+  ) {
+    UIhelper.inputValueInTextBoxByLabelName('Environment name', envName);
+    UIhelper.selectValueInDropdownbyLabelName('Select cluster', selectCluster);
+    UIhelper.selectValueInDropdownbyLabelName('Cluster type', clusterType);
+    UIhelper.inputValueInTextBoxByLabelName('Ingress domain', ingressDomain);
+
+    cy.get(environmentsPagePO.kubconfigTextArea).clear().type(kubeconfig, { log: false });
+    cy.get(environmentsPagePO.kubeconfigValidationMsg).should(
+      'have.text',
+      'Contents verified. Everything looks good.',
+    );
+
+    UIhelper.inputValueInTextBoxByLabelName(
+      'Target namespace on the selected cluster',
+      targetNamespace,
+    );
+    this.clickOnCreateEnv();
+  }
+
+  static clickOnCreateEnv() {
+    UIhelper.clickButton('Create environment');
+  }
+
+  static verifyEnvCardDetails(
+    envName: string,
+    type: string,
+    deploymentStrategy: string,
+    clusterType: string,
+    applicationStatus?: string,
+  ) {
+    cy.contains(environmentsPagePO.envCard, envName).within(() => {
+      cy.get(environmentsPagePO.envCardConnectionLabel)
+        .trigger('mouseenter')
+        .should('be.visible')
+        .and('contain.text', 'Connection successful');
+      this.verifyCardLabelAndValue('Type', type);
+      this.verifyCardLabelAndValue('Deployment strategy', deploymentStrategy);
+      this.verifyCardLabelAndValue('Cluster type', clusterType);
+      if (applicationStatus) {
+        this.verifyCardLabelAndValue('Application status', applicationStatus, 100000);
+      }
+    });
+  }
+
+  static verifyCardLabelAndValue(label: string, value: string, timeout = 40000) {
+    cy.contains(environmentsPagePO.label, label)
+      .contains(value, { timeout: timeout })
+      .should('be.visible');
+  }
+
+  static deleteEnvironment(envName) {
+    cy.contains(environmentsPagePO.envCard, envName).find(environmentsPagePO.kebabButton).click();
+    cy.get(environmentsPagePO.envDropdownDeleteBtn).should('have.text', 'Delete').click();
+    cy.get(environmentsPagePO.envDeleteBtn)
+      .should('have.text', 'Delete')
+      .and('be.disabled')
+      .and('be.visible');
+    UIhelper.inputValueInTextBoxByLabelName(`Type "${envName}" to confirm deletion`, envName);
+    cy.get(environmentsPagePO.envDeleteBtn)
+      .should('be.enabled')
+      .and('be.visible')
+      .click()
+      .should('not.exist');
+    cy.contains(environmentsPagePO.envCard, envName).should('not.exist');
+  }
+
+  static deleteEnvironmentUsingAPI(envName: string) {
+    cy.getCookie('cs_jwt')
+      .should('exist')
+      .its('value')
+      .then((token) => {
+        const namespace = `${Cypress.env('USERNAME').toLowerCase()}-tenant`;
+        const request = {
+          method: 'DELETE',
+          url: `${Common.getOrigin()}/api/k8s/workspaces/${Cypress.env(
+            'USERNAME',
+          ).toLowerCase()}/apis/appstudio.redhat.com/v1alpha1/namespaces/${namespace}/environments/${envName}`,
+          headers: {
+            authorization: `Bearer ${token}`,
+            accept: 'application/json',
+          },
+          failOnStatusCode: false,
+        };
+        cy.request(request);
+      });
+  }
+}

--- a/integration-tests/tests/environments-tests.spec.ts
+++ b/integration-tests/tests/environments-tests.spec.ts
@@ -1,0 +1,87 @@
+import { NavItem } from '../support/constants/PageTitle';
+import { DetailsTab } from '../support/pages/tabs/PipelinerunsTabPage';
+import { Applications } from '../utils/Applications';
+import { Common } from '../utils/Common';
+import { UIhelper } from '../utils/UIhelper';
+import { EnvironmentsPage } from '../support/pages/EnvironmentsPage';
+
+describe('Create Env using Non-OpenShift Cluster', () => {
+  const applicationName = Common.generateAppName();
+  const publicRepo = 'https://github.com/hac-test/devfile-sample-code-with-quarkus';
+  const componentName: string = Common.generateAppName('java-quarkus');
+
+  const envName = Common.generateAppName('env');
+  const clusterInformation = {
+    cluster: 'I want to bring my own cluster',
+    type: 'Non-OpenShift',
+    ingressDomain: 'apps.hac-devsandbox.5unc.p1.openshiftapps.com',
+    kubeconfig: Buffer.from(Cypress.env('VC_KUBECONFIG'), 'base64').toString('utf8'),
+    targetNamespace: 'default',
+  };
+
+  after(function () {
+    Applications.deleteApplication(applicationName);
+    EnvironmentsPage.deleteEnvironmentUsingAPI(envName);
+  });
+
+  describe('Create a environment', () => {
+    it('Create environment', () => {
+      Common.navigateTo(NavItem.environments);
+      EnvironmentsPage.clickOnCreateEnv();
+      EnvironmentsPage.createEnvironment(
+        envName,
+        clusterInformation.cluster,
+        clusterInformation.type,
+        clusterInformation.ingressDomain,
+        clusterInformation.kubeconfig,
+        clusterInformation.targetNamespace,
+      );
+    });
+
+    it('Verify new Env on Environments Tab', () => {
+      EnvironmentsPage.verifyEnvCardDetails(envName, 'Self Managed', 'Automatic', 'Kubernetes');
+    });
+  });
+
+  describe('Create an Application', () => {
+    it('Create an Application with a component', () => {
+      Common.navigateTo(NavItem.applications);
+      Applications.createApplication();
+      Applications.createComponent(publicRepo, componentName, applicationName);
+    });
+
+    it('Verify the Pipeline run details', () => {
+      Applications.goToPipelinerunsTab();
+      UIhelper.getTableRow('Pipeline run List', /Running|Pending/)
+        .contains(`${componentName}-`)
+        .invoke('text')
+        .then((pipelinerunName) => {
+          UIhelper.clickLink(pipelinerunName);
+          DetailsTab.waitUntilStatusIsNotRunning();
+        });
+    });
+  });
+
+  describe('Verify application in deployments Tab and delete application and env', () => {
+    it('verify application status in Deployments Tab', () => {
+      Applications.clickBreadcrumbLink(applicationName);
+      UIhelper.clickTab('Deployments');
+      EnvironmentsPage.verifyEnvCardDetails(
+        envName,
+        'Self Managed',
+        'Automatic',
+        'Kubernetes',
+        'Healthy',
+      );
+    });
+
+    it('Delete Application', () => {
+      Applications.deleteApplication(applicationName);
+    });
+
+    it('Delete Environment', () => {
+      Common.navigateTo(NavItem.environments);
+      EnvironmentsPage.deleteEnvironment(envName);
+    });
+  });
+});

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -90,6 +90,7 @@ podman run --userns=keep-id ${COMMON_SETUP} \
     -e CYPRESS_GH_PASSWORD=${CYPRESS_GH_PASSWORD} \
     -e CYPRESS_QUAY_TOKEN=${CYPRESS_QUAY_TOKEN} \
     -e CYPRESS_RP_TOKEN=${CYPRESS_RP_HAC} \
+    -e CYPRESS_VC_KUBECONFIG=${CYPRESS_VC_KUBECONFIG} \
     ${TEST_IMAGE} || TEST_RUN=1
 
 if [[ $TEST_IMAGE =~ "hac-dev:pr" ]]; then


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/HAC-4147

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
BYOC automation : 
1. Create new Env from environments Nav Tab using the vcluster kubeconfig.
2. Validate the connection is successful and Details on environment cards are correct.
3. Create a new Application and component and wait for successful build.
4. Navigate to deployments Tab of the components and validate the Details on env card are correct and application status is healthy.
5. Delete the application.
6. Delete and validate the new Environment from Environments Nav Tab.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Test

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
