### PR TITLE
Integration test git support

### DIFF
--- a/src/components/ApplicationDetails/tabs/overview/visualization/hooks/__data__/workflow-data.ts
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/hooks/__data__/workflow-data.ts
@@ -747,7 +747,6 @@ export const sampleIntegrationTestScenarios: IntegrationTestScenarioKind[] = [
     },
     spec: {
       application: 'frontend-app',
-      bundle: 'quay.io/kpavic/test-bundle:pipeline',
       contexts: [
         {
           description: 'Runs only during application testing',
@@ -765,7 +764,7 @@ export const sampleIntegrationTestScenarios: IntegrationTestScenarioKind[] = [
           value: ['test'],
         },
       ],
-      pipeline: 'demo-pipeline',
+      resolverRef: null,
     },
   },
   {
@@ -777,7 +776,6 @@ export const sampleIntegrationTestScenarios: IntegrationTestScenarioKind[] = [
     },
     spec: {
       application: 'frontend-app',
-      bundle: 'quay.io/kpavic/test-bundle:pipeline',
       contexts: [
         {
           description: 'Runs only during application testing',
@@ -795,7 +793,7 @@ export const sampleIntegrationTestScenarios: IntegrationTestScenarioKind[] = [
           value: ['test'],
         },
       ],
-      pipeline: 'demo-pipeline',
+      resolverRef: null,
     },
   },
 ];

--- a/src/components/ImportForm/SourceSection/SourceSection.tsx
+++ b/src/components/ImportForm/SourceSection/SourceSection.tsx
@@ -17,7 +17,7 @@ import GitOptions from './GitOptions';
 
 import './SourceSection.scss';
 
