### PR TITLE
Allow users to show running pipeline from components views

### DIFF
--- a/src/components/ApplicationDetails/DetailsPage.scss
+++ b/src/components/ApplicationDetails/DetailsPage.scss
@@ -6,6 +6,7 @@
     flex-direction: column;
 
     &__tabItem {
+      position: relative;
       &.isFilled.pf-c-tab-content {
         flex: 1;
       }

--- a/src/components/Components/BuildStatusColumn.tsx
+++ b/src/components/Components/BuildStatusColumn.tsx
@@ -33,7 +33,7 @@ const BuildStatusColumn: React.FC<BuildStatusComponentProps> = ({ component }) =
             data-testid={`view-build-logs-${component.metadata.name}`}
             isInline
           >
-            View build logs
+            View details
           </Button>
         </FlexItem>
       )}

--- a/src/components/Components/__tests__/BuildStatusColumn.spec.tsx
+++ b/src/components/Components/__tests__/BuildStatusColumn.spec.tsx
@@ -25,7 +25,7 @@ jest.mock('../../../utils/component-utils', () => {
 const useK8sWatchResourceMock = useK8sWatchResource as jest.Mock;
 
 describe('BuildStatusColumn', () => {
-  it('should render View Build logs action item', async () => {
+  it('should render View details action item', async () => {
     useK8sWatchResourceMock.mockReturnValue([mockPipelineRuns, true]);
     render(
       <BrowserRouter>
@@ -33,7 +33,7 @@ describe('BuildStatusColumn', () => {
       </BrowserRouter>,
     );
     await waitFor(() => screen.getByText('Build Succeeded'));
-    await waitFor(() => screen.getByText('View build logs'));
+    await waitFor(() => screen.getByText('View details'));
   });
   it('should render failures', async () => {
     useK8sWatchResourceMock.mockReturnValue([[mockPipelineRuns[2]], true]);
@@ -43,7 +43,7 @@ describe('BuildStatusColumn', () => {
       </BrowserRouter>,
     );
     await waitFor(() => screen.getByText('Build Failed'));
-    await waitFor(() => screen.getByText('View build logs'));
+    await waitFor(() => screen.getByText('View details'));
   });
 
   it('should not render merge status if the pipelineruns is still loading', async () => {
@@ -56,23 +56,23 @@ describe('BuildStatusColumn', () => {
     expect(screen.queryByText('Merge build PR')).not.toBeInTheDocument();
   });
 
-  it('should not render View Build logs action item for components without build pipelinerun', async () => {
+  it('should not render View details action item for components without build pipelinerun', async () => {
     useK8sWatchResourceMock.mockReturnValue([[], true]);
     render(
       <BrowserRouter>
         <BuildStatusColumn component={componentCRMocks[0]} />
       </BrowserRouter>,
     );
-    expect(screen.queryByText('View build logs')).not.toBeInTheDocument();
+    expect(screen.queryByText('View details')).not.toBeInTheDocument();
   });
 
-  it('should render View Build logs action item for components without PAC annotation', async () => {
+  it('should render View details action item for components without PAC annotation', async () => {
     useK8sWatchResourceMock.mockReturnValue([[mockPipelineRuns], true]);
     render(
       <BrowserRouter>
         <BuildStatusColumn component={componentCRMocks[0]} />
       </BrowserRouter>,
     );
-    await waitFor(() => screen.getByText('View build logs'));
+    await waitFor(() => screen.getByText('View details'));
   });
 });

--- a/src/components/Components/__tests__/ComponentListItem.spec.tsx
+++ b/src/components/Components/__tests__/ComponentListItem.spec.tsx
@@ -58,17 +58,17 @@ describe('ComponentListItem', () => {
     screen.getAllByText('Route');
   });
 
-  it('should render View Build logs action item', async () => {
+  it('should render View details action item', async () => {
     render(
       <BrowserRouter>
         <ComponentListItem component={componentCRMocks[0]} routes={[]} />
       </BrowserRouter>,
     );
     await waitFor(() => screen.getByText('Build Succeeded'));
-    await waitFor(() => screen.getByText('View build logs'));
+    await waitFor(() => screen.getByText('View details'));
   });
 
-  it('should render View Build logs action item', async () => {
+  it('should render View details action item', async () => {
     mockLatestPipelineRunForComponent.mockReturnValue([mockPipelineRuns[1], true]);
     render(
       <BrowserRouter>
@@ -76,7 +76,7 @@ describe('ComponentListItem', () => {
       </BrowserRouter>,
     );
     await waitFor(() => screen.getByText('Build Failed'));
-    await waitFor(() => screen.getByText('View build logs'));
+    await waitFor(() => screen.getByText('View details'));
   });
 
   it('should render Delete action item', async () => {

--- a/src/components/LogViewer/BuildLogViewer.scss
+++ b/src/components/LogViewer/BuildLogViewer.scss
@@ -2,7 +2,21 @@
   height: 70%;
   display: flex;
   flex-direction: column;
+  .pf-c-modal-box__body {
+    overflow-y: hidden;
+    display: flex;
+    flex-direction: column;
+    gap: var(--pf-global--spacer--lg);
+    margin-right: 0;
+  }
+  &__title {
+    margin-right: var(--pf-global--spacer--xl);
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--pf-global--spacer--sm);
+  }
   &__body {
-    height: 100%;
+    flex: 1;
+    position: relative;
   }
 }

--- a/src/components/PipelineRunDetailsView/tabs/PipelineRunLogsTab.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/PipelineRunLogsTab.tsx
@@ -8,7 +8,7 @@ type PipelineRunLogsTabProps = {
 };
 
 const PipelineRunLogsTab: React.FC<PipelineRunLogsTabProps> = ({ pipelineRun, taskRuns }) => (
-  <PipelineRunLogs obj={pipelineRun} taskRuns={taskRuns} />
+  <PipelineRunLogs className="pf-u-pt-md" obj={pipelineRun} taskRuns={taskRuns} />
 );
 
 export default PipelineRunLogsTab;

--- a/src/shared/components/pipeline-run-logs/PipelineRunLogs.scss
+++ b/src/shared/components/pipeline-run-logs/PipelineRunLogs.scss
@@ -2,8 +2,9 @@
   display: flex;
   flex: 1;
   width: 100%;
-  height: 100%;
-  padding: var(--pf-global--spacer--xl) 0;
+  position: absolute;
+  top: 0;
+  bottom: 0;
   &__nav {
     list-style-type: none;
   }
@@ -42,9 +43,8 @@
   }
   &__container {
     flex: 1;
-    padding-right: var(--pf-global--spacer--xl);
   }
   &__container .pane-body {
-    padding: 0px;
+    padding: 0;
   }
 }

--- a/src/shared/components/pipeline-run-logs/PipelineRunLogs.tsx
+++ b/src/shared/components/pipeline-run-logs/PipelineRunLogs.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Nav, NavItem, NavList } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
 import get from 'lodash/get';
 import { ColoredStatusIcon } from '../../../components/topology/StatusIcon';
 import { WatchK8sResource } from '../../../dynamic-plugin-sdk';
@@ -13,6 +14,7 @@ import { getPLRLogSnippet } from './logs/pipelineRunLogSnippet';
 import './PipelineRunLogs.scss';
 
 interface PipelineRunLogsProps {
+  className?: string;
   obj: PipelineRunKind;
   taskRuns: TaskRunKind[];
   activeTask?: string;
@@ -88,7 +90,7 @@ class PipelineRunLogs extends React.Component<PipelineRunLogsProps, PipelineRunL
   };
 
   render() {
-    const { obj, taskRuns: tRuns } = this.props;
+    const { className, obj, taskRuns: tRuns } = this.props;
     const { activeItem } = this.state;
 
     const taskRunFromYaml = tRuns?.reduce((acc, value) => {
@@ -135,7 +137,7 @@ class PipelineRunLogs extends React.Component<PipelineRunLogsProps, PipelineRunL
     };
 
     return (
-      <div className="pipeline-run-logs">
+      <div className={css('pipeline-run-logs', className)}>
         <div className="pipeline-run-logs__tasklist" data-testid="logs-tasklist">
           {taskCount > 0 ? (
             <Nav onSelect={this.onNavSelect} theme="light">

--- a/src/shared/components/pipeline-run-logs/__tests__/MultiStreamLogs.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/__tests__/MultiStreamLogs.spec.tsx
@@ -103,6 +103,21 @@ describe('MultiStreamLogs', () => {
     });
   });
 
+  it('should disable download when an error is present', () => {
+    render(
+      <MultiStreamLogs
+        resourceName={samplePod.metadata.name}
+        resource={samplePod}
+        errorMessage="test error"
+        taskName={'step-init'}
+        downloadAllLabel={'Download all task logs'}
+        onDownloadAll={downloadAllCallback}
+      />,
+    );
+    const downloadButton = screen.getByText('Download');
+    expect(downloadButton).toBeDisabled();
+  });
+
   it('should render resume log stream button when user scrolls up and removed when users scrolls to the bottom of the logs', async () => {
     mockUseScrollDirection.mockReturnValue([ScrollDirection.scrollingUp, () => {}]);
     const { getByTestId, rerender } = render(

--- a/src/shared/components/pipeline-run-logs/logs/MultiStreamLogs.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/MultiStreamLogs.tsx
@@ -99,7 +99,7 @@ export const MultiStreamLogs: React.FC<MultiStreamLogsProps> = ({
         })}
       >
         <FlexItem className="multi-stream-logs__button" align={{ default: 'alignRight' }}>
-          <Button variant="link" onClick={downloadLogs} isInline>
+          <Button variant="link" onClick={downloadLogs} isDisabled={!!errorMessage} isInline>
             <DownloadIcon className="multi-stream-logs__icon" />
             {t('Download')}
           </Button>


### PR DESCRIPTION
## Fixes 
Fixes [RHTAPBUGS-98](https://issues.redhat.com/browse/RHTAPBUGS-98)

## Description
Update component list item link from `View build logs` to `View details`.
Update the BuildLogViewer to include a link to the build pipeline run.
Some minor layout fixes in the BuildLogViewer modal.
Make log viewer tasks list scroll rather than the window in the pipeline run logs tab.

## Type of change
- [x] Bugfix

## Screen shots / Gifs for design review 

![image](https://github.com/openshift/hac-dev/assets/11633780/07bb2ef1-8c2c-409a-a572-259957149c04)


![image](https://github.com/openshift/hac-dev/assets/11633780/a4571d58-3cb0-4c2f-815e-a97f0ce9dd88)
