### PR TITLE
Stabilise clicking on navigation menu items

### DIFF
--- a/integration-tests/support/constants/PageTitle.ts
+++ b/integration-tests/support/constants/PageTitle.ts
@@ -7,9 +7,10 @@ export const pageTitles = {
 };
 
 export enum NavItem {
+  overview = 'Overview',
   applications = 'Applications',
-  settings = 'Settings',
   environments = 'Environments',
+  learning = 'Learning Resources',
 }
 
 export const FULL_APPLICATION_TITLE = 'Red Hat Trusted Application Pipeline';

--- a/integration-tests/utils/Common.ts
+++ b/integration-tests/utils/Common.ts
@@ -7,7 +7,10 @@ export class Common {
   }
 
   static navigateTo(link: NavItem) {
-    cy.get(navigation.sideNavigation(link), { timeout: 80000 }).click();
+    for (let item in NavItem) {
+      cy.get(navigation.sideNavigation(NavItem[item]), { timeout: 30000 }).should('be.visible');
+    }
+    cy.get(navigation.sideNavigation(link)).click();
     Common.waitForLoad();
   }
 


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-4543

## Description
Wait for all navigation items to be visible before clicking on something.