-enum AccessHelpText {
+export enum AccessHelpText {
   default = '',
   checking = 'Checking access...',
   validated = 'Access validated',

--- a/src/components/IntegrationTest/IntegrationTestForm/IntegrationTestView.tsx
+++ b/src/components/IntegrationTest/IntegrationTestForm/IntegrationTestView.tsx
@@ -6,7 +6,11 @@ import { useTrackEvent, TrackEvents } from '../../../utils/analytics';
 import { useWorkspaceInfo } from '../../../utils/workspace-context-utils';
 import IntegrationTestForm from './IntegrationTestForm';
 import { IntegrationTestLabels } from './types';
-import { editIntegrationTest, createIntegrationTest } from './utils/create-utils';
+import {
+  editIntegrationTest,
+  createIntegrationTest,
+  ResolverRefParams,
+} from './utils/create-utils';
 import { integrationTestValidationSchema } from './utils/validation-utils';
 
 type IntegrationTestViewProps = {
@@ -22,11 +26,24 @@ const IntegrationTestView: React.FunctionComponent<IntegrationTestViewProps> = (
   const navigate = useNavigate();
   const { namespace, workspace } = useWorkspaceInfo();
 
+  const url = integrationTest?.spec.resolverRef?.params?.find(
+    (param) => param.name === ResolverRefParams.URL,
+  );
+
+  const revision = integrationTest?.spec.resolverRef?.params?.find(
+    (param) => param.name === ResolverRefParams.REVISION,
+  );
+
+  const path = integrationTest?.spec.resolverRef?.params?.find(
+    (param) => param.name === ResolverRefParams.PATH,
+  );
+
   const initialValues = {
     integrationTest: {
       name: integrationTest?.metadata.name ?? '',
-      bundle: integrationTest?.spec.bundle ?? '',
-      pipeline: integrationTest?.spec.pipeline ?? '',
+      url: url?.value ?? '',
+      revision: revision?.value ?? '',
+      path: path?.value ?? '',
       optional:
         integrationTest?.metadata.labels?.[IntegrationTestLabels.OPTIONAL] === 'true' ?? false,
     },

--- a/src/components/IntegrationTest/IntegrationTestForm/types.ts
+++ b/src/components/IntegrationTest/IntegrationTestForm/types.ts
@@ -3,9 +3,11 @@ import { ImportFormValues } from '../../../components/ImportForm/utils/types';
 
 export type IntegrationTestFormValues = {
   name: string;
-  pipeline: string;
-  bundle: string;
+  url: string;
+  revision?: string;
+  path?: string;
   optional: boolean;
+  secret?: string;
 };
 
 export enum IntegrationTestAnnotations {

--- a/src/components/IntegrationTest/IntegrationTestForm/utils/__tests__/create-utils.spec.ts
+++ b/src/components/IntegrationTest/IntegrationTestForm/utils/__tests__/create-utils.spec.ts
@@ -1,7 +1,13 @@
 import { k8sCreateResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { IntegrationTestScenarioModel } from '../../../../../models';
+import { MockIntegrationTestsWithGit } from '../../../IntegrationTestsListView/__data__/mock-integration-tests';
 import { IntegrationTestLabels } from '../../types';
-import { createIntegrationTest } from '../create-utils';
+import {
+  ResolverRefParams,
+  createIntegrationTest,
+  getLabelForParam,
+  getURLForParam,
+} from '../create-utils';
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   k8sCreateResource: jest.fn(),
@@ -18,21 +24,33 @@ const integrationTestData = {
   },
   spec: {
     application: 'Test Application',
-    bundle: '',
+    resolverRef: {
+      resolver: 'git',
+      params: [
+        { name: 'url', value: 'test-url' },
+        { name: 'revision', value: 'test-revision' },
+        { name: 'pathInRepo', value: 'test-path' },
+      ],
+    },
     contexts: [
       {
         description: 'Application testing',
         name: 'application',
       },
     ],
-    pipeline: '',
   },
 };
 
 describe('Create Utils', () => {
   it('Should call k8sCreateResource with integration test data', async () => {
     await createIntegrationTest(
-      { name: 'app-test', bundle: '', pipeline: '', optional: false },
+      {
+        name: 'app-test',
+        revision: 'test-revision',
+        url: 'test-url',
+        path: 'test-path',
+        optional: false,
+      },
       'Test Application',
       'test-ns',
     );
@@ -50,7 +68,13 @@ describe('Create Utils', () => {
   it('Should contain the optional test value in the labels', async () => {
     createResourceMock.mockImplementation(({ resource }) => resource);
     const resource = await createIntegrationTest(
-      { name: 'app-test', bundle: '', pipeline: '', optional: true },
+      {
+        name: 'app-test',
+        revision: 'test-revision',
+        url: 'test-url',
+        path: 'test-path',
+        optional: true,
+      },
       'Test Application',
       'test-ns',
     );
@@ -61,10 +85,65 @@ describe('Create Utils', () => {
   it('Should not contain the optional label if the test is mandatory', async () => {
     createResourceMock.mockImplementation(({ resource }) => resource);
     const resource = await createIntegrationTest(
-      { name: 'app-test', bundle: '', pipeline: '', optional: false },
+      {
+        name: 'app-test',
+        revision: 'test-revision',
+        url: 'test-url',
+        path: 'test-path',
+        optional: false,
+      },
       'Test Application',
       'test-ns',
     );
     expect(resource.metadata.labels).not.toBeDefined();
+  });
+
+  it('Should not contain the optional label if the test is mandatory', async () => {
+    createResourceMock.mockImplementation(({ resource }) => resource);
+    const resource = await createIntegrationTest(
+      {
+        name: 'app-test',
+        revision: 'test-revision',
+        url: 'test-url',
+        path: 'test-path',
+        optional: false,
+      },
+      'Test Application',
+      'test-ns',
+    );
+    expect(resource.metadata.labels).not.toBeDefined();
+  });
+
+  it('Should return correct labels for params', () => {
+    createResourceMock.mockImplementation(({ resource }) => resource);
+    const resource = MockIntegrationTestsWithGit[0];
+    expect(getLabelForParam(resource.spec.resolverRef.params[0].name)).toBe('GitHub URL');
+    expect(getLabelForParam(resource.spec.resolverRef.params[1].name)).toBe('Revision');
+    expect(getLabelForParam(resource.spec.resolverRef.params[2].name)).toBe('Path in repository');
+    expect(getLabelForParam('test-param')).toBe('Test-param');
+  });
+
+  it('Should return correct link for params', () => {
+    createResourceMock.mockImplementation(({ resource }) => resource);
+    const resource = MockIntegrationTestsWithGit[0];
+    const k8sResource = MockIntegrationTestsWithGit[2];
+    expect(getURLForParam(resource.spec.resolverRef.params, ResolverRefParams.URL)).toBe(
+      'https://test-url',
+    );
+    expect(getURLForParam(k8sResource.spec.resolverRef.params, ResolverRefParams.URL)).toBe(
+      'https://github.com/redhat-appstudio/integration-examples',
+    );
+    expect(getURLForParam(resource.spec.resolverRef.params, ResolverRefParams.REVISION)).toBe(
+      'https://test-url/tree/main',
+    );
+    expect(getURLForParam(k8sResource.spec.resolverRef.params, ResolverRefParams.REVISION)).toBe(
+      'https://github.com/redhat-appstudio/integration-examples/tree/main',
+    );
+    expect(getURLForParam(resource.spec.resolverRef.params, ResolverRefParams.PATH)).toBe(
+      'https://test-url/tree/main/test-path',
+    );
+    expect(getURLForParam(k8sResource.spec.resolverRef.params, ResolverRefParams.PATH)).toBe(
+      'https://github.com/redhat-appstudio/integration-examples/tree/main/pipelines/integration_pipeline_pass.yaml',
+    );
   });
 });

--- a/src/components/IntegrationTest/IntegrationTestForm/utils/__tests__/validation-utils.spec.ts
+++ b/src/components/IntegrationTest/IntegrationTestForm/utils/__tests__/validation-utils.spec.ts
@@ -6,8 +6,9 @@ describe('validation-utils', () => {
       integrationTestValidationSchema.validate({
         integrationTest: {
           name: 'test-name',
-          pipeline: 'pipeline',
-          bundle: 'quay.io/foo/bar',
+          url: 'test-url',
+          path: 'test-path',
+          revision: 'revision',
         },
       }),
     ).not.toThrow();
@@ -17,8 +18,9 @@ describe('validation-utils', () => {
     await expect(
       integrationTestValidationSchema.validate({
         integrationTest: {
-          pipeline: 'pipeline',
-          bundle: 'quay.io/foo/bar',
+          url: 'test-url',
+          path: 'test-path',
+          revision: 'revision',
         },
       }),
     ).rejects.toThrow('Required');
@@ -29,8 +31,9 @@ describe('validation-utils', () => {
       integrationTestValidationSchema.validate({
         integrationTest: {
           name: '$symbol-first',
-          pipeline: 'pipeline',
-          bundle: 'quay.io/foo/bar',
+          url: 'test-url',
+          path: 'test-path',
+          revision: 'revision',
         },
       }),
     ).rejects.toThrow(
@@ -38,23 +41,24 @@ describe('validation-utils', () => {
     );
   });
 
-  it('should fail when pipeline is missing', async () => {
+  it('should fail when url is missing', async () => {
     await expect(
       integrationTestValidationSchema.validate({
         integrationTest: {
           name: 'test-name',
-          bundle: 'quay.io/foo/bar',
+          path: 'test-path',
+          revision: 'revision',
         },
       }),
     ).rejects.toThrow('Required');
   });
 
-  it('should fail when bundle is missing', async () => {
+  it('should fail when path is missing', async () => {
     await expect(
       integrationTestValidationSchema.validate({
         integrationTest: {
-          name: 'test-name',
-          pipeline: 'pipeline',
+          url: 'test-url',
+          path: 'test-path',
         },
       }),
     ).rejects.toThrow('Required');

--- a/src/components/IntegrationTest/IntegrationTestForm/utils/create-utils.ts
+++ b/src/components/IntegrationTest/IntegrationTestForm/utils/create-utils.ts
@@ -4,7 +4,11 @@ import {
   IntegrationTestScenarioGroupVersionKind,
   IntegrationTestScenarioModel,
 } from '../../../../models';
-import { IntegrationTestScenarioKind, ResolverParam } from '../../../../types/coreBuildService';
+import {
+  IntegrationTestScenarioKind,
+  ResolverParam,
+  ResolverType,
+} from '../../../../types/coreBuildService';
 import { FormValues, IntegrationTestFormValues, IntegrationTestLabels } from '../types';
 
 export enum ResolverRefParams {
@@ -28,7 +32,7 @@ export const editIntegrationTest = (
     spec: {
       ...integrationTest.spec,
       resolverRef: {
-        resolver: 'git',
+        resolver: ResolverType.GIT,
         params: [
           { name: ResolverRefParams.URL, value: url },
           { name: ResolverRefParams.REVISION, value: revision },
@@ -83,7 +87,7 @@ export const createIntegrationTest = (
     spec: {
       application,
       resolverRef: {
-        resolver: 'git',
+        resolver: ResolverType.GIT,
         params: [
           { name: ResolverRefParams.URL, value: url },
           { name: ResolverRefParams.REVISION, value: revision },
@@ -137,16 +141,16 @@ export const getURLForParam = (params: ResolverParam[], paramName: string): stri
   const resolverParam =
     paramName === ResolverRefParams.URL ? url : params.find((param) => param.name === paramName);
 
-  const checkedURL = getGitHubLink(url.value);
+  const checkedURL = getGitHubLink(url?.value);
 
   if (paramName === ResolverRefParams.URL) {
     return checkedURL;
   }
-  if (paramName === ResolverRefParams.PATH) {
+  if (paramName === ResolverRefParams.PATH && resolverParam) {
     const branch = params.find((param) => param.name === ResolverRefParams.REVISION);
     return `${checkedURL}/tree/${branch.value}/${resolverParam.value}`;
   }
-  if (paramName === ResolverRefParams.REVISION) {
+  if (paramName === ResolverRefParams.REVISION && resolverParam) {
     return `${checkedURL}/tree/${resolverParam.value}`;
   }
   return null;

--- a/src/components/IntegrationTest/IntegrationTestForm/utils/validation-utils.ts
+++ b/src/components/IntegrationTest/IntegrationTestForm/utils/validation-utils.ts
@@ -1,9 +1,4 @@
 import * as yup from 'yup';
-import {
-  containerImageRegex,
-  MAX_RESOURCE_NAME_LENGTH,
-  RESOURCE_NAME_LENGTH_ERROR_MSG,
-} from '../../../ImportForm/utils/validation-utils';
 
 const k8sResourceNameRegex =
   /^\s*?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\s*?$/;
@@ -16,13 +11,14 @@ export const integrationTestValidationSchema = yup.object({
       .matches(
         k8sResourceNameRegex,
         'Must start with a letter or number and end with a letter or number. Valid characters include lowercase letters from a to z, numbers from 0 to 9, and hyphens ( - ).',
-      )
-      .max(MAX_RESOURCE_NAME_LENGTH, RESOURCE_NAME_LENGTH_ERROR_MSG),
-    pipeline: yup.string().required('Required'),
-    bundle: yup
+      ),
+    url: yup
       .string()
       .required('Required')
-      .max(2000, 'Please enter a URL that is less than 2000 characters.')
-      .matches(containerImageRegex, 'Invalid container image'),
+      .max(2000, 'Please enter a URL that is less than 2000 characters.'),
+    path: yup
+      .string()
+      .required('Required')
+      .max(2000, 'Please enter a path that is less than 2000 characters.'),
   }),
 });

--- a/src/components/IntegrationTest/IntegrationTestsListView/IntegrationTestListHeader.ts
+++ b/src/components/IntegrationTest/IntegrationTestsListView/IntegrationTestListHeader.ts
@@ -13,7 +13,7 @@ export const IntegrationTestListHeader = () => {
       props: { className: integrationListTableColumnClasses.name },
     },
     {
-      title: 'Container image',
+      title: 'Github URL',
       props: { className: integrationListTableColumnClasses.containerImage },
     },
     {
@@ -21,7 +21,7 @@ export const IntegrationTestListHeader = () => {
       props: { className: integrationListTableColumnClasses.mandatory },
     },
     {
-      title: 'Pipelines',
+      title: 'Revision',
       props: { className: integrationListTableColumnClasses.pipeline },
     },
     {

--- a/src/components/IntegrationTest/IntegrationTestsListView/IntegrationTestListRow.tsx
+++ b/src/components/IntegrationTest/IntegrationTestsListView/IntegrationTestListRow.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
+import { Truncate } from '@patternfly/react-core';
 import ActionMenu from '../../../shared/components/action-menu/ActionMenu';
 import ExternalLink from '../../../shared/components/links/ExternalLink';
 import { RowFunctionArgs, TableData } from '../../../shared/components/table';
 import { IntegrationTestScenarioKind } from '../../../types/coreBuildService';
 import { useWorkspaceInfo } from '../../../utils/workspace-context-utils';
 import { IntegrationTestLabels } from '../IntegrationTestForm/types';
+import { ResolverRefParams, getURLForParam } from '../IntegrationTestForm/utils/create-utils';
 import { integrationListTableColumnClasses } from './IntegrationTestListHeader';
 import { useIntegrationTestActions } from './useIntegrationTestActions';
 
@@ -14,10 +16,6 @@ const IntegrationTestListRow: React.FC<RowFunctionArgs<IntegrationTestScenarioKi
 }) => {
   const actions = useIntegrationTestActions(obj);
   const { workspace } = useWorkspaceInfo();
-  const containerImageUrl = /(http(s?)):\/\//i.test(obj.spec.bundle)
-    ? obj.spec.bundle
-    : `https://${obj.spec.bundle}`;
-
   return (
     <>
       <TableData
@@ -31,7 +29,23 @@ const IntegrationTestListRow: React.FC<RowFunctionArgs<IntegrationTestScenarioKi
         </Link>
       </TableData>
       <TableData className={integrationListTableColumnClasses.containerImage}>
-        <ExternalLink href={containerImageUrl} text={containerImageUrl} stopPropagation />
+        {obj?.spec?.resolverRef?.params ? (
+          <ExternalLink
+            href={getURLForParam(obj?.spec?.resolverRef?.params, ResolverRefParams.URL)}
+            text={
+              <Truncate
+                content={
+                  obj?.spec?.resolverRef?.params.find(
+                    (param) => param.name === ResolverRefParams.URL,
+                  )?.value
+                }
+              />
+            }
+            stopPropagation
+          />
+        ) : (
+          '-'
+        )}
       </TableData>
       <TableData className={integrationListTableColumnClasses.mandatory}>
         {obj.metadata.labels?.[IntegrationTestLabels.OPTIONAL] === 'true'
@@ -39,7 +53,19 @@ const IntegrationTestListRow: React.FC<RowFunctionArgs<IntegrationTestScenarioKi
           : 'Mandatory'}
       </TableData>
       <TableData className={integrationListTableColumnClasses.pipeline}>
-        {obj.spec.pipeline}
+        {obj?.spec?.resolverRef?.params ? (
+          <ExternalLink
+            href={getURLForParam(obj?.spec?.resolverRef?.params, ResolverRefParams.REVISION)}
+            text={
+              obj?.spec?.resolverRef?.params.find(
+                (param) => param.name === ResolverRefParams.REVISION,
+              )?.value
+            }
+            stopPropagation
+          />
+        ) : (
+          '-'
+        )}
       </TableData>
       <TableData className={integrationListTableColumnClasses.kebab}>
         <ActionMenu actions={actions} />

--- a/src/components/IntegrationTest/IntegrationTestsListView/IntegrationTestListRow.tsx
+++ b/src/components/IntegrationTest/IntegrationTestsListView/IntegrationTestListRow.tsx
@@ -37,7 +37,7 @@ const IntegrationTestListRow: React.FC<RowFunctionArgs<IntegrationTestScenarioKi
                 content={
                   obj?.spec?.resolverRef?.params.find(
                     (param) => param.name === ResolverRefParams.URL,
-                  )?.value
+                  )?.value || '-'
                 }
               />
             }
@@ -59,7 +59,7 @@ const IntegrationTestListRow: React.FC<RowFunctionArgs<IntegrationTestScenarioKi
             text={
               obj?.spec?.resolverRef?.params.find(
                 (param) => param.name === ResolverRefParams.REVISION,
-              )?.value
+              )?.value || '-'
             }
             stopPropagation
           />

--- a/src/components/IntegrationTest/IntegrationTestsListView/__data__/mock-integration-tests.ts
+++ b/src/components/IntegrationTest/IntegrationTestsListView/__data__/mock-integration-tests.ts
@@ -1,3 +1,4 @@
+import { IntegrationTestScenarioKind } from '../../../../types/coreBuildService';
 import { IntegrationTestLabels } from '../../IntegrationTestForm/types';
 
 export const MockIntegrationTests = [
@@ -48,6 +49,114 @@ export const MockIntegrationTests = [
         },
       ],
       pipeline: 'pipeline-2',
+    },
+  },
+];
+
+export const MockIntegrationTestsWithGit: IntegrationTestScenarioKind[] = [
+  {
+    apiVersion: 'appstudio.redhat.com/v1alpha1',
+    kind: 'IntegrationTestScenario',
+    metadata: {
+      labels: {
+        [IntegrationTestLabels.OPTIONAL]: 'true',
+      },
+      annotations: {
+        'app.kubernetes.io/display-name': 'Test 1',
+      },
+      name: 'test-app-test-1',
+      namespace: 'test-namespace',
+      uid: 'ed722704-74bc-4152-b27b-bee29cc7bfd2',
+    },
+    spec: {
+      application: 'test-app',
+      resolverRef: {
+        resolver: 'git',
+        params: [
+          { name: 'url', value: 'https://test-url' },
+          { name: 'revision', value: 'main' },
+          { name: 'pathInRepo', value: 'test-path' },
+        ],
+      },
+      contexts: [
+        {
+          description: 'Application testing 1',
+          name: 'application',
+        },
+      ],
+    },
+  },
+  {
+    apiVersion: 'appstudio.redhat.com/v1alpha1',
+    kind: 'IntegrationTestScenario',
+    metadata: {
+      annotations: {
+        'app.kubernetes.io/display-name': 'Test 2',
+      },
+      name: 'test-app-test-2',
+      namespace: 'test-namespace',
+      uid: 'ed722704-74bc-4152-b27b-bee29cc7bfd3',
+    },
+    spec: {
+      application: 'test-app',
+      resolverRef: {
+        resolver: 'git',
+        params: [
+          { name: 'url', value: 'test-url2' },
+          { name: 'revision', value: 'main2' },
+          { name: 'pathInRepo', value: 'test-path2' },
+        ],
+      },
+      contexts: [
+        {
+          description: 'Application testing 2',
+          name: 'application',
+        },
+      ],
+    },
+  },
+  {
+    apiVersion: 'appstudio.redhat.com/v1beta1',
+    kind: 'IntegrationTestScenario',
+    metadata: {
+      creationTimestamp: '2023-04-26T11:16:32Z',
+      generation: 1,
+      managedFields: [],
+      name: 'example-git',
+      namespace: 'default',
+      resourceVersion: '1031539',
+      uid: '19b590b6-c583-4651-8342-a60d98a1bcb1',
+    },
+    spec: {
+      application: 'example-app',
+      resolverRef: {
+        params: [
+          {
+            name: 'url',
+            value: 'https://github.com/redhat-appstudio/integration-examples.git',
+          },
+          {
+            name: 'revision',
+            value: 'main',
+          },
+          {
+            name: 'pathInRepo',
+            value: 'pipelines/integration_pipeline_pass.yaml',
+          },
+        ],
+        resolver: 'git',
+      },
+    },
+    status: {
+      conditions: [
+        {
+          lastTransitionTime: '2023-04-26T11:16:32Z',
+          message: 'Failed to get application for scenario.',
+          reason: 'Invalid',
+          status: 'False',
+          type: 'IntegrationTestScenarioValid',
+        },
+      ],
     },
   },
 ];

--- a/src/components/IntegrationTest/IntegrationTestsListView/__data__/mock-integration-tests.ts
+++ b/src/components/IntegrationTest/IntegrationTestsListView/__data__/mock-integration-tests.ts
@@ -1,4 +1,4 @@
-import { IntegrationTestScenarioKind } from '../../../../types/coreBuildService';
+import { IntegrationTestScenarioKind, ResolverType } from '../../../../types/coreBuildService';
 import { IntegrationTestLabels } from '../../IntegrationTestForm/types';
 
 export const MockIntegrationTests = [
@@ -53,6 +53,44 @@ export const MockIntegrationTests = [
   },
 ];
 
+export const MockIntegrationTestsWithBundles: IntegrationTestScenarioKind[] = [
+  {
+    apiVersion: 'appstudio.redhat.com/v1alpha1',
+    kind: 'IntegrationTestScenario',
+    metadata: {
+      labels: {
+        [IntegrationTestLabels.OPTIONAL]: 'true',
+      },
+      annotations: {
+        'app.kubernetes.io/display-name': 'Test 1',
+      },
+      name: 'test-app-test-1',
+      namespace: 'test-namespace',
+      uid: 'ed722704-74bc-4152-b27b-bee29cc7bfd2',
+    },
+    spec: {
+      application: 'test-app',
+      resolverRef: {
+        resolver: ResolverType.BUNDLES,
+        params: [
+          {
+            name: 'bundle',
+            value: 'quay.io/redhat-appstudio/example-tekton-bundle:integration-pipeline-pass',
+          },
+          { name: 'name', value: 'integration-pipeline-pass' },
+          { name: 'kind', value: 'pipeline' },
+        ],
+      },
+      contexts: [
+        {
+          description: 'Application testing 1',
+          name: 'application',
+        },
+      ],
+    },
+  },
+];
+
 export const MockIntegrationTestsWithGit: IntegrationTestScenarioKind[] = [
   {
     apiVersion: 'appstudio.redhat.com/v1alpha1',
@@ -71,7 +109,7 @@ export const MockIntegrationTestsWithGit: IntegrationTestScenarioKind[] = [
     spec: {
       application: 'test-app',
       resolverRef: {
-        resolver: 'git',
+        resolver: ResolverType.GIT,
         params: [
           { name: 'url', value: 'https://test-url' },
           { name: 'revision', value: 'main' },
@@ -100,7 +138,7 @@ export const MockIntegrationTestsWithGit: IntegrationTestScenarioKind[] = [
     spec: {
       application: 'test-app',
       resolverRef: {
-        resolver: 'git',
+        resolver: ResolverType.GIT,
         params: [
           { name: 'url', value: 'test-url2' },
           { name: 'revision', value: 'main2' },
@@ -144,7 +182,7 @@ export const MockIntegrationTestsWithGit: IntegrationTestScenarioKind[] = [
             value: 'pipelines/integration_pipeline_pass.yaml',
           },
         ],
-        resolver: 'git',
+        resolver: ResolverType.GIT,
       },
     },
     status: {

--- a/src/components/IntegrationTest/IntegrationTestsListView/__tests__/IntegrationTestsListRow.spec.tsx
+++ b/src/components/IntegrationTest/IntegrationTestsListView/__tests__/IntegrationTestsListRow.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
-import { MockIntegrationTests } from '../__data__/mock-integration-tests';
+import { MockIntegrationTestsWithGit } from '../__data__/mock-integration-tests';
 import IntegrationTestListRow from '../IntegrationTestListRow';
 
 jest.mock('react-router-dom', () => ({
@@ -13,19 +13,19 @@ jest.mock('../../../../utils/rbac', () => ({
 
 describe('IntegrationTestListRow', () => {
   it('should render integration test info with https appended url', () => {
-    const integrationTest = MockIntegrationTests[0];
+    const integrationTest = MockIntegrationTestsWithGit[0];
     const wrapper = render(<IntegrationTestListRow obj={integrationTest} columns={[]} />, {
       container: document.createElement('tr'),
     });
     const cells = wrapper.container.getElementsByTagName('td');
 
     expect(cells[0].innerHTML).toBe(integrationTest.metadata.name);
-    expect(cells[1].children[0].innerHTML).toBe(`https://${integrationTest.spec.bundle}`);
-    expect(cells[3].innerHTML).toBe(integrationTest.spec.pipeline);
+    const anchor = cells[3].children[0] as HTMLElement;
+    expect(anchor.getAttribute('href')).toBe('https://test-url/tree/main');
   });
 
   it('should read the optional field from label', () => {
-    const optionalIntegrationTest = MockIntegrationTests[0];
+    const optionalIntegrationTest = MockIntegrationTestsWithGit[0];
     const wrapper = render(<IntegrationTestListRow obj={optionalIntegrationTest} columns={[]} />, {
       container: document.createElement('tr'),
     });
@@ -34,7 +34,7 @@ describe('IntegrationTestListRow', () => {
   });
 
   it('should show mandatory value if the optional labels are not set', () => {
-    const mandatoryIntegrationTest = MockIntegrationTests[1];
+    const mandatoryIntegrationTest = MockIntegrationTestsWithGit[1];
     const wrapper = render(<IntegrationTestListRow obj={mandatoryIntegrationTest} columns={[]} />, {
       container: document.createElement('tr'),
     });
@@ -43,7 +43,7 @@ describe('IntegrationTestListRow', () => {
   });
 
   it('should append https to bundle url only where required', () => {
-    const integrationTest = MockIntegrationTests[1];
+    const integrationTest = MockIntegrationTestsWithGit[1];
     const wrapper = render(<IntegrationTestListRow obj={integrationTest} columns={[]} />, {
       container: document.createElement('tr'),
     });

--- a/src/components/IntegrationTest/IntegrationTestsListView/__tests__/IntegrationTestsListRow.spec.tsx
+++ b/src/components/IntegrationTest/IntegrationTestsListView/__tests__/IntegrationTestsListRow.spec.tsx
@@ -41,13 +41,4 @@ describe('IntegrationTestListRow', () => {
     const cells = wrapper.container.getElementsByTagName('td');
     expect(cells[2].innerHTML).toBe('Mandatory');
   });
-
-  it('should append https to bundle url only where required', () => {
-    const integrationTest = MockIntegrationTestsWithGit[1];
-    const wrapper = render(<IntegrationTestListRow obj={integrationTest} columns={[]} />, {
-      container: document.createElement('tr'),
-    });
-    const cells = wrapper.container.getElementsByTagName('td');
-    expect(cells[1].children[0].innerHTML).toBe(`${integrationTest.spec.bundle}`);
-  });
 });

--- a/src/components/IntegrationTest/IntegrationTestsListView/useIntegrationTestActions.tsx
+++ b/src/components/IntegrationTest/IntegrationTestsListView/useIntegrationTestActions.tsx
@@ -1,6 +1,6 @@
 import { IntegrationTestScenarioModel } from '../../../models';
 import { Action } from '../../../shared/components/action-menu/types';
-import { IntegrationTestScenarioKind } from '../../../types/coreBuildService';
+import { IntegrationTestScenarioKind, ResolverType } from '../../../types/coreBuildService';
 import { useAccessReviewForModel } from '../../../utils/rbac';
 import { useWorkspaceInfo } from '../../../utils/workspace-context-utils';
 import { createDeleteModalLauncher } from '../../modal/DeleteResourceModal';
@@ -44,8 +44,13 @@ export const useIntegrationTestActions = (
       cta: {
         href: `/application-pipeline/workspaces/${workspace}/applications/${integrationTest.spec.application}/integrationtests/${integrationTest.metadata.name}/edit`,
       },
-      disabled: !canUpdateIntegrationTest,
-      disabledTooltip: "You don't have access to edit this integration test",
+      disabled:
+        !canUpdateIntegrationTest ||
+        integrationTest.spec?.resolverRef?.resolver !== ResolverType.GIT,
+      disabledTooltip:
+        integrationTest.spec?.resolverRef?.resolver !== ResolverType.GIT && canUpdateIntegrationTest
+          ? undefined
+          : "You don't have access to edit this integration test",
       analytics: {
         link_name: 'edit-integration-test',
         link_location: 'integration-test-actions',

--- a/src/components/IntegrationTest/__tests__/IntegrationTestDetailsView.spec.tsx
+++ b/src/components/IntegrationTest/__tests__/IntegrationTestDetailsView.spec.tsx
@@ -11,7 +11,7 @@ import { IntegrationTestScenarioKind } from '../../../types/coreBuildService';
 import { routerRenderer } from '../../../utils/test-utils';
 import { mockPipelineRuns } from '../../ApplicationDetails/__data__/mock-pipeline-run';
 import IntegrationTestDetailsView from '../IntegrationTestDetailsView';
-import { MockIntegrationTests } from '../IntegrationTestsListView/__data__/mock-integration-tests';
+import { MockIntegrationTestsWithGit } from '../IntegrationTestsListView/__data__/mock-integration-tests';
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   useK8sWatchResource: jest.fn(),
@@ -36,7 +36,7 @@ const watchResourceMock = useK8sWatchResource as jest.Mock;
 
 configure({ testIdAttribute: 'data-test' });
 
-const mockIntegrationTests: IntegrationTestScenarioKind[] = [...MockIntegrationTests];
+const mockIntegrationTests: IntegrationTestScenarioKind[] = [...MockIntegrationTestsWithGit];
 
 const getMockedResources = (params: WatchK8sResource) => {
   if (params.groupVersionKind === IntegrationTestScenarioGroupVersionKind) {

--- a/src/components/IntegrationTest/tabs/IntegrationTestOverviewTab.tsx
+++ b/src/components/IntegrationTest/tabs/IntegrationTestOverviewTab.tsx
@@ -15,19 +15,18 @@ import { IntegrationTestScenarioKind } from '../../../types/coreBuildService';
 import { useWorkspaceInfo } from '../../../utils/workspace-context-utils';
 import MetadataList from '../../PipelineRunDetailsView/MetadataList';
 import { IntegrationTestLabels } from '../IntegrationTestForm/types';
+import { getLabelForParam, getURLForParam } from '../IntegrationTestForm/utils/create-utils';
 
 interface IntegrationTestOverviewTabProps {
   integrationTest: IntegrationTestScenarioKind;
 }
+
 const IntegrationTestOverviewTab: React.FC<IntegrationTestOverviewTabProps> = ({
   integrationTest,
 }) => {
   const { workspace } = useWorkspaceInfo();
   const optionalReleaseLabel =
     integrationTest.metadata.labels?.[IntegrationTestLabels.OPTIONAL] === 'true';
-  const quayImageLink = /(http(s?)):\/\//i.test(integrationTest.spec.bundle)
-    ? integrationTest.spec.bundle
-    : `https://${integrationTest.spec.bundle}`;
 
   return (
     <>
@@ -85,18 +84,34 @@ const IntegrationTestOverviewTab: React.FC<IntegrationTestOverviewTabProps> = ({
                 default: '1Col',
               }}
             >
-              <DescriptionListGroup>
-                <DescriptionListTerm>Image bundle</DescriptionListTerm>
-                <DescriptionListDescription>
-                  <ExternalLink href={quayImageLink}>{integrationTest.spec.bundle}</ExternalLink>
-                </DescriptionListDescription>
-              </DescriptionListGroup>
-              <DescriptionListGroup>
-                <DescriptionListTerm>Pipeline to run</DescriptionListTerm>
-                <DescriptionListDescription>
-                  {integrationTest.spec.pipeline}
-                </DescriptionListDescription>
-              </DescriptionListGroup>
+              {integrationTest.spec.resolverRef && (
+                <>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Type</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {integrationTest.spec.resolverRef.resolver}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  {integrationTest.spec.resolverRef.params.map((param) => {
+                    const paramLink = getURLForParam(
+                      integrationTest.spec.resolverRef.params,
+                      param.name,
+                    );
+                    return (
+                      <DescriptionListGroup key={param.name}>
+                        <DescriptionListTerm>{getLabelForParam(param.name)}</DescriptionListTerm>
+                        <DescriptionListDescription>
+                          {paramLink ? (
+                            <ExternalLink href={paramLink}>{param.value}</ExternalLink>
+                          ) : (
+                            param.value
+                          )}
+                        </DescriptionListDescription>
+                      </DescriptionListGroup>
+                    );
+                  })}
+                </>
+              )}
               <DescriptionListGroup>
                 <DescriptionListTerm>Optional for release</DescriptionListTerm>
                 <DescriptionListDescription>

--- a/src/components/IntegrationTest/tabs/__tests__/IntegrationTestOverviewTab.spec.tsx
+++ b/src/components/IntegrationTest/tabs/__tests__/IntegrationTestOverviewTab.spec.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
-import { MockIntegrationTestsWithGit } from '../../IntegrationTestsListView/__data__/mock-integration-tests';
+import {
+  MockIntegrationTestsWithBundles,
+  MockIntegrationTestsWithGit,
+} from '../../IntegrationTestsListView/__data__/mock-integration-tests';
 import IntegrationTestOverviewTab from '../IntegrationTestOverviewTab';
 
 jest.mock('react-router-dom', () => ({
@@ -57,5 +60,13 @@ describe('IntegrationTestOverviewTab', () => {
   it('should append https to the git url if it is not present in the spec', () => {
     render(<IntegrationTestOverviewTab integrationTest={MockIntegrationTestsWithGit[1]} />);
     expect(screen.getAllByRole('link')[0].getAttribute('href')).toBe('https://test-url2');
+  });
+
+  it('should render correct param values for bundle resolvers', () => {
+    render(<IntegrationTestOverviewTab integrationTest={MockIntegrationTestsWithBundles[0]} />);
+    screen.getByText('test-app-test-1'); // name
+    screen.getByText('test-namespace'); // namespace
+    screen.getByText('Optional'); // optional for release
+    screen.getByText('Bundle');
   });
 });

--- a/src/components/IntegrationTest/tabs/__tests__/IntegrationTestOverviewTab.spec.tsx
+++ b/src/components/IntegrationTest/tabs/__tests__/IntegrationTestOverviewTab.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
-import { MockIntegrationTests } from '../../IntegrationTestsListView/__data__/mock-integration-tests';
+import { MockIntegrationTestsWithGit } from '../../IntegrationTestsListView/__data__/mock-integration-tests';
 import IntegrationTestOverviewTab from '../IntegrationTestOverviewTab';
 
 jest.mock('react-router-dom', () => ({
@@ -13,53 +13,49 @@ jest.mock('../../../../utils/workspace-context-utils', () => ({
 
 describe('IntegrationTestOverviewTab', () => {
   it('should render correct details', () => {
-    render(<IntegrationTestOverviewTab integrationTest={MockIntegrationTests[0]} />);
+    render(<IntegrationTestOverviewTab integrationTest={MockIntegrationTestsWithGit[0]} />);
     screen.getByText('test-app-test-1'); // name
     screen.getByText('test-namespace'); // namespace
-    screen.getByText('pipeline-1'); // pipeline-to-run
+    screen.getByText('main'); // revision
     screen.getByText('Optional'); // optional for release
-    expect(screen.getAllByRole('link')[0].getAttribute('href')).toBe(
-      'https://quay.io/test-rep/test-bundle:test-1',
-    ); // image bundle
-    expect(screen.getAllByRole('link')[1].getAttribute('href')).toBe(
-      '/application-pipeline/workspaces/test-ws/applications/test-app',
-    ); // application link
+    expect(screen.getAllByRole('link')[0].getAttribute('href')).toBe('https://test-url'); // git url
   });
 
-  it('should render correct details', () => {
-    render(<IntegrationTestOverviewTab integrationTest={MockIntegrationTests[1]} />);
+  it('should render correct param fields', () => {
+    render(<IntegrationTestOverviewTab integrationTest={MockIntegrationTestsWithGit[0]} />);
+    screen.getByText('test-app-test-1'); // name
+    screen.getByText('test-namespace'); // namespace
+    screen.getByText('GitHub URL'); // url
+    screen.getByText('Path in repository'); // Path in Repo
+    screen.getByText('Revision'); // revision
+    screen.getByText('Optional'); // optional for release
+    expect(screen.getAllByRole('link')[0].getAttribute('href')).toBe('https://test-url'); // git url
+  });
+
+  it('should render correct param values', () => {
+    render(<IntegrationTestOverviewTab integrationTest={MockIntegrationTestsWithGit[1]} />);
     screen.getByText('test-app-test-2'); // name
     screen.getByText('test-namespace'); // namespace
-    screen.getByText('pipeline-2'); // pipeline-to-run
+    screen.getByText('test-url2'); // url
+    screen.getByText('main2'); // revision
+    screen.getByText('test-path2'); // path
     screen.getByText('Mandatory'); // optional for release
-    expect(screen.getAllByRole('link')[0].getAttribute('href')).toBe(
-      'https://quay.io/test-rep/test-bundle:test-2',
-    ); // image bundle
+    expect(screen.getAllByRole('link')[0].getAttribute('href')).toBe('https://test-url2'); // git url
     expect(screen.getAllByRole('link')[1].getAttribute('href')).toBe(
-      '/application-pipeline/workspaces/test-ws/applications/test-app',
-    ); // application link
+      'https://test-url2/tree/main2',
+    ); // revision
+    expect(screen.getAllByRole('link')[2].getAttribute('href')).toBe(
+      'https://test-url2/tree/main2/test-path2',
+    ); // path link
   });
 
-  it('should use the image url from the spec', () => {
-    render(
-      <IntegrationTestOverviewTab
-        integrationTest={{
-          ...MockIntegrationTests[1],
-          spec: {
-            ...MockIntegrationTests[1].spec,
-            bundle: `http://quay.io/test-rep/test-bundle:test-2`,
-          },
-        }}
-      />,
-    );
-    expect(screen.getAllByRole('link')[0].getAttribute('href')).toBe(
-      'http://quay.io/test-rep/test-bundle:test-2',
-    );
+  it('should use the git url from the spec param', () => {
+    render(<IntegrationTestOverviewTab integrationTest={MockIntegrationTestsWithGit[0]} />);
+    expect(screen.getAllByRole('link')[0].getAttribute('href')).toBe('https://test-url');
   });
-  it('should append https to the bundle url if it is not present in the spec', () => {
-    render(<IntegrationTestOverviewTab integrationTest={MockIntegrationTests[1]} />);
-    expect(screen.getAllByRole('link')[0].getAttribute('href')).toBe(
-      'https://quay.io/test-rep/test-bundle:test-2',
-    );
+
+  it('should append https to the git url if it is not present in the spec', () => {
+    render(<IntegrationTestOverviewTab integrationTest={MockIntegrationTestsWithGit[1]} />);
+    expect(screen.getAllByRole('link')[0].getAttribute('href')).toBe('https://test-url2');
   });
 });

--- a/src/models/integration-test-scenario.ts
+++ b/src/models/integration-test-scenario.ts
@@ -3,7 +3,7 @@ import { K8sGroupVersionKind } from '../dynamic-plugin-sdk';
 
 export const IntegrationTestScenarioModel: K8sModelCommon = {
   apiGroup: 'appstudio.redhat.com',
-  apiVersion: 'v1alpha1',
+  apiVersion: 'v1beta1',
   kind: 'IntegrationTestScenario',
   plural: 'integrationtestscenarios',
   namespaced: true,

--- a/src/types/coreBuildService.ts
+++ b/src/types/coreBuildService.ts
@@ -1,6 +1,10 @@
 import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 import { Condition } from './pipeline-run';
 
+export enum ResolverType {
+  GIT = 'git',
+  BUNDLES = 'bundles',
+}
 export type IntegrationTestScenarioKind = K8sResourceCommon & {
   spec: IntegrationTestScenarioSpec;
 };
@@ -16,7 +20,7 @@ export type IntegrationTestScenarioSpec = {
   environment?: Environment;
   params?: Param[];
   resolverRef?: {
-    resolver: string;
+    resolver: ResolverType;
     params: ResolverParam[];
   };
   pipeline?: string;

--- a/src/types/coreBuildService.ts
+++ b/src/types/coreBuildService.ts
@@ -5,13 +5,22 @@ export type IntegrationTestScenarioKind = K8sResourceCommon & {
   spec: IntegrationTestScenarioSpec;
 };
 
+export type ResolverParam = {
+  name: string;
+  value: string;
+};
+
 export type IntegrationTestScenarioSpec = {
   application: string;
-  bundle: string;
-  pipeline: string;
   contexts?: Context[];
   environment?: Environment;
   params?: Param[];
+  resolverRef?: {
+    resolver: string;
+    params: ResolverParam[];
+  };
+  pipeline?: string;
+  bundle?: string;
 };
 
 export type Context = {


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

This PR is built on top of Abhi's Git resolver support PR - https://github.com/openshift/hac-dev/pull/574


This PR specifically handles

1. UI breaking issue if bundle resolver is added via CLI (also webhook will convert all the existing ITS to new bundle format)
2. Disable edit action for the new bundle resolver as the UI supports only GIT resolvers in the add/edit form at the moment.

