### PR TITLE
Add e2e test for default integration test

### DIFF
--- a/integration-tests/support/pages/tabs/IntegrationTestsTabPage.ts
+++ b/integration-tests/support/pages/tabs/IntegrationTestsTabPage.ts
@@ -16,6 +16,10 @@ export class IntegrationTestsTabPage {
     cy.get(integrationTestsTabPO.filterInputField).clear().type(inputString);
   }
 
+  hasIntegrationTest(integrationTestName: string) {
+    UIhelper.verifyRowInTable('Integration tests', integrationTestName, [integrationTestName]);
+  }
+
   openAndClickKebabMenu(integrationTestName: string, option: string) {
     cy.get(`[data-id="${integrationTestName}"]`).find(actions.kebabButton).click();
     cy.contains('li', option).click();

--- a/integration-tests/tests/basic-happy-path.spec.ts
+++ b/integration-tests/tests/basic-happy-path.spec.ts
@@ -10,10 +10,12 @@ import { Common } from '../utils/Common';
 import { UIhelper } from '../utils/UIhelper';
 import { APIHelper } from '../utils/APIHelper';
 import { FULL_APPLICATION_TITLE } from '../support/constants/PageTitle';
+import { IntegrationTestsTabPage } from '../support/pages/tabs/IntegrationTestsTabPage';
 
 describe('Basic Happy Path', () => {
   const applicationName = Common.generateAppName();
   const applicationDetailPage = new ApplicationDetailPage();
+  const integrationTestsTab = new IntegrationTestsTabPage();
   const publicRepo = 'https://github.com/hac-test/devfile-sample-code-with-quarkus';
   const componentName: string = Common.generateAppName('java-quarkus');
   const piplinerunlogsTasks = ['init', 'clone-repository', 'build-container', 'show-summary'];
@@ -41,6 +43,11 @@ describe('Basic Happy Path', () => {
       'Build Running',
       'Default',
     );
+  });
+
+  it('Check default Integration Test', () => {
+    Applications.goToIntegrationTestsTab();
+    integrationTestsTab.hasIntegrationTest(`${applicationName}-enterprise-contract`);
   });
 
   describe('Check different ways to add a component', () => {

--- a/integration-tests/utils/Applications.ts
+++ b/integration-tests/utils/Applications.ts
@@ -142,6 +142,7 @@ export class Applications {
 
   static goToIntegrationTestsTab() {
     cy.get(integrationTestsTabPO.clickTab).click();
+    Common.waitForLoad();
   }
 
   static importCodeStep(publicGitRepo: string) {


### PR DESCRIPTION
## Description
Add a test to ensure the default integration test is created automatically when a new Application is created.

https://issues.redhat.com/browse/HACBS-2193

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): e2e tests

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
