### PR TITLE
Add reset handler to review form cancel button

### DIFF
--- a/src/components/ImportForm/GitImportActions.tsx
+++ b/src/components/ImportForm/GitImportActions.tsx
@@ -16,12 +16,14 @@ import './GitImportActions.scss';
 type GitImportActionsProps = {
   reviewMode: boolean;
   onBack: () => void;
+  onCancel: () => void;
   sticky?: boolean;
 };
 
 const GitImportActions: React.FunctionComponent<GitImportActionsProps> = ({
   reviewMode,
   onBack,
+  onCancel,
   sticky,
 }) => {
   const {
@@ -31,7 +33,6 @@ const GitImportActions: React.FunctionComponent<GitImportActionsProps> = ({
     isSubmitting,
     isValidating,
     setErrors,
-    handleReset,
     handleSubmit,
   } = useFormikContext<ImportFormValues>();
 
@@ -67,7 +68,7 @@ const GitImportActions: React.FunctionComponent<GitImportActionsProps> = ({
                 </Button>
               </ActionListItem>
               <ActionListItem>
-                <Button variant="link" type="reset" onClick={handleReset}>
+                <Button variant="link" type="reset" onClick={onCancel}>
                   Cancel
                 </Button>
               </ActionListItem>

--- a/src/components/ImportForm/GitImportForm.tsx
+++ b/src/components/ImportForm/GitImportForm.tsx
@@ -205,6 +205,7 @@ const GitImportForm: React.FunctionComponent<GitImportFormProps> = ({
           <GitImportActions
             reviewMode={reviewMode}
             onBack={formikProps.dirty ? handleBack(true) : handleBack(false)}
+            onCancel={formikProps.dirty ? handleReset(true) : handleReset(false)}
             sticky={reviewMode}
           />
         </>

--- a/src/components/ImportForm/__tests__/GitImportActions.spec.tsx
+++ b/src/components/ImportForm/__tests__/GitImportActions.spec.tsx
@@ -24,7 +24,7 @@ describe('GitImportActions', () => {
   it('should render only Import code action if not in review mode', () => {
     useFormikContextMock.mockReturnValue({ values: { inAppContext: false } });
 
-    render(<GitImportActions reviewMode={false} onBack={handleBack} />);
+    render(<GitImportActions reviewMode={false} onBack={handleBack} onCancel={jest.fn()} />);
 
     screen.getByRole('button', { name: 'Import code' });
   });
@@ -32,7 +32,7 @@ describe('GitImportActions', () => {
   it('should render all the actions if in review mode', () => {
     useFormikContextMock.mockReturnValue({ values: { inAppContext: false } });
 
-    render(<GitImportActions reviewMode={true} onBack={handleBack} />);
+    render(<GitImportActions reviewMode={true} onBack={handleBack} onCancel={jest.fn()} />);
 
     screen.getByRole('button', { name: 'Create application' });
     screen.getByRole('button', { name: 'Back' });
@@ -42,7 +42,7 @@ describe('GitImportActions', () => {
   it('should render Add Component button', () => {
     useFormikContextMock.mockReturnValue({ values: { inAppContext: true } });
 
-    render(<GitImportActions reviewMode={true} onBack={handleBack} />);
+    render(<GitImportActions reviewMode={true} onBack={handleBack} onCancel={jest.fn()} />);
 
     screen.getByRole('button', { name: 'Add component' });
     screen.getByRole('button', { name: 'Cancel' });
@@ -51,7 +51,7 @@ describe('GitImportActions', () => {
   it('should render disabled actions if form is not valid', () => {
     useFormikContextMock.mockReturnValue({ values: { inAppContext: false }, isValid: false });
 
-    render(<GitImportActions reviewMode={false} onBack={handleBack} />);
+    render(<GitImportActions reviewMode={false} onBack={handleBack} onCancel={jest.fn()} />);
 
     expect(screen.getByRole('button', { name: 'Import code' })).toBeDisabled();
   });
@@ -59,7 +59,7 @@ describe('GitImportActions', () => {
   it('should render disabled action with spinner if form is submitting', () => {
     useFormikContextMock.mockReturnValue({ values: { inAppContext: false }, isSubmitting: true });
 
-    render(<GitImportActions reviewMode={true} onBack={handleBack} />);
+    render(<GitImportActions reviewMode={true} onBack={handleBack} onCancel={jest.fn()} />);
 
     screen.getByRole('progressbar');
     expect(screen.getByRole('button', { name: 'Loading... Create application' })).toBeDisabled();
@@ -68,7 +68,7 @@ describe('GitImportActions', () => {
   it('should call handleBack function when back button is clicked', async () => {
     useFormikContextMock.mockReturnValue({ values: { inAppContext: false }, setErrors: jest.fn() });
 
-    render(<GitImportActions reviewMode={true} onBack={handleBack} />);
+    render(<GitImportActions reviewMode={true} onBack={handleBack} onCancel={jest.fn()} />);
 
     const backButton = screen.getByRole('button', { name: 'Back' });
     await waitFor(() => backButton.click());


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/RHTAPBUGS-502
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
Add reset handler directly to git import actions so that clicking does not immediately reset formik state.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

https://github.com/openshift/hac-dev/assets/20013884/066a556c-5150-4074-a407-39e404406b98

<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
Click cancel in review form.
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
