### PR TITLE
Fetch pipelineruns only for active components in an application

### DIFF
--- a/src/components/PipelineRunListView/PipelineRunsListView.tsx
+++ b/src/components/PipelineRunListView/PipelineRunsListView.tsx
@@ -14,6 +14,7 @@ import {
 } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import { PipelineRunLabel } from '../../consts/pipelinerun';
+import { useComponents } from '../../hooks/useComponents';
 import { usePipelineRuns } from '../../hooks/usePipelineRuns';
 import { useSearchParam } from '../../hooks/useSearchParam';
 import { Table } from '../../shared';
@@ -29,6 +30,7 @@ import { PipelineRunListRowWithVulnerabilities } from './PipelineRunListRow';
 type PipelineRunsListViewProps = { applicationName: string };
 const PipelineRunsListView: React.FC<PipelineRunsListViewProps> = ({ applicationName }) => {
   const { namespace } = useWorkspaceInfo();
+  const [components] = useComponents(namespace, applicationName);
   const [nameFilter, setNameFilter] = useSearchParam('name', '');
   const [statusFilterExpanded, setStatusFilterExpanded] = React.useState<boolean>(false);
   const [statusFiltersParam, setStatusFiltersParam] = useSearchParam('status', '');
@@ -40,9 +42,16 @@ const PipelineRunsListView: React.FC<PipelineRunsListViewProps> = ({ application
           matchLabels: {
             [PipelineRunLabel.APPLICATION]: applicationName,
           },
+          matchExpressions: [
+            {
+              key: `${PipelineRunLabel.COMPONENT}`,
+              operator: 'In',
+              values: components?.map((c) => c.metadata?.name),
+            },
+          ],
         },
       }),
-      [applicationName],
+      [applicationName, components],
     ),
   );
 

--- a/src/components/PipelineRunListView/__tests__/PipelineRunListView.spec.tsx
+++ b/src/components/PipelineRunListView/__tests__/PipelineRunListView.spec.tsx
@@ -2,9 +2,11 @@ import * as React from 'react';
 import '@testing-library/jest-dom';
 import { Table as PfTable, TableHeader } from '@patternfly/react-table';
 import { render, screen, fireEvent, configure } from '@testing-library/react';
+import { useComponents } from '../../../hooks/useComponents';
 import { usePipelineRuns } from '../../../hooks/usePipelineRuns';
 import { useSearchParam } from '../../../hooks/useSearchParam';
 import { PipelineRunKind } from '../../../types';
+import { mockComponentsData } from '../../ApplicationDetails/__data__';
 import { PipelineRunListRow } from '../PipelineRunListRow';
 import PipelineRunsListView from '../PipelineRunsListView';
 
