### PR TITLE
Always include git revision in repository url

### DIFF
--- a/src/components/GitLink/GitRepoLink.tsx
+++ b/src/components/GitLink/GitRepoLink.tsx
@@ -21,18 +21,16 @@ const GitRepoLink: React.FC<Props> = ({ url, revision, context }) => {
     path,
   )}`;
 
-  // omit the main and master branch to reduce visual clutter
-  const rev = revision === 'main' || revision === 'master' ? '' : revision;
-
   return (
     <Tooltip content={fullUrl} position={TooltipPosition.bottom}>
       <ExternalLink href={fullUrl} icon={icon}>
         {parsed.owner}/{parsed.name}
-        {rev ? (
+        {revision ? (
           <>
             {' '}
             (<CodeBranchIcon />
-            {rev} {path ? ` / ${path}` : ''})
+            {revision}
+            {path ? ` / ${path}` : ''})
           </>
         ) : path ? (
           ` (${path})`

--- a/src/components/GitLink/__tests__/GitRepoLink.spec.tsx
+++ b/src/components/GitLink/__tests__/GitRepoLink.spec.tsx
@@ -14,4 +14,14 @@ describe('GitRepoLink', () => {
     const result = render(<GitRepoLink url="https://bitbucket.org/myorg/myproject" />);
     expect(result.baseElement.querySelector('svg').getAttribute('alt')).toBe('Bitbucket');
   });
+
+  it('should render revision if available', () => {
+    const result = render(<GitRepoLink url="https://github.com/myorg/myproject" revision="main" />);
+    expect(result.baseElement).toHaveTextContent('(main)');
+  });
+
+  it('should render context dir if available', () => {
+    const result = render(<GitRepoLink url="https://github.com/myorg/myproject" context="./src" />);
+    expect(result.baseElement).toHaveTextContent('(src)');
+  });
 });


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/RHTAPBUGS-238
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
Always display the revision in git repository URLs.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
![0](https://github.com/openshift/hac-dev/assets/20013884/f53ec5a2-4f42-4051-bcc9-d75fbfaee784)
![1](https://github.com/openshift/hac-dev/assets/20013884/e62d3d98-88a3-4709-bc03-bf46ecb66bec)
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
