### PR TITLE
Fix container img url

### DIFF
--- a/src/components/IntegrationTest/IntegrationTestsListView/IntegrationTestListRow.tsx
+++ b/src/components/IntegrationTest/IntegrationTestsListView/IntegrationTestListRow.tsx
@@ -14,7 +14,10 @@ const IntegrationTestListRow: React.FC<RowFunctionArgs<IntegrationTestScenarioKi
 }) => {
   const actions = useIntegrationTestActions(obj);
   const { workspace } = useWorkspaceInfo();
-  const containerImageUrl = `https://${obj.spec.bundle}`;
+  const containerImageUrl = /(http(s?)):\/\//i.test(obj.spec.bundle)
+    ? obj.spec.bundle
+    : `https://${obj.spec.bundle}`;
+
   return (
     <>
       <TableData

--- a/src/components/IntegrationTest/IntegrationTestsListView/__data__/mock-integration-tests.ts
+++ b/src/components/IntegrationTest/IntegrationTestsListView/__data__/mock-integration-tests.ts
@@ -40,7 +40,7 @@ export const MockIntegrationTests = [
     },
     spec: {
       application: 'test-app',
-      bundle: 'quay.io/test-rep/test-bundle:test-2',
+      bundle: 'https://quay.io/test-rep/test-bundle:test-2',
       contexts: [
         {
           description: 'Application testing 2',

--- a/src/components/IntegrationTest/IntegrationTestsListView/__tests__/IntegrationTestsListRow.spec.tsx
+++ b/src/components/IntegrationTest/IntegrationTestsListView/__tests__/IntegrationTestsListRow.spec.tsx
@@ -12,7 +12,7 @@ jest.mock('../../../../utils/rbac', () => ({
 }));
 
 describe('IntegrationTestListRow', () => {
-  it('should render integration test info', () => {
+  it('should render integration test info with https appended url', () => {
     const integrationTest = MockIntegrationTests[0];
     const wrapper = render(<IntegrationTestListRow obj={integrationTest} columns={[]} />, {
       container: document.createElement('tr'),
@@ -20,7 +20,7 @@ describe('IntegrationTestListRow', () => {
     const cells = wrapper.container.getElementsByTagName('td');
 
     expect(cells[0].innerHTML).toBe(integrationTest.metadata.name);
-    expect(cells[1].innerHTML.includes(integrationTest.spec.bundle)).toBeTruthy();
+    expect(cells[1].children[0].innerHTML).toBe(`https://${integrationTest.spec.bundle}`);
     expect(cells[3].innerHTML).toBe(integrationTest.spec.pipeline);
   });
 
@@ -40,5 +40,14 @@ describe('IntegrationTestListRow', () => {
     });
     const cells = wrapper.container.getElementsByTagName('td');
     expect(cells[2].innerHTML).toBe('Mandatory');
+  });
+
+  it('should append https to bundle url only where required', () => {
+    const integrationTest = MockIntegrationTests[1];
+    const wrapper = render(<IntegrationTestListRow obj={integrationTest} columns={[]} />, {
+      container: document.createElement('tr'),
+    });
+    const cells = wrapper.container.getElementsByTagName('td');
+    expect(cells[1].children[0].innerHTML).toBe(`${integrationTest.spec.bundle}`);
   });
 });


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/RHTAPBUGS-141

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
fix https:// append

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

<img width="856" alt="Screenshot 2023-06-12 at 5 12 11 PM" src="https://github.com/openshift/hac-dev/assets/24852534/9a834232-d60e-4942-88b1-aef73266ddc0">
<img width="1483" alt="Screenshot 2023-06-12 at 5 14 16 PM" src="https://github.com/openshift/hac-dev/assets/24852534/38a16824-99eb-4fb4-92cd-d360cde5b2e8">

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