@@ -14,6 +16,9 @@ jest.mock('react-i18next', () => ({
 
 jest.mock('../../../hooks/usePipelineRuns', () => ({
   usePipelineRuns: jest.fn(),
+}));
+jest.mock('../../../hooks/useComponents', () => ({
+  useComponents: jest.fn(),
 }));
 
 jest.mock('../../../utils/workspace-context-utils', () => ({
@@ -59,6 +64,7 @@ jest.mock('../../../utils/rbac', () => ({
 }));
 
 const useSearchParamMock = useSearchParam as jest.Mock;
+const useComponentsMock = useComponents as jest.Mock;
 
 const params: any = {};
 
@@ -154,46 +160,47 @@ const usePipelineRunsMock = usePipelineRuns as jest.Mock;
 describe('Pipeline run List', () => {
   beforeEach(() => {
     useSearchParamMock.mockImplementation(mockUseSearchParam);
+    useComponentsMock.mockReturnValue([mockComponentsData, true]);
   });
 
-  // it('should render spinner if application data is not loaded', () => {
-  //   usePipelineRunsMock.mockReturnValue([[], false]);
-  //   render(<PipelineRunsListView applicationName={appName} />);
-  //   screen.getByRole('progressbar');
-  // });
+  it('should render spinner if application data is not loaded', () => {
+    usePipelineRunsMock.mockReturnValue([[], false]);
+    render(<PipelineRunsListView applicationName={appName} />);
+    screen.getByRole('progressbar');
+  });
 
-  // it('should render empty state if no application is present', () => {
-  //   usePipelineRunsMock.mockReturnValue([[], true]);
-  //   render(<PipelineRunsListView applicationName={appName} />);
-  //   screen.queryByText(/Keep tabs on components and activity/);
-  //   screen.queryByText(/Monitor your components with pipelines and oversee CI\/CD activity./);
-  //   const button = screen.queryByText('Add component');
-  //   expect(button).toBeInTheDocument();
-  //   expect(button.closest('a').href).toContain(
-  //     `http://localhost/application-pipeline/workspaces/test-ws/import?application=my-test-app`,
-  //   );
-  // });
+  it('should render empty state if no application is present', () => {
+    usePipelineRunsMock.mockReturnValue([[], true]);
+    render(<PipelineRunsListView applicationName={appName} />);
+    screen.queryByText(/Keep tabs on components and activity/);
+    screen.queryByText(/Monitor your components with pipelines and oversee CI\/CD activity./);
+    const button = screen.queryByText('Add component');
+    expect(button).toBeInTheDocument();
+    expect(button.closest('a').href).toContain(
+      `http://localhost/application-pipeline/workspaces/test-ws/import?application=my-test-app`,
+    );
+  });
 
-  // it('should render correct columns when pipelineRuns are present', () => {
-  //   usePipelineRunsMock.mockReturnValue([pipelineRuns, true]);
-  //   render(<PipelineRunsListView applicationName={appName} />);
-  //   screen.queryByText('Name');
-  //   screen.queryByText('Started');
-  //   screen.queryByText('Duration');
-  //   screen.queryAllByText('Status');
-  //   screen.queryByText('Type');
-  //   screen.queryByText('Component');
-  // });
+  it('should render correct columns when pipelineRuns are present', () => {
+    usePipelineRunsMock.mockReturnValue([pipelineRuns, true]);
+    render(<PipelineRunsListView applicationName={appName} />);
+    screen.queryByText('Name');
+    screen.queryByText('Started');
+    screen.queryByText('Duration');
+    screen.queryAllByText('Status');
+    screen.queryByText('Type');
+    screen.queryByText('Component');
+  });
 
-  // it('should render entire pipelineRuns list when no filter value', async () => {
-  //   usePipelineRunsMock.mockReturnValue([pipelineRuns, true]);
-  //   render(<PipelineRunsListView applicationName={appName} />);
-  //   expect(screen.queryByText('basic-node-js-first')).toBeInTheDocument();
-  //   expect(screen.queryByText('basic-node-js-second')).toBeInTheDocument();
-  //   expect(screen.queryByText('basic-node-js-third')).toBeInTheDocument();
-  //   const filter = screen.getByPlaceholderText<HTMLInputElement>('Filter by name...');
-  //   expect(filter.value).toBe('');
-  // });
+  it('should render entire pipelineRuns list when no filter value', async () => {
+    usePipelineRunsMock.mockReturnValue([pipelineRuns, true]);
+    render(<PipelineRunsListView applicationName={appName} />);
+    expect(screen.queryByText('basic-node-js-first')).toBeInTheDocument();
+    expect(screen.queryByText('basic-node-js-second')).toBeInTheDocument();
+    expect(screen.queryByText('basic-node-js-third')).toBeInTheDocument();
+    const filter = screen.getByPlaceholderText<HTMLInputElement>('Filter by name...');
+    expect(filter.value).toBe('');
+  });
 
   it('should render filtered pipelinerun list', async () => {
     usePipelineRunsMock.mockReturnValue([pipelineRuns, true]);


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/RHTAPBUGS-483

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Tekton results query for fetching pipelineruns returns all the records that matches the application, this leads to showing the pipelineruns for the components which was deleted long before.

**Solution:**

 Updated the query to fetch the pipelinruns by passing the active components  in the application to avoid showing old invalid build pipelineruns.
 

## Type of change
<!-- Please delete options that are not relevant. -->


- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

**Before:** 

Shows deleted Component's build pipelinerun in the list view:
![image](https://github.com/openshift/hac-dev/assets/9964343/a68d0298-ac29-4c66-b1ce-f651cab8fc60)

**After:**

Shows only the build pipeline runs of all active components.

![image](https://github.com/openshift/hac-dev/assets/9964343/66b8979b-18b8-4598-9116-3bdd12c5d266)


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

The pipelinerun list view should not include the deleted component's pipelinerun

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
cc: @rohitkrai03 