### PR TITLE
Add support for Tekton result logs

### DIFF
--- a/src/components/PipelineRunDetailsView/sidepanels/TaskRunPanel.tsx
+++ b/src/components/PipelineRunDetailsView/sidepanels/TaskRunPanel.tsx
@@ -61,9 +61,8 @@ const TaskRunPanel: React.FC<Props> = ({ taskNode, onClose }) => {
           <Tab title="Logs" eventKey="logs">
             <DrawerPanelBody style={{ height: '100%' }}>
               <TaskRunLogs
-                taskName={task.name}
+                taskRun={taskRun}
                 namespace={taskNode.getData().namespace}
-                podName={taskRun?.status?.podName}
                 status={status}
               />
             </DrawerPanelBody>

--- a/src/components/TaskRunDetailsView/tabs/TaskRunLogsTab.tsx
+++ b/src/components/TaskRunDetailsView/tabs/TaskRunLogsTab.tsx
@@ -8,14 +8,10 @@ export type TaskRunLogProps = {
 };
 
 const TaskRunLogsTab: React.FC<TaskRunLogProps> = ({ taskRun }) => {
-  const podName = taskRun?.status?.podName;
-  const taskName = taskRun?.spec.taskRef?.name ?? taskRun?.metadata.name;
   const status = taskRunStatus(taskRun);
   const namespace = taskRun.metadata?.namespace;
 
-  return (
-    <TaskRunLogs podName={podName} taskName={taskName} status={status} namespace={namespace} />
-  );
+  return <TaskRunLogs taskRun={taskRun} status={status} namespace={namespace} />;
 };
 
 export default TaskRunLogsTab;

--- a/src/components/TaskRuns/TaskRunLogs.tsx
+++ b/src/components/TaskRuns/TaskRunLogs.tsx
@@ -1,16 +1,18 @@
 import React from 'react';
 import { PodGroupVersionKind } from '../../models/pod';
 import LogsWrapperComponent from '../../shared/components/pipeline-run-logs/logs/LogsWrapperComponent';
+import { TaskRunKind } from '../../types';
 import { runStatus } from '../../utils/pipeline-utils';
 
 type Props = {
-  podName: string;
-  taskName: string;
+  taskRun: TaskRunKind;
   namespace: string;
   status: runStatus;
 };
 
-const TaskRunLogs: React.FC<Props> = ({ taskName, podName, namespace, status }) => {
+const TaskRunLogs: React.FC<Props> = ({ taskRun, namespace, status }) => {
+  const podName = taskRun?.status?.podName;
+
   if (status === runStatus.Skipped) {
     return <div>No logs. This task was skipped.</div>;
   }
@@ -22,13 +24,13 @@ const TaskRunLogs: React.FC<Props> = ({ taskName, podName, namespace, status }) 
   }
   return (
     <LogsWrapperComponent
+      taskRun={taskRun}
       resource={{
         name: podName,
         groupVersionKind: PodGroupVersionKind,
         namespace,
         isList: false,
       }}
-      taskName={taskName}
     />
   );
 };

--- a/src/components/TaskRuns/__tests__/TaskRunLogs.spec.tsx
+++ b/src/components/TaskRuns/__tests__/TaskRunLogs.spec.tsx
@@ -7,21 +7,19 @@ import TaskRunLogs from '../TaskRunLogs';
 describe('TaskRunLogs', () => {
   it('should render no logs found', () => {
     const result = render(
-      <TaskRunLogs podName={null} namespace="test" taskName="task" status={runStatus.Running} />,
+      <TaskRunLogs taskRun={null} namespace="test" status={runStatus.Running} />,
     );
     expect(result.queryByText('No logs found.')).toBeInTheDocument();
   });
 
   it('should render waiting to start', () => {
-    const result = render(
-      <TaskRunLogs podName={null} namespace="test" taskName="task" status={runStatus.Idle} />,
-    );
+    const result = render(<TaskRunLogs taskRun={null} namespace="test" status={runStatus.Idle} />);
     expect(result.queryByText('Waiting on task to start.')).toBeInTheDocument();
   });
 
   it('should render no logs due to Skipped status', () => {
     const result = render(
-      <TaskRunLogs podName={null} namespace="test" taskName="task" status={runStatus.Skipped} />,
+      <TaskRunLogs taskRun={null} namespace="test" status={runStatus.Skipped} />,
     );
     expect(result.queryByText('No logs. This task was skipped.')).toBeInTheDocument();
   });

--- a/src/shared/components/pipeline-run-logs/__tests__/LogWrapperComponent.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/__tests__/LogWrapperComponent.spec.tsx
@@ -1,0 +1,340 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { commonFetchText, useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { screen, render, waitFor, configure, fireEvent, act } from '@testing-library/react';
+import { saveAs } from 'file-saver';
+import { debounce, throttle } from 'lodash-es';
+import { PodGroupVersionKind } from '../../../../models/pod';
+import { TaskRunKind } from '../../../../types';
+import { useFullscreen } from '../../../hooks/fullscreen';
+import { useScrollDirection } from '../../../hooks/scroll';
+import LogsWrapperComponent from '../logs/LogsWrapperComponent';
+
+jest.mock('../logs/Logs', () => (props) => {
+  React.useEffect(() => {
+    props.onComplete(props.container.name);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return <div>{`Logs - ${props.container.name}`}</div>;
+});
+
+jest.mock('../../../hooks/scroll', () => {
+  const actual = jest.requireActual('../../../hooks/scroll');
+
+  return {
+    ...actual,
+    useScrollDirection: jest.fn(),
+  };
+});
+
+jest.mock('../../../hooks/fullscreen', () => {
+  return {
+    useFullscreen: jest.fn(),
+  };
+});
+
+jest.mock('file-saver', () => {
+  const actual = jest.requireActual('lodash-es');
+  return {
+    ...actual,
+    saveAs: jest.fn(),
+  };
+});
+
+jest.mock('lodash-es', () => {
+  const actual = jest.requireActual('lodash-es');
+  return {
+    ...actual,
+    debounce: jest.fn(),
+    throttle: jest.fn(),
+  };
+});
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => {
+  const actual = jest.requireActual('@openshift/dynamic-plugin-sdk-utils');
+  return {
+    ...actual,
+    useK8sWatchResource: jest.fn(),
+    commonFetchText: jest.fn(),
+  };
+});
+
+const mockCommonFetchText = commonFetchText as jest.Mock;
+const watchResourceMock = useK8sWatchResource as jest.Mock;
+const useFullscreenMock = useFullscreen as jest.Mock;
+
+const mockDebounce = debounce as jest.Mock;
+const mockThrottle = throttle as jest.Mock;
+const mockUseScrollDirection = useScrollDirection as jest.Mock;
+const mockSaveAs = saveAs as jest.Mock;
+
+const downloadAllCallback = jest.fn();
+
+describe('LogWrapperComponent', () => {
+  const taskRun: TaskRunKind = {
+    apiVersion: 'v1alpha1',
+    kind: 'TaskRun',
+    metadata: {
+      labels: {
+        'tekton.dev/pipelineTask': 'do-something',
+      },
+      name: 'test-caseqfvdj-do-something',
+    },
+    spec: {
+      taskRef: {
+        name: 'first',
+      },
+    },
+    status: {
+      completionTime: '2022-11-28T12:09:26Z',
+      conditions: [
+        {
+          lastTransitionTime: '2022-11-28T12:09:26Z',
+          message: 'All Steps have completed executing',
+          reason: 'Succeeded',
+          status: 'True',
+          type: 'Succeeded',
+        },
+      ],
+      podName: 'test-caseqfvdj-do-something-pod',
+      startTime: '2022-11-28T12:09:18Z',
+      steps: [
+        {
+          container: 'step-do-something',
+          imageID:
+            'docker.io/library/alpine@sha256:8914eb54f968791faf6a8638949e480fef81e697984fba772b3976835194c6d4',
+          name: 'do-something',
+          terminated: {
+            containerID: 'cri-o://51ed1ddfa563e5149d0281ebc9c761967bf6bbb85c5454e0b34ae04066d8091c',
+            exitCode: 0,
+            finishedAt: '2022-11-28T12:09:26Z',
+            reason: 'Completed',
+            startedAt: '2022-11-28T12:09:26Z',
+          },
+        },
+      ],
+      taskSpec: {
+        params: [
+          {
+            name: 'arg',
+            type: 'string',
+          },
+        ],
+        steps: [
+          {
+            image: 'alpine',
+            name: 'do-something',
+            resources: {},
+            script: 'echo "prefix:suffix" | grep "prefix:suffix"\n',
+          },
+        ],
+      },
+    },
+  };
+
+  let fullScreen = false;
+
+  useFullscreenMock.mockImplementation(() => {
+    return [
+      fullScreen,
+      () => {},
+      () => {
+        fullScreen = !fullScreen;
+      },
+    ];
+  });
+
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(jest.fn());
+    fullScreen = false;
+
+    configure({ testIdAttribute: 'data-testid' });
+    mockCommonFetchText.mockReturnValue(Promise.resolve());
+    mockDebounce.mockImplementation((fn) => fn);
+    mockThrottle.mockImplementation((fn) => fn);
+    mockUseScrollDirection.mockReturnValue([null, () => {}]);
+    watchResourceMock.mockReturnValue([{ metadata: { name: 'test-pod' } }, true]);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render loading indicator', async () => {
+    watchResourceMock.mockReturnValueOnce([[], false]);
+    render(
+      <LogsWrapperComponent
+        resource={{
+          name: 'podName',
+          groupVersionKind: PodGroupVersionKind,
+          namespace: 'test-ns',
+          isList: false,
+        }}
+        taskRun={taskRun}
+        downloadAllLabel="Download all task logs"
+        onDownloadAll={downloadAllCallback}
+      />,
+    );
+
+    await waitFor(() => {
+      screen.getByTestId('loading-indicator');
+    });
+  });
+
+  it('should download data on download', async () => {
+    watchResourceMock.mockReturnValueOnce([[], true, 'error']);
+    const downloadAll = () =>
+      new Promise<Error>((resolve) => {
+        resolve(null);
+      });
+
+    render(
+      <LogsWrapperComponent
+        resource={{
+          name: 'podName',
+          groupVersionKind: PodGroupVersionKind,
+          namespace: 'test-ns',
+          isList: false,
+        }}
+        taskRun={taskRun}
+        downloadAllLabel="Download all task logs"
+        onDownloadAll={downloadAll}
+      />,
+    );
+
+    const downloadButton = screen.getByText('Download');
+    expect(downloadButton).toHaveClass('pf-c-button');
+
+    act(() => {
+      fireEvent.click(downloadButton);
+    });
+    await waitFor(() => {
+      expect(mockSaveAs).toHaveBeenCalled();
+    });
+  });
+  it('should render the logs control buttons and container', () => {
+    render(
+      <LogsWrapperComponent
+        resource={{
+          name: 'podName',
+          groupVersionKind: PodGroupVersionKind,
+          namespace: 'test-ns',
+          isList: false,
+        }}
+        taskRun={taskRun}
+        downloadAllLabel={'Download all task logs'}
+        onDownloadAll={downloadAllCallback}
+      />,
+    );
+
+    waitFor(() => {
+      screen.getByTestId('logs-task-container');
+      screen.getByText('Download');
+      screen.getByText('Download all task logs');
+      screen.getByText('Expand');
+    });
+  });
+  it('should render fullscreen', async () => {
+    fullScreen = true;
+    render(
+      <LogsWrapperComponent
+        resource={{
+          name: 'podName',
+          groupVersionKind: PodGroupVersionKind,
+          namespace: 'test-ns',
+          isList: false,
+        }}
+        taskRun={taskRun}
+        downloadAllLabel={'Download all task logs'}
+        onDownloadAll={downloadAllCallback}
+      />,
+    );
+
+    await waitFor(() => {
+      screen.getByText('Collapse');
+    });
+  });
+  it('should call onDownloadAll callback when download all button is pressed', async () => {
+    downloadAllCallback.mockImplementation(() => null);
+    const downloadAll = () =>
+      new Promise<Error>((resolve) => {
+        resolve(null);
+        downloadAllCallback();
+      });
+
+    render(
+      <LogsWrapperComponent
+        resource={{
+          name: 'podName',
+          groupVersionKind: PodGroupVersionKind,
+          namespace: 'test-ns',
+          isList: false,
+        }}
+        taskRun={taskRun}
+        downloadAllLabel="Download all task logs"
+        onDownloadAll={downloadAll}
+      />,
+    );
+
+    const downloadAllButton = screen.getByText('Download all task logs');
+    expect(downloadAllButton).toHaveClass('pf-c-button');
+
+    act(() => {
+      fireEvent.click(screen.getByText('Download all task logs'));
+    });
+    await waitFor(() => {
+      expect(downloadAllCallback).toHaveBeenCalled();
+    });
+  });
+  it('should show tekton logs when pod is not available', async () => {
+    watchResourceMock.mockReturnValue([[], true, 'error']);
+    const downloadAll = () =>
+      new Promise<Error>((resolve) => {
+        resolve(null);
+      });
+
+    render(
+      <LogsWrapperComponent
+        resource={{
+          name: 'podName',
+          groupVersionKind: PodGroupVersionKind,
+          namespace: 'test-ns',
+          isList: false,
+        }}
+        taskRun={taskRun}
+        downloadAllLabel="Download all task logs"
+        onDownloadAll={downloadAll}
+      />,
+    );
+    screen.getByTestId('tr-logs-container');
+  });
+
+  it('should handle if the download fails', async () => {
+    downloadAllCallback.mockImplementation(() => null);
+    const downloadAll = () =>
+      new Promise<Error>((resolve, reject) => {
+        reject(new Error('Download Failed'));
+        downloadAllCallback();
+      });
+    render(
+      <LogsWrapperComponent
+        resource={{
+          name: 'podName',
+          groupVersionKind: PodGroupVersionKind,
+          namespace: 'test-ns',
+          isList: false,
+        }}
+        taskRun={taskRun}
+        downloadAllLabel="Download all task logs"
+        onDownloadAll={downloadAll}
+      />,
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByText('Download all task logs'));
+    });
+    await waitFor(() => {
+      expect(downloadAllCallback).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/shared/components/pipeline-run-logs/__tests__/MultiStreamLogs.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/__tests__/MultiStreamLogs.spec.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import '@testing-library/jest-dom';
-import { commonFetchText } from '@openshift/dynamic-plugin-sdk-utils';
 import { screen, render, waitFor, configure, fireEvent, act } from '@testing-library/react';
-import { debounce, throttle } from 'lodash-es';
 import { samplePod } from '../../../../__data__/pod-data';
 import { ScrollDirection, useScrollDirection } from '../../../hooks/scroll';
 import { MultiStreamLogs } from '../logs/MultiStreamLogs';
@@ -23,42 +21,16 @@ jest.mock('../../../hooks/scroll', () => {
     useScrollDirection: jest.fn(),
   };
 });
-jest.mock('react-i18next', () => ({
-  useTranslation: jest.fn(() => ({ t: (x) => x })),
-}));
 
-jest.mock('lodash-es', () => {
-  const actual = jest.requireActual('lodash-es');
-  return {
-    ...actual,
-    debounce: jest.fn(),
-    throttle: jest.fn(),
-  };
-});
-
-jest.mock('@openshift/dynamic-plugin-sdk-utils', () => {
-  const actual = jest.requireActual('@openshift/dynamic-plugin-sdk-utils');
-  return {
-    ...actual,
-    commonFetchText: jest.fn(),
-  };
-});
-
-const mockCommmonFetchText = commonFetchText as jest.Mock;
-const mockDebounce = debounce as jest.Mock;
-const mockThrottle = throttle as jest.Mock;
 const mockUseScrollDirection = useScrollDirection as jest.Mock;
 
+const getCurrentLogs = () => 'Current log text';
+
 describe('MultiStreamLogs', () => {
-  let downloadAllCallback;
   beforeEach(() => {
-    downloadAllCallback = jest.fn();
     jest.spyOn(console, 'warn').mockImplementation(jest.fn());
 
     configure({ testIdAttribute: 'data-testid' });
-    mockCommmonFetchText.mockReturnValue(Promise.resolve());
-    mockDebounce.mockImplementation((fn) => fn);
-    mockThrottle.mockImplementation((fn) => fn);
     mockUseScrollDirection.mockReturnValue([null, () => {}]);
   });
 
@@ -72,9 +44,7 @@ describe('MultiStreamLogs', () => {
       <MultiStreamLogs
         resourceName={'invalid-pod'}
         resource={samplePod}
-        errorMessage={''}
-        taskName={'step-init'}
-        onDownloadAll={downloadAllCallback}
+        setCurrentLogsGetter={getCurrentLogs}
       />,
     );
 
@@ -83,51 +53,13 @@ describe('MultiStreamLogs', () => {
     });
   });
 
-  it('should render the logs control buttons and container', () => {
-    render(
-      <MultiStreamLogs
-        resourceName={samplePod.metadata.name}
-        resource={samplePod}
-        errorMessage={''}
-        taskName={'step-init'}
-        downloadAllLabel={'Download all task logs'}
-        onDownloadAll={downloadAllCallback}
-      />,
-    );
-
-    waitFor(() => {
-      screen.getByTestId('logs-task-container');
-      screen.getByText('Download');
-      screen.getByText('Download all task logs');
-      screen.getByText('Expand');
-    });
-  });
-
-  it('should disable download when an error is present', () => {
-    render(
-      <MultiStreamLogs
-        resourceName={samplePod.metadata.name}
-        resource={samplePod}
-        errorMessage="test error"
-        taskName={'step-init'}
-        downloadAllLabel={'Download all task logs'}
-        onDownloadAll={downloadAllCallback}
-      />,
-    );
-    const downloadButton = screen.getByText('Download');
-    expect(downloadButton).toBeDisabled();
-  });
-
   it('should render resume log stream button when user scrolls up and removed when users scrolls to the bottom of the logs', async () => {
     mockUseScrollDirection.mockReturnValue([ScrollDirection.scrollingUp, () => {}]);
     const { getByTestId, rerender } = render(
       <MultiStreamLogs
         resourceName={samplePod.metadata.name}
         resource={samplePod}
-        errorMessage={''}
-        taskName={'step-init'}
-        downloadAllLabel={'Download all task logs'}
-        onDownloadAll={downloadAllCallback}
+        setCurrentLogsGetter={() => {}}
       />,
     );
 
@@ -146,58 +78,12 @@ describe('MultiStreamLogs', () => {
       <MultiStreamLogs
         resourceName={samplePod.metadata.name}
         resource={samplePod}
-        errorMessage={''}
-        taskName={'step-init'}
-        downloadAllLabel={'Download all task logs'}
-        onDownloadAll={downloadAllCallback}
+        setCurrentLogsGetter={() => {}}
       />,
     );
 
     await waitFor(() => {
       expect(screen.queryByTestId('resume-log-stream')).not.toBeInTheDocument();
-    });
-  });
-
-  it('should call onDownload callback when download button is pressed', async () => {
-    downloadAllCallback.mockReturnValue(Promise.resolve());
-
-    render(
-      <MultiStreamLogs
-        resourceName={samplePod.metadata.name}
-        resource={samplePod}
-        errorMessage={''}
-        taskName={'step-init'}
-        downloadAllLabel={'Download all task logs'}
-        onDownloadAll={downloadAllCallback}
-      />,
-    );
-
-    act(() => {
-      fireEvent.click(screen.getByText('Download all task logs'));
-    });
-    await waitFor(() => {
-      expect(downloadAllCallback).toHaveBeenCalled();
-    });
-  });
-
-  it('should handle if the download fails', async () => {
-    downloadAllCallback.mockImplementation(() => Promise.reject(new Error('Download Failed')));
-    render(
-      <MultiStreamLogs
-        resourceName={samplePod.metadata.name}
-        resource={samplePod}
-        errorMessage={''}
-        taskName={'step-init'}
-        downloadAllLabel={'Download all task logs'}
-        onDownloadAll={downloadAllCallback}
-      />,
-    );
-
-    act(() => {
-      fireEvent.click(screen.getByText('Download all task logs'));
-    });
-    await waitFor(() => {
-      expect(downloadAllCallback).rejects.toThrowError();
     });
   });
 });

--- a/src/shared/components/pipeline-run-logs/__tests__/TektonTaskRunLog.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/__tests__/TektonTaskRunLog.spec.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { screen, render, waitFor, configure } from '@testing-library/react';
+import { testTaskRuns } from '../../../../components/TaskRunListView/__data__/mock-TaskRun-data';
+import { useTRTaskRunLog } from '../../../../hooks/useTektonResults';
+import { useScrollDirection } from '../../../hooks/scroll';
+import { TektonTaskRunLog } from '../logs/TektonTaskRunLog';
+
+jest.mock('../logs/Logs', () => (props) => {
+  React.useEffect(() => {
+    props.onComplete(props.container.name);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return <div>{`Logs - ${props.container.name}`}</div>;
+});
+
+jest.mock('../../../hooks/scroll', () => {
+  const actual = jest.requireActual('../../../hooks/scroll');
+
+  return {
+    ...actual,
+    useScrollDirection: jest.fn(),
+  };
+});
+
+jest.mock('../../../../hooks/useTektonResults', () => ({
+  useTRTaskRunLog: jest.fn(),
+}));
+
+const mockUseScrollDirection = useScrollDirection as jest.Mock;
+const useTRTaskRunLogMock = useTRTaskRunLog as jest.Mock;
+
+describe('TektonTaskRunLog', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(jest.fn());
+
+    configure({ testIdAttribute: 'data-testid' });
+    mockUseScrollDirection.mockReturnValue([null, () => {}]);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render loading indicator', async () => {
+    useTRTaskRunLogMock.mockReturnValue(['', false, null]);
+    configure({ testIdAttribute: 'data-test' });
+
+    render(<TektonTaskRunLog taskRun={testTaskRuns[0]} setCurrentLogsGetter={() => {}} />);
+
+    await waitFor(() => {
+      screen.getByTestId('loading-indicator');
+    });
+  });
+  it('should display the tekton log results', async () => {
+    useTRTaskRunLogMock.mockReturnValue(['tekton log results', true, null]);
+
+    render(<TektonTaskRunLog taskRun={testTaskRuns[0]} setCurrentLogsGetter={() => {}} />);
+
+    await waitFor(() => {
+      screen.getByText('tekton log results');
+    });
+  });
+});

--- a/src/shared/components/pipeline-run-logs/logs/LogsWrapperComponent.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/LogsWrapperComponent.tsx
@@ -1,20 +1,38 @@
 import * as React from 'react';
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { Button, Flex, FlexItem } from '@patternfly/react-core';
+import { CompressIcon, DownloadIcon, ExpandIcon } from '@patternfly/react-icons/dist/js/icons';
+import classNames from 'classnames';
+import { saveAs } from 'file-saver';
 import { WatchK8sResource } from '../../../../dynamic-plugin-sdk';
-import { HttpError } from '../../../utils/error/http-error';
+import { TaskRunKind } from '../../../../types';
+import { useFullscreen } from '../../../hooks/fullscreen';
+import { LoadingInline } from '../../status-box/StatusBox';
 import { PodKind } from '../../types';
 import { MultiStreamLogs } from './MultiStreamLogs';
+import { TektonTaskRunLog } from './TektonTaskRunLog';
 
 type LogsWrapperComponentProps = {
-  taskName: string;
+  taskRun: TaskRunKind;
   downloadAllLabel?: string;
   onDownloadAll?: () => Promise<Error>;
   resource: WatchK8sResource;
 };
 
-const LogsWrapperComponent: React.FC<LogsWrapperComponentProps> = ({ resource, ...props }) => {
+const LogsWrapperComponent: React.FC<LogsWrapperComponentProps> = ({
+  resource,
+  taskRun,
+  onDownloadAll,
+  downloadAllLabel = 'Download all',
+  ...props
+}) => {
   const resourceRef = React.useRef(null);
   const [obj, loaded, error] = useK8sWatchResource<PodKind>(resource);
+  const [isFullscreen, fullscreenRef, fullscreenToggle] = useFullscreen<HTMLDivElement>();
+  const [downloadAllStatus, setDownloadAllStatus] = React.useState(false);
+  const currentLogGetterRef = React.useRef<() => string>();
+
+  const taskName = taskRun?.spec.taskRef?.name ?? taskRun?.metadata.name;
 
   if (loaded && !error && resource.name === obj.metadata.name) {
     resourceRef.current = obj;
@@ -22,18 +40,101 @@ const LogsWrapperComponent: React.FC<LogsWrapperComponentProps> = ({ resource, .
     resourceRef.current = null;
   }
 
-  const errorMessage =
-    (error as HttpError)?.code === 404
-      ? `Logs are no longer accessible for ${props.taskName} task`
-      : null;
+  const downloadLogs = () => {
+    if (!currentLogGetterRef.current) return;
+    const logString = currentLogGetterRef.current();
+    const blob = new Blob([logString], {
+      type: 'text/plain;charset=utf-8',
+    });
+    saveAs(blob, `${taskName}.log`);
+  };
 
+  const setLogGetter = React.useCallback((getter) => (currentLogGetterRef.current = getter), []);
+
+  const startDownloadAll = () => {
+    setDownloadAllStatus(true);
+    onDownloadAll()
+      .then(() => {
+        setDownloadAllStatus(false);
+      })
+      .catch((err: Error) => {
+        setDownloadAllStatus(false);
+        // eslint-disable-next-line no-console
+        console.warn(err.message || 'Error downloading logs.');
+      });
+  };
   return (
-    <MultiStreamLogs
-      {...props}
-      resourceName={resource?.name}
-      resource={resourceRef.current}
-      errorMessage={errorMessage}
-    />
+    <div ref={fullscreenRef} className="multi-stream-logs">
+      <Flex
+        className={(classNames as any)({
+          'multi-stream-logs--fullscreen': isFullscreen,
+        })}
+      >
+        <FlexItem className="multi-stream-logs__button" align={{ default: 'alignRight' }}>
+          <Button variant="link" onClick={downloadLogs} isInline>
+            <DownloadIcon className="multi-stream-logs__icon" />
+            Download
+          </Button>
+        </FlexItem>
+        <FlexItem className="multi-stream-logs__divider">|</FlexItem>
+        {onDownloadAll && (
+          <>
+            <FlexItem className="multi-stream-logs__button">
+              <Button
+                variant="link"
+                onClick={startDownloadAll}
+                isDisabled={downloadAllStatus}
+                isInline
+              >
+                <DownloadIcon className="multi-stream-logs__icon" />
+                {downloadAllLabel}
+                {downloadAllStatus && <LoadingInline />}
+              </Button>
+            </FlexItem>
+            <FlexItem className="multi-stream-logs__divider">|</FlexItem>
+          </>
+        )}
+        {fullscreenToggle && (
+          <FlexItem className="multi-stream-logs__button">
+            <Button variant="link" onClick={fullscreenToggle} isInline>
+              {isFullscreen ? (
+                <>
+                  <CompressIcon className="multi-stream-logs__icon" />
+                  Collapse
+                </>
+              ) : (
+                <>
+                  <ExpandIcon className="multi-stream-logs__icon" />
+                  Expand
+                </>
+              )}
+            </Button>
+          </FlexItem>
+        )}
+      </Flex>
+      {loaded || error ? (
+        <>
+          {!error ? (
+            <MultiStreamLogs
+              {...props}
+              taskRun={taskRun}
+              resourceName={resource?.name}
+              resource={resourceRef.current}
+              setCurrentLogsGetter={setLogGetter}
+            />
+          ) : (
+            <TektonTaskRunLog taskRun={taskRun} setCurrentLogsGetter={setLogGetter} />
+          )}
+        </>
+      ) : (
+        <span
+          className="multi-stream-logs__taskName__loading-indicator"
+          data-testid="loading-indicator"
+        >
+          <LoadingInline />
+        </span>
+      )}
+    </div>
   );
 };
 

--- a/src/shared/components/pipeline-run-logs/logs/TektonTaskRunLog.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/TektonTaskRunLog.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import { useTRTaskRunLog } from '../../../../hooks/useTektonResults';
+import { TaskRunKind } from '../../../../types';
+import { HttpError } from '../../../utils/error/http-error';
+import { LoadingInline } from '../../status-box/StatusBox';
+
+import './Logs.scss';
+import './MultiStreamLogs.scss';
+
+type TektonTaskRunLogProps = {
+  taskRun?: TaskRunKind;
+  setCurrentLogsGetter: (getter: () => string) => void;
+};
+
+export const TektonTaskRunLog: React.FC<TektonTaskRunLogProps> = ({
+  taskRun,
+  setCurrentLogsGetter,
+}) => {
+  const scrollPane = React.useRef<HTMLDivElement>();
+  const taskName = taskRun?.spec.taskRef?.name ?? taskRun?.metadata.name;
+  const [trResults, trLoaded, trError] = useTRTaskRunLog(
+    taskRun.metadata.namespace,
+    taskRun.metadata.name,
+  );
+
+  React.useEffect(() => {
+    setCurrentLogsGetter(() => scrollPane.current?.innerText);
+  }, [setCurrentLogsGetter]);
+
+  React.useEffect(() => {
+    if (!trError && trLoaded && scrollPane.current && trResults) {
+      scrollPane.current.scrollTop = scrollPane.current.scrollHeight;
+    }
+  }, [trError, trLoaded, trResults]);
+
+  const errorMessage =
+    (trError as HttpError)?.code === 404
+      ? `Logs are no longer accessible for ${taskName} task`
+      : null;
+
+  return (
+    <>
+      <div className="multi-stream-logs__taskName" data-testid="logs-taskName">
+        {taskName}
+        {!trLoaded && (
+          <span
+            className="multi-stream-logs__taskName__loading-indicator"
+            data-testid="loading-indicator"
+          >
+            <LoadingInline />
+          </span>
+        )}
+      </div>
+      <div
+        className="multi-stream-logs__container"
+        data-testid="tr-logs-task-container"
+        ref={scrollPane}
+      >
+        <div className="multi-stream-logs__container__logs" data-testid="tr-logs-container">
+          {errorMessage && (
+            <div className="pipeline-run-logs__logtext" data-testid="tr-logs-error-message">
+              {errorMessage}
+            </div>
+          )}
+          {!errorMessage && trLoaded ? (
+            <div className="logs" data-testid="tr-logs-container">
+              <p className="logs__name">{taskName}</p>
+              <div>
+                <div className="logs__content" data-testid="tr-logs-content">
+                  {trResults}
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </>
+  );
+};

--- a/src/shared/components/pipeline-run-logs/logs/log-snippet-utils.ts
+++ b/src/shared/components/pipeline-run-logs/logs/log-snippet-utils.ts
@@ -1,10 +1,8 @@
-import i18next from 'i18next';
 import { Condition } from '../../../../types';
 import { CombinedErrorDetails } from './log-snippet-types';
 
 const joinConditions = (conditions: Condition[]) =>
-  conditions.map((condition) => condition.message).join('\n') ||
-  i18next.t('Unknown failure condition');
+  conditions.map((condition) => condition.message).join('\n') || 'Unknown failure condition';
 
 export const taskRunSnippetMessage = (
   taskName: string,
@@ -15,17 +13,14 @@ export const taskRunSnippetMessage = (
     // Not enough to go to the logs, print all the conditions messages together
     return {
       staticMessage: joinConditions(taskRunStatus.conditions),
-      title: i18next.t('Failure on task {{taskName}} - check logs for details.', {
-        taskName,
-      }),
+      title: `Failure on task ${taskName} - check logs for details.`,
     };
   }
   // We don't know enough but have enough to locate the logs
   return {
     containerName,
     podName: taskRunStatus.podName,
-    title: i18next.t('Failure on task {{taskName}} - check logs for details.', {
-      taskName,
-    }),
+    staticMessage: joinConditions(taskRunStatus.conditions),
+    title: `Failure on task ${taskName} - check logs for details.`,
   };
 };

--- a/src/shared/components/pipeline-run-logs/logs/logs-utils.ts
+++ b/src/shared/components/pipeline-run-logs/logs/logs-utils.ts
@@ -5,7 +5,8 @@ import {
 } from '@openshift/dynamic-plugin-sdk-utils';
 import { saveAs } from 'file-saver';
 import { PodModel } from '../../../../models/pod';
-import { PLRTaskRunData, PLRTaskRuns } from '../../../../types';
+import { TaskRunKind } from '../../../../types';
+import { getTaskRunLog } from '../../../../utils/tekton-results';
 import { LineBuffer } from '../../../utils/line-buffer';
 import { ContainerSpec, ContainerStatus, PodKind } from '../../types';
 import { containerToLogSourceStatus, LOG_SOURCE_TERMINATED, LOG_SOURCE_WAITING } from '../utils';
@@ -71,20 +72,23 @@ type WatchURLStatus = {
 };
 
 export const getDownloadAllLogsCallback = (
-  sortedTaskRuns: string[],
-  taskRunFromYaml: PLRTaskRuns,
+  sortedTaskRunNames: string[],
+  taskRuns: TaskRunKind[],
   namespace: string,
   pipelineRunName: string,
 ): (() => Promise<Error>) => {
   const getWatchUrls = async (): Promise<StepsWatchUrl> => {
     const stepsList: ContainerStatus[][] = await Promise.all(
-      sortedTaskRuns.map((currTask) => {
-        const { status } = taskRunFromYaml[currTask] as PLRTaskRunData;
+      sortedTaskRunNames.map((currTask) => {
+        const { status } = taskRuns.find((t) => t.metadata.name === currTask) ?? {};
         return getOrderedStepsFromPod(status?.podName, namespace);
       }),
     );
-    return sortedTaskRuns.reduce((acc, currTask, i) => {
-      const { pipelineTaskName, status } = taskRunFromYaml[currTask];
+    return sortedTaskRunNames.reduce((acc, currTask, i) => {
+      const taskRun = taskRuns.find((t) => t.metadata.name === currTask);
+      const pipelineTaskName = taskRun?.spec.taskRef?.name ?? taskRun?.metadata.name;
+      const status = taskRun.status;
+
       const podName = status?.podName;
       const steps = stepsList[i];
       const allStepUrls = steps.reduce((stepUrls, currentStep) => {
@@ -118,41 +122,43 @@ export const getDownloadAllLogsCallback = (
 
   const fetchLogs = async (tasksPromise: Promise<StepsWatchUrl>) => {
     const tasks = await tasksPromise;
-    const allRequests: Promise<string>[] = sortedTaskRuns.reduce((acc, currTask) => {
+    let allLogs = '';
+    for (const currTask of sortedTaskRunNames) {
       const task = tasks[currTask];
-      const promises: Promise<string>[] = Object.keys(task.steps).map((step, i) => {
-        let heading = '';
-        if (i === 0) {
-          heading += `${task.name}\n\n`;
+      const steps = Object.keys(task.steps);
+      allLogs += `${task.name}\n\n`;
+
+      if (steps.length > 0) {
+        for (const step of steps) {
+          const { url, status } = task.steps[step];
+          const getContentPromise = commonFetchText(url).then((logs) => {
+            return `${step.toUpperCase()}\n\n${logs}\n\n`;
+          });
+          allLogs +=
+            status === LOG_SOURCE_TERMINATED
+              ? // If we are done, we want this log content
+                await getContentPromise
+              : // If we are not done, let's not wait indefinitely
+                await Promise.race([
+                  getContentPromise,
+                  new Promise<string>((resolve) => {
+                    setTimeout(() => resolve(''), 1000);
+                  }),
+                ]);
         }
-        heading += `${step}\n\n`;
-        const { url, status } = task.steps[step];
-        const getContentPromise = commonFetchText(url).then((logs) => {
-          return `${heading}${logs}\n\n`;
-        });
-        if (status === LOG_SOURCE_TERMINATED) {
-          // If we are done, we want this log content
-          return getContentPromise;
-        }
-        // If we are not done, let's not wait indefinitely
-        return Promise.race([
-          getContentPromise,
-          new Promise<string>((resolve) => {
-            setTimeout(() => resolve(''), 1000);
-          }),
-        ]);
-      });
-      return [...acc, ...promises];
-    }, []);
+      } else {
+        allLogs += await getTaskRunLog(namespace, currTask).then(
+          (log) => `${tasks[currTask].name.toUpperCase()}\n\n${log}\n\n`,
+        );
+      }
+    }
     const buffer = new LineBuffer();
-    return Promise.all(allRequests).then((allLogs) => {
-      buffer.ingest(allLogs.join(''));
-      const blob = buffer.getBlob({
-        type: 'text/plain;charset=utf-8',
-      });
-      saveAs(blob, `${pipelineRunName}.log`);
-      return null;
+    buffer.ingest(allLogs);
+    const blob = buffer.getBlob({
+      type: 'text/plain;charset=utf-8',
     });
+    saveAs(blob, `${pipelineRunName}.log`);
+    return null;
   };
   return (): Promise<Error> => {
     return fetchLogs(getWatchUrls());

--- a/src/shared/components/pipeline-run-logs/logs/pipelineRunLogSnippet.ts
+++ b/src/shared/components/pipeline-run-logs/logs/pipelineRunLogSnippet.ts
@@ -1,10 +1,4 @@
-import {
-  Condition,
-  PipelineRunKind,
-  PLRTaskRunData,
-  PLRTaskRunStep,
-  TaskRunKind,
-} from '../../../../types';
+import { Condition, PipelineRunKind, PLRTaskRunStep, TaskRunKind } from '../../../../types';
 import { pipelineRunStatus, taskRunStatus } from '../../../../utils/pipeline-utils';
 import { CombinedErrorDetails } from './log-snippet-types';
 import { taskRunSnippetMessage } from './log-snippet-utils';
@@ -36,8 +30,7 @@ export const getPLRLogSnippet = (
     return null;
   }
 
-  const tRuns: PLRTaskRunData[] = Object.values(taskRuns || pipelineRun.status.taskRuns || {});
-  const failedTaskRuns = tRuns.filter((taskRun) =>
+  const failedTaskRuns = taskRuns.filter((taskRun) =>
     taskRun?.status?.conditions?.find(
       (condition) => condition.type === 'Succeeded' && condition.status === 'False',
     ),
@@ -58,7 +51,11 @@ export const getPLRLogSnippet = (
     (step: PLRTaskRunStep) => step.terminated?.exitCode !== 0,
   )?.container;
 
-  return taskRunSnippetMessage(failedTaskRun.pipelineTaskName, failedTaskRun.status, containerName);
+  return taskRunSnippetMessage(
+    failedTaskRun?.spec.taskRef?.name ?? failedTaskRun?.metadata.name,
+    failedTaskRun.status,
+    containerName,
+  );
 };
 
 export const getTRLogSnippet = (taskRun: TaskRunKind): CombinedErrorDetails => {


### PR DESCRIPTION
## Fixes 
Fixes https://issues.redhat.com/browse/HAC-4318

## Description
Adds support for retrieving log results from Texton when pods are no longer available.

## Type of change
- [x] Feature

## Screen shots / Gifs for design review 
![image](https://github.com/openshift/hac-dev/assets/11633780/47438f63-7c7d-4cf7-b809-6f4842e571c9)


/cc @rohitkrai03 @christianvogt 