### PR TITLE
Use selected runtime field value to show/hide dockerfile field

### DIFF
--- a/src/components/ImportForm/ReviewSection/ReviewComponentCard.tsx
+++ b/src/components/ImportForm/ReviewSection/ReviewComponentCard.tsx
@@ -54,8 +54,8 @@ export const ReviewComponentCard: React.FC<ReviewComponentCardProps> = ({
   const fieldPrefix = `components[${detectedComponentIndex}].componentStub`;
   const [expandedComponent, setExpandedComponent] = React.useState(isExpanded);
   const [targetPortTouched, setTargetPortTouched] = React.useState(false);
-  const [, { value: language }] = useField<string>(
-    `components[${detectedComponentIndex}].language`,
+  const [, { value: selectedRuntime }] = useField<string>(
+    `components[${detectedComponentIndex}].selectedRuntime`,
   );
 
   return (
@@ -138,7 +138,7 @@ export const ReviewComponentCard: React.FC<ReviewComponentCardProps> = ({
                   }
                 />
               </GridItem>
-              {language === 'Dockerfile' && (
+              {selectedRuntime === 'Dockerfile' && (
                 <GridItem sm={12} lg={4}>
                   <InputField
                     name={`${fieldPrefix}.source.git.dockerfileUrl`}

--- a/src/components/ImportForm/ReviewSection/RuntimeSelector.tsx
+++ b/src/components/ImportForm/ReviewSection/RuntimeSelector.tsx
@@ -74,8 +74,9 @@ export const RuntimeSelector: React.FC<RuntimeSelectorProps> = ({ detectedCompon
     const runtime = samples.find((s) => value.includes(s.name));
 
     if (
+      runtime &&
       (runtime?.attributes?.git as any)?.remotes?.origin ===
-      selectedRuntime?.attributes?.git?.remotes?.origin
+        selectedRuntime?.attributes?.git?.remotes?.origin
     ) {
       return;
     }
@@ -83,6 +84,7 @@ export const RuntimeSelector: React.FC<RuntimeSelectorProps> = ({ detectedCompon
       ? sourceUrl
       : (runtime?.attributes?.git as any)?.remotes?.origin;
     setSelectedRuntime(value === dockerFileSample.value ? dockerFileSample : runtime);
+    setFieldValue(`${fieldPrefix}.selectedRuntime`, value);
     setRuntimeSource(runtimeSourceUrl);
     setDetecting(true);
     setFieldValue('isDetected', false);
@@ -164,8 +166,10 @@ export const RuntimeSelector: React.FC<RuntimeSelectorProps> = ({ detectedCompon
         ) || dockerFileSample;
       setSelectedRuntime(runtime);
       setRecommendedRuntime(runtime);
+      setFieldValue(`${fieldPrefix}.selectedRuntime`, runtime.name);
     } else if (!selectedRuntime && !detectionFailed) {
       setSelectedRuntime({ name: DetectingRuntime });
+      setFieldValue(`${fieldPrefix}.selectedRuntime`, null);
     }
   }, [
     components,
@@ -175,6 +179,8 @@ export const RuntimeSelector: React.FC<RuntimeSelectorProps> = ({ detectedCompon
     samplesLoaded,
     selectedRuntime,
     detectionFailed,
+    setFieldValue,
+    fieldPrefix,
   ]);
 
   React.useEffect(() => {

--- a/src/components/ImportForm/ReviewSection/__tests__/ReviewComponentCard.spec.tsx
+++ b/src/components/ImportForm/ReviewSection/__tests__/ReviewComponentCard.spec.tsx
@@ -165,7 +165,7 @@ describe('ReviewComponentCard', () => {
         detectedComponentIndex={0}
         showRuntimeSelector
       />,
-      { isDetected: true, source: { git: {} } },
+      { isDetected: true, source: { git: {} }, components: [] },
     );
     screen.getByLabelText('Component name');
   });
@@ -180,7 +180,7 @@ describe('ReviewComponentCard', () => {
         showRuntimeSelector
         editMode
       />,
-      { isDetected: true, source: { git: {} } },
+      { isDetected: true, source: { git: {} }, components: [] },
     );
     expect(screen.getByLabelText('Component name')).toBeDisabled();
   });
@@ -194,7 +194,7 @@ describe('ReviewComponentCard', () => {
         showRuntimeSelector
         isExpanded
       />,
-      { isDetected: true, source: { git: {} } },
+      { isDetected: true, source: { git: {} }, components: [] },
     );
 
     expect(screen.getByText('Build & deploy configuration')).toBeInTheDocument();
@@ -221,7 +221,7 @@ describe('ReviewComponentCard', () => {
         detectedComponentIndex={0}
         showRuntimeSelector
       />,
-      { isDetected: true, source: { git: {} } },
+      { isDetected: true, source: { git: {} }, components: [] },
     );
     await act(async () => screen.getByTestId(`${componentName}-toggle-button`).click());
 
@@ -237,7 +237,7 @@ describe('ReviewComponentCard', () => {
         detectedComponentIndex={0}
         showRuntimeSelector
       />,
-      { isDetected: true, source: { git: {} } },
+      { isDetected: true, source: { git: {} }, components: [] },
     );
     await act(async () => screen.getByTestId(`${componentName}-toggle-button`).click());
 

--- a/src/components/ImportForm/ReviewSection/__tests__/RuntimeSelector.spec.tsx
+++ b/src/components/ImportForm/ReviewSection/__tests__/RuntimeSelector.spec.tsx
@@ -74,6 +74,7 @@ describe('RuntimeSelector', () => {
       source: { git: {} },
     });
 
+    expect(setFieldValueMock).toHaveBeenCalledWith('components[0].selectedRuntime', 'Dockerfile');
     await act(() => expect(screen.getByText('Dockerfile')).toBeVisible());
   });
 
@@ -116,6 +117,7 @@ describe('RuntimeSelector', () => {
       source: { git: {} },
     });
 
+    expect(setFieldValueMock).toHaveBeenCalledWith('components[0].selectedRuntime', 'Basic Nodejs');
     expect(screen.getByText('Basic Nodejs')).toBeVisible();
   });
 

--- a/src/components/ImportForm/utils/types.ts
+++ b/src/components/ImportForm/utils/types.ts
@@ -33,6 +33,7 @@ export type DetectedFormComponent = {
   devfileFound?: boolean;
   defaultBuildPipeline?: boolean;
   targetPortDetected?: boolean;
+  selectedRuntime?: string;
 };
 export type ImportSecret = {
   secretName: string;


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/RHTAPBUGS-401
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
Use the selected runtime value instead of the detected runtime value to show/hide the dockerfile field.

This shows the dockerfile field even if the cdq doesn't return the detected project type as `Dockerfile`.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
(No design changes)
![0](https://github.com/openshift/hac-dev/assets/20013884/50de5444-87d6-468c-bdbd-c4444816265c)
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
Use a repo for which cdq doesn't return Dockerfile as the language/project type. Eg. https://github.com/openshift-cnv/cnv-fbc
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
