### PR TITLE
show add integration button in the list view

### DIFF
--- a/src/components/IntegrationTest/IntegrationTestsListView/IntegrationTestsListView.tsx
+++ b/src/components/IntegrationTest/IntegrationTestsListView/IntegrationTestsListView.tsx
@@ -37,12 +37,10 @@ type IntegrationTestsListViewProps = {
   applicationName: string;
 };
 
-const IntegrationTestsEmptyState: React.FC<{ handleAddTest: () => void }> = ({ handleAddTest }) => {
-  const [canCreateIntegrationTest] = useAccessReviewForModel(
-    IntegrationTestScenarioModel,
-    'create',
-  );
-
+const IntegrationTestsEmptyState: React.FC<{
+  handleAddTest: () => void;
+  canCreateIntegrationTest: boolean;
+}> = ({ handleAddTest, canCreateIntegrationTest }) => {
   return (
     <AppEmptyState
       data-test="integration-tests__empty"
@@ -73,6 +71,10 @@ const IntegrationTestsEmptyState: React.FC<{ handleAddTest: () => void }> = ({ h
 
 const IntegrationTestsListView: React.FC<IntegrationTestsListViewProps> = ({ applicationName }) => {
   const { namespace, workspace } = useWorkspaceInfo();
+  const [canCreateIntegrationTest] = useAccessReviewForModel(
+    IntegrationTestScenarioModel,
+    'create',
+  );
 
   const navigate = useNavigate();
   const [integrationTests, integrationTestsLoaded] = useIntegrationTestScenarios(
@@ -116,7 +118,12 @@ const IntegrationTestsListView: React.FC<IntegrationTestsListViewProps> = ({ app
   }
 
   if (!applicationIntegrationTests?.length) {
-    return <IntegrationTestsEmptyState handleAddTest={handleAddTest} />;
+    return (
+      <IntegrationTestsEmptyState
+        handleAddTest={handleAddTest}
+        canCreateIntegrationTest={canCreateIntegrationTest}
+      />
+    );
   }
   const onClearFilters = () => setNameFilter('');
   const onNameInput = (name: string) => setNameFilter(name);
@@ -150,6 +157,17 @@ const IntegrationTestsListView: React.FC<IntegrationTestsListViewProps> = ({ app
                     value={nameFilter}
                   />
                 </InputGroup>
+              </ToolbarItem>
+              <ToolbarItem>
+                <ButtonWithAccessTooltip
+                  variant={ButtonVariant.secondary}
+                  onClick={handleAddTest}
+                  isDisabled={!canCreateIntegrationTest}
+                  tooltip="You don't have access to add an integration test"
+                  data-test="add-integration-test"
+                >
+                  Add integration test
+                </ButtonWithAccessTooltip>
               </ToolbarItem>
             </ToolbarGroup>
           </ToolbarContent>

--- a/src/components/IntegrationTest/IntegrationTestsListView/__tests__/IntegrationTestsListView.spec.tsx
+++ b/src/components/IntegrationTest/IntegrationTestsListView/__tests__/IntegrationTestsListView.spec.tsx
@@ -72,6 +72,18 @@ describe('IntegrationTestsListView', () => {
     expect(wrapper.container.getElementsByTagName('table')).toHaveLength(1);
   });
 
+  it('should show button to add integration test and it should redirect to add integration page', async () => {
+    useK8sWatchResourceMock.mockReturnValue([MockIntegrationTests, true, undefined]);
+    const integrationListView = render(<IntegrationTestsListView applicationName="test-app" />);
+    fireEvent.click(integrationListView.getByTestId('add-integration-test'));
+
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith(
+        '/application-pipeline/workspaces/test-ws/applications/test-app/integrationtests/add',
+      ),
+    );
+  });
+
   it('should show the add integration test page on Add action', async () => {
     useK8sWatchResourceMock.mockReturnValue([[], true, undefined]);
     const wrapper = render(<IntegrationTestsListView applicationName="test-app" />);


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/RHTAPBUGS-211


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When you have no integration tests, the empty state directs the user to create one. Once you have at least one integration test, and no longer see the empty state, it gets trickier to figure out how to add additional integration tests. There's no add button near the table.

Users who explore may find it within the Actions menu, but it should be presented right on the main page.



## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


**Before:**

<img width="1491" alt="Screenshot 2023-06-27 at 12 15 19 PM" src="https://github.com/openshift/hac-dev/assets/9964343/e937ad45-09f5-4877-aa6c-1af571466d2f">


**After:**

<img width="1494" alt="Screenshot 2023-06-27 at 12 10 58 PM" src="https://github.com/openshift/hac-dev/assets/9964343/f21927ce-f3ae-44b8-97dc-63d96d361d7f">



## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
