### PR TITLE
add workspace context in the tekton results api requests

### DIFF
--- a/src/components/LogViewer/BuildLogViewer.tsx
+++ b/src/components/LogViewer/BuildLogViewer.tsx
@@ -88,7 +88,7 @@ export const BuildLogViewer: React.FC<BuildLogViewerProps> = ({ component }) => 
       </div>
       <div className="build-log-viewer__body">
         {pipelineRun && taskRuns && tloaded ? (
-          <PipelineRunLogs obj={pipelineRun} taskRuns={taskRuns} />
+          <PipelineRunLogs obj={pipelineRun} taskRuns={taskRuns} workspace={workspace} />
         ) : (
           <LoadingBox />
         )}

--- a/src/components/PipelineRunDetailsView/tabs/PipelineRunLogsTab.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/PipelineRunLogsTab.tsx
@@ -1,14 +1,23 @@
 import * as React from 'react';
 import { PipelineRunLogs } from '../../../shared';
 import { PipelineRunKind, TaskRunKind } from '../../../types';
+import { useWorkspaceInfo } from '../../../utils/workspace-context-utils';
 
 type PipelineRunLogsTabProps = {
   pipelineRun: PipelineRunKind;
   taskRuns: TaskRunKind[];
 };
 
-const PipelineRunLogsTab: React.FC<PipelineRunLogsTabProps> = ({ pipelineRun, taskRuns }) => (
-  <PipelineRunLogs className="pf-u-pt-md" obj={pipelineRun} taskRuns={taskRuns} />
-);
+const PipelineRunLogsTab: React.FC<PipelineRunLogsTabProps> = ({ pipelineRun, taskRuns }) => {
+  const { workspace } = useWorkspaceInfo();
+  return (
+    <PipelineRunLogs
+      className="pf-u-pt-md"
+      obj={pipelineRun}
+      taskRuns={taskRuns}
+      workspace={workspace}
+    />
+  );
+};
 
 export default PipelineRunLogsTab;

--- a/src/hooks/__tests__/usePipelineRuns.spec.ts
+++ b/src/hooks/__tests__/usePipelineRuns.spec.ts
@@ -15,6 +15,10 @@ import { useTRPipelineRuns, useTRTaskRuns } from '../useTektonResults';
 jest.mock('@openshift/dynamic-plugin-sdk-utils');
 jest.mock('../useTektonResults');
 
+jest.mock('../../utils/workspace-context-utils', () => ({
+  useWorkspaceInfo: jest.fn(() => ({ namespace: 'test-ns', workspace: 'test-ws' })),
+}));
+
 const useK8sWatchResourceMock = useK8sWatchResource as jest.Mock;
 const useTRPipelineRunsMock = useTRPipelineRuns as jest.Mock;
 const useTRTaskRunsMock = useTRTaskRuns as jest.Mock;

--- a/src/hooks/usePipelineRuns.ts
+++ b/src/hooks/usePipelineRuns.ts
@@ -12,6 +12,7 @@ import { useDeepCompareMemoize } from '../shared';
 import { PipelineRunKind, TaskRunGroupVersionKind, TaskRunKind } from '../types';
 import { getCommitSha } from '../utils/commits-utils';
 import { EQ } from '../utils/tekton-results';
+import { useWorkspaceInfo } from '../utils/workspace-context-utils';
 import { GetNextPage, useTRPipelineRuns, useTRTaskRuns } from './useTektonResults';
 
 const useRuns = <Kind extends K8sResourceCommon>(
@@ -23,6 +24,7 @@ const useRuns = <Kind extends K8sResourceCommon>(
     name?: string;
   },
 ): [Kind[], boolean, unknown, GetNextPage] => {
+  const { workspace } = useWorkspaceInfo();
   const etcdRunsRef = React.useRef<Kind[]>([]);
   const optionsMemo = useDeepCompareMemoize(options);
   const limit = optionsMemo?.limit;
@@ -72,7 +74,8 @@ const useRuns = <Kind extends K8sResourceCommon>(
 
   // Query tekton results if there's no limit or we received less items from etcd than the current limit
   const queryTr =
-    !limit || (namespace && ((runs && loaded && optionsMemo.limit > runs.length) || error));
+    !limit ||
+    (workspace && namespace && ((runs && loaded && optionsMemo.limit > runs.length) || error));
 
   const trOptions: typeof optionsMemo = React.useMemo(() => {
     if (optionsMemo?.name) {

--- a/src/shared/components/pipeline-run-logs/PipelineRunLogs.tsx
+++ b/src/shared/components/pipeline-run-logs/PipelineRunLogs.tsx
@@ -18,6 +18,7 @@ interface PipelineRunLogsProps {
   obj: PipelineRunKind;
   taskRuns: TaskRunKind[];
   activeTask?: string;
+  workspace: string;
 }
 interface PipelineRunLogsState {
   activeItem: string;
@@ -90,7 +91,7 @@ class PipelineRunLogs extends React.Component<PipelineRunLogsProps, PipelineRunL
   };
 
   render() {
-    const { className, obj, taskRuns } = this.props;
+    const { className, obj, taskRuns, workspace } = this.props;
     const { activeItem } = this.state;
 
     const taskRunNames = this.getSortedTaskRun(taskRuns, [
@@ -107,6 +108,7 @@ class PipelineRunLogs extends React.Component<PipelineRunLogsProps, PipelineRunL
         ? getDownloadAllLogsCallback(
             taskRunNames,
             taskRuns,
+            workspace,
             obj.metadata?.namespace,
             obj.metadata?.name,
           )

--- a/src/shared/components/pipeline-run-logs/__tests__/PipelineRunLogs.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/__tests__/PipelineRunLogs.spec.tsx
@@ -51,14 +51,21 @@ describe('PipelineRunLogs', () => {
   });
 
   it('should render task list and log window', () => {
-    render(<PipelineRunLogs obj={pipelineRun} taskRuns={testTaskRuns} />);
+    render(<PipelineRunLogs workspace="test-ws" obj={pipelineRun} taskRuns={testTaskRuns} />);
 
     screen.getByTestId('logs-tasklist');
     screen.getByTestId('logs-task-container');
   });
 
   it('should render select and render the first task log', () => {
-    render(<PipelineRunLogs obj={pipelineRun} taskRuns={testTaskRuns} activeTask="first" />);
+    render(
+      <PipelineRunLogs
+        workspace="test-ws"
+        obj={pipelineRun}
+        taskRuns={testTaskRuns}
+        activeTask="first"
+      />,
+    );
 
     screen.getByTestId('logs-tasklist');
     within(screen.getByTestId('logs-taskName')).getByText('first');
@@ -69,6 +76,7 @@ describe('PipelineRunLogs', () => {
 
     render(
       <PipelineRunLogs
+        workspace="test-ws"
         obj={runningPipelineRun}
         taskRuns={[{ ...testTaskRuns[0], status: { ...testTaskRuns[0].status, podName: '' } }]}
       />,
@@ -84,7 +92,7 @@ describe('PipelineRunLogs', () => {
     const plrWithNoStatus = testPipelineRuns[DataState.RUNNING];
     plrWithNoStatus.status = undefined;
 
-    render(<PipelineRunLogs obj={plrWithNoStatus} taskRuns={[]} />);
+    render(<PipelineRunLogs workspace="test-ws" obj={plrWithNoStatus} taskRuns={[]} />);
 
     screen.getByTestId('logs-tasklist');
     screen.getByTestId('task-logs-error');
@@ -95,7 +103,7 @@ describe('PipelineRunLogs', () => {
   it('should show no taskruns found when taskruns are pruned ', () => {
     const succeededPLR = testPipelineRuns[DataState.SUCCEEDED];
 
-    render(<PipelineRunLogs obj={succeededPLR} taskRuns={[]} />);
+    render(<PipelineRunLogs workspace="test-ws" obj={succeededPLR} taskRuns={[]} />);
 
     screen.getByTestId('logs-tasklist');
     screen.getByTestId('task-logs-error');
@@ -106,7 +114,7 @@ describe('PipelineRunLogs', () => {
   it('should show error message if the pipelinerun is failed', () => {
     const failedPLR = testPipelineRuns[DataState.FAILED];
 
-    render(<PipelineRunLogs obj={failedPLR} taskRuns={[]} />);
+    render(<PipelineRunLogs workspace="test-ws" obj={failedPLR} taskRuns={[]} />);
 
     screen.getByTestId('logs-tasklist');
     screen.getByTestId('task-logs-error');
@@ -122,7 +130,7 @@ describe('PipelineRunLogs', () => {
     ]);
     useTRTaskRunLogMock.mockReturnValue(['Tekton log results', true, null]);
 
-    render(<PipelineRunLogs obj={pipelineRun} taskRuns={testTaskRuns} />);
+    render(<PipelineRunLogs workspace="test-ws" obj={pipelineRun} taskRuns={testTaskRuns} />);
 
     screen.getByTestId('tr-logs-content');
     screen.getByText('Tekton log results');
@@ -140,14 +148,14 @@ describe('PipelineRunLogs', () => {
       new HttpError('logs not found', 404, null, { statusText: 'some status message' }),
     ]);
 
-    render(<PipelineRunLogs obj={pipelineRun} taskRuns={testTaskRuns} />);
+    render(<PipelineRunLogs workspace="test-ws" obj={pipelineRun} taskRuns={testTaskRuns} />);
 
     screen.getByTestId('tr-logs-error-message');
     screen.getByText('Logs are no longer accessible for first task');
   });
 
   it('should render the task names in the same order when a task is clicked', () => {
-    render(<PipelineRunLogs obj={pipelineRun} taskRuns={testTaskRuns} />);
+    render(<PipelineRunLogs workspace="test-ws" obj={pipelineRun} taskRuns={testTaskRuns} />);
 
     const expectTasktoBeOrdered = () => {
       const logsContainer = within(screen.getByTestId('logs-tasklist'));

--- a/src/shared/components/pipeline-run-logs/logs/logs-utils.ts
+++ b/src/shared/components/pipeline-run-logs/logs/logs-utils.ts
@@ -74,6 +74,7 @@ type WatchURLStatus = {
 export const getDownloadAllLogsCallback = (
   sortedTaskRunNames: string[],
   taskRuns: TaskRunKind[],
+  workspace: string,
   namespace: string,
   pipelineRunName: string,
 ): (() => Promise<Error>) => {
@@ -147,7 +148,7 @@ export const getDownloadAllLogsCallback = (
                 ]);
         }
       } else {
-        allLogs += await getTaskRunLog(namespace, currTask).then(
+        allLogs += await getTaskRunLog(workspace, namespace, currTask).then(
           (log) => `${tasks[currTask].name.toUpperCase()}\n\n${log}\n\n`,
         );
       }

--- a/src/utils/__tests__/tekton-results.spec.ts
+++ b/src/utils/__tests__/tekton-results.spec.ts
@@ -311,39 +311,48 @@ describe('tekton-results', () => {
 
   describe('createTektonResultsUrl', () => {
     it('should create minimal URL', () => {
-      expect(createTektonResultsUrl('test-ns', DataType.PipelineRun)).toEqual(
-        '/plugins/tekton-results/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=50&filter=data_type+%3D%3D+%22tekton.dev%2Fv1beta1.PipelineRun%22',
+      expect(createTektonResultsUrl('test-ws', 'test-ns', DataType.PipelineRun)).toEqual(
+        '/plugins/tekton-results/workspaces/test-ws/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=50&filter=data_type+%3D%3D+%22tekton.dev%2Fv1beta1.PipelineRun%22',
       );
-      expect(createTektonResultsUrl('test-ns', DataType.TaskRun)).toEqual(
-        '/plugins/tekton-results/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=50&filter=data_type+%3D%3D+%22tekton.dev%2Fv1beta1.TaskRun%22',
+      expect(createTektonResultsUrl('test-ws', 'test-ns', DataType.TaskRun)).toEqual(
+        '/plugins/tekton-results/workspaces/test-ws/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=50&filter=data_type+%3D%3D+%22tekton.dev%2Fv1beta1.TaskRun%22',
       );
     });
 
     it('should create URL with nextPageToken', () => {
       expect(
-        createTektonResultsUrl('test-ns', DataType.PipelineRun, null, null, 'test-token'),
+        createTektonResultsUrl(
+          'test-ws',
+          'test-ns',
+          DataType.PipelineRun,
+          null,
+          null,
+          'test-token',
+        ),
       ).toContain('page_token=test-token');
     });
 
     it('should create URL with filter', () => {
-      expect(createTektonResultsUrl('test-ns', DataType.PipelineRun, 'foo=bar')).toEqual(
-        '/plugins/tekton-results/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=50&filter=data_type+%3D%3D+%22tekton.dev%2Fv1beta1.PipelineRun%22+%26%26+foo%3Dbar',
+      expect(createTektonResultsUrl('test-ws', 'test-ns', DataType.PipelineRun, 'foo=bar')).toEqual(
+        '/plugins/tekton-results/workspaces/test-ws/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=50&filter=data_type+%3D%3D+%22tekton.dev%2Fv1beta1.PipelineRun%22+%26%26+foo%3Dbar',
       );
     });
 
     it('should create URL with page size', () => {
       // default page size
-      expect(createTektonResultsUrl('test-ns', DataType.PipelineRun)).toContain('page_size=50');
+      expect(createTektonResultsUrl('test-ws', 'test-ns', DataType.PipelineRun)).toContain(
+        'page_size=50',
+      );
       // min page size
       expect(
-        createTektonResultsUrl('test-ns', DataType.PipelineRun, '', {
+        createTektonResultsUrl('test-ws', 'test-ns', DataType.PipelineRun, '', {
           pageSize: 1,
         }),
       ).toContain('page_size=5');
 
       // min page size
       expect(
-        createTektonResultsUrl('test-ns', DataType.PipelineRun, '', {
+        createTektonResultsUrl('test-ws', 'test-ns', DataType.PipelineRun, '', {
           pageSize: 11000,
         }),
       ).toContain('page_size=10000');
@@ -351,7 +360,7 @@ describe('tekton-results', () => {
 
     it('should create URL using limit to affect page size', () => {
       expect(
-        createTektonResultsUrl('test-ns', DataType.PipelineRun, '', {
+        createTektonResultsUrl('test-ws', 'test-ns', DataType.PipelineRun, '', {
           pageSize: 10,
           limit: 5,
         }),
@@ -360,7 +369,13 @@ describe('tekton-results', () => {
 
     it('should create URL merging filters', () => {
       expect(
-        createTektonResultsUrl('test-ns', DataType.PipelineRun, 'foo=bar', sampleOptions),
+        createTektonResultsUrl(
+          'test-ws',
+          'test-ns',
+          DataType.PipelineRun,
+          'foo=bar',
+          sampleOptions,
+        ),
       ).toContain(
         'filter=data_type+%3D%3D+%22tekton.dev%2Fv1beta1.PipelineRun%22+%26%26+foo%3Dbar+%26%26+data.metadata.labels%5B%22test%22%5D+%3D%3D+%22a%22+%26%26+data.metadata.labels%5B%22mtest%22%5D+%3D%3D+%22ma%22+%26%26+count+%3E+1',
       );
@@ -371,14 +386,30 @@ describe('tekton-results', () => {
     it('should return cached value', async () => {
       commonFetchJSONMock.mockReturnValue(mockEmptyRecordsList);
 
-      await getFilteredRecord('test-ns', DataType.PipelineRun);
-      await getFilteredRecord('test-ns', DataType.PipelineRun);
+      await getFilteredRecord('test-ws', 'test-ns', DataType.PipelineRun);
+      await getFilteredRecord('test-ws', 'test-ns', DataType.PipelineRun);
       expect(commonFetchJSONMock).toHaveBeenCalledTimes(2);
 
       commonFetchJSONMock.mockClear();
 
-      await getFilteredRecord('test-ns', DataType.PipelineRun, null, null, null, 'cache-key');
-      await getFilteredRecord('test-ns', DataType.PipelineRun, null, null, null, 'cache-key');
+      await getFilteredRecord(
+        'test-ws',
+        'test-ns',
+        DataType.PipelineRun,
+        null,
+        null,
+        null,
+        'cache-key',
+      );
+      await getFilteredRecord(
+        'test-ws',
+        'test-ns',
+        DataType.PipelineRun,
+        null,
+        null,
+        null,
+        'cache-key',
+      );
       expect(commonFetchJSONMock).toHaveBeenCalledTimes(1);
     });
 
@@ -388,7 +419,7 @@ describe('tekton-results', () => {
           code: 404,
         };
       });
-      const result = await getFilteredRecord('test-ns', DataType.PipelineRun);
+      const result = await getFilteredRecord('test-ws', 'test-ns', DataType.PipelineRun);
       expect(result).toEqual([[], { nextPageToken: null, records: [] }]);
     });
 
@@ -398,17 +429,23 @@ describe('tekton-results', () => {
           code: 502,
         };
       });
-      await expect(getFilteredRecord('test-ns', DataType.PipelineRun)).rejects.toBeTruthy();
+      await expect(
+        getFilteredRecord('test-ws', 'test-ns', DataType.PipelineRun),
+      ).rejects.toBeTruthy();
     });
 
     it('should return record list and decoded value', async () => {
       commonFetchJSONMock.mockReturnValue(mockRecordsList);
-      expect(await getFilteredRecord('test-ns', DataType.PipelineRun)).toEqual(mockResponseCheck);
+      expect(await getFilteredRecord('test-ws', 'test-ns', DataType.PipelineRun)).toEqual(
+        mockResponseCheck,
+      );
     });
 
     it('should return record list and decoded value', async () => {
       commonFetchJSONMock.mockReturnValue(mockRecordsList);
-      expect(await getFilteredRecord('test-ns', DataType.PipelineRun, null, { limit: 1 })).toEqual([
+      expect(
+        await getFilteredRecord('test-ws', 'test-ns', DataType.PipelineRun, null, { limit: 1 }),
+      ).toEqual([
         [mockResponseCheck[0][0]],
         {
           nextPageToken: null,
@@ -421,13 +458,13 @@ describe('tekton-results', () => {
   describe('getPipelineRuns', () => {
     it('should return record list and decoded value', async () => {
       commonFetchJSONMock.mockReturnValue(mockRecordsList);
-      expect(await getPipelineRuns('test-ns')).toEqual(mockResponseCheck);
+      expect(await getPipelineRuns('test-ws', 'test-ns')).toEqual(mockResponseCheck);
     });
 
     it('should query tekton results with options', async () => {
-      await getPipelineRuns('test-ns', sampleOptions, 'test-token');
+      await getPipelineRuns('test-ws', 'test-ns', sampleOptions, 'test-token');
       expect(commonFetchJSONMock).toHaveBeenCalledWith(
-        '/plugins/tekton-results/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=50&page_token=test-token&filter=data_type+%3D%3D+%22tekton.dev%2Fv1beta1.PipelineRun%22+%26%26+data.metadata.labels%5B%22test%22%5D+%3D%3D+%22a%22+%26%26+data.metadata.labels%5B%22mtest%22%5D+%3D%3D+%22ma%22+%26%26+count+%3E+1',
+        '/plugins/tekton-results/workspaces/test-ws/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=50&page_token=test-token&filter=data_type+%3D%3D+%22tekton.dev%2Fv1beta1.PipelineRun%22+%26%26+data.metadata.labels%5B%22test%22%5D+%3D%3D+%22a%22+%26%26+data.metadata.labels%5B%22mtest%22%5D+%3D%3D+%22ma%22+%26%26+count+%3E+1',
       );
     });
   });
@@ -435,13 +472,13 @@ describe('tekton-results', () => {
   describe('getTaskRuns', () => {
     it('should return record list and decoded value', async () => {
       commonFetchJSONMock.mockReturnValue(mockRecordsList);
-      expect(await getTaskRuns('test-ns')).toEqual(mockResponseCheck);
+      expect(await getTaskRuns('test-ws', 'test-ns')).toEqual(mockResponseCheck);
     });
 
     it('should query tekton results with options', async () => {
-      await getTaskRuns('test-ns', sampleOptions, 'test-token');
+      await getTaskRuns('test-ws', 'test-ns', sampleOptions, 'test-token');
       expect(commonFetchJSONMock).toHaveBeenCalledWith(
-        '/plugins/tekton-results/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=50&page_token=test-token&filter=data_type+%3D%3D+%22tekton.dev%2Fv1beta1.TaskRun%22+%26%26+data.metadata.labels%5B%22test%22%5D+%3D%3D+%22a%22+%26%26+data.metadata.labels%5B%22mtest%22%5D+%3D%3D+%22ma%22+%26%26+count+%3E+1',
+        '/plugins/tekton-results/workspaces/test-ws/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=50&page_token=test-token&filter=data_type+%3D%3D+%22tekton.dev%2Fv1beta1.TaskRun%22+%26%26+data.metadata.labels%5B%22test%22%5D+%3D%3D+%22a%22+%26%26+data.metadata.labels%5B%22mtest%22%5D+%3D%3D+%22ma%22+%26%26+count+%3E+1',
       );
     });
   });
@@ -451,20 +488,20 @@ describe('tekton-results', () => {
       commonFetchJSONMock
         .mockReturnValueOnce(mockLogsRecordsList)
         .mockReturnValueOnce(Promise.resolve(mockLogResponse));
-      expect(await getTaskRunLog('test-ns', 'sample-task-run')).toEqual('sample log');
+      expect(await getTaskRunLog('test-ws', 'test-ns', 'sample-task-run')).toEqual('sample log');
       expect(commonFetchJSONMock.mock.calls).toEqual([
         [
-          '/plugins/tekton-results/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=5&filter=data_type+%3D%3D+%22results.tekton.dev%2Fv1alpha2.Log%22+%26%26+data.spec.resource.kind+%3D%3D+%22TaskRun%22+%26%26+data.spec.resource.name+%3D%3D+%22sample-task-run%22',
+          '/plugins/tekton-results/workspaces/test-ws/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=5&filter=data_type+%3D%3D+%22results.tekton.dev%2Fv1alpha2.Log%22+%26%26+data.spec.resource.kind+%3D%3D+%22TaskRun%22+%26%26+data.spec.resource.name+%3D%3D+%22sample-task-run%22',
         ],
         [
-          '/plugins/tekton-results/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/b9f43742-3675-4a71-8d73-31c5f5080a74/logs/113298cc-07f9-3ce0-85e3-5cf635eacf62',
+          '/plugins/tekton-results/workspaces/test-ws/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/b9f43742-3675-4a71-8d73-31c5f5080a74/logs/113298cc-07f9-3ce0-85e3-5cf635eacf62',
         ],
       ]);
     });
 
     it('should throw error 404 if record not found', async () => {
       commonFetchJSONMock.mockReturnValue(mockEmptyRecordsList);
-      await expect(getTaskRunLog('test-ns', 'sample-task-run')).rejects.toEqual({
+      await expect(getTaskRunLog('test-ws', 'test-ns', 'sample-task-run')).rejects.toEqual({
         code: 404,
       });
     });


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/RHTAPBUGS-522


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Tekton results API is failing with `401` Unauthorised error while you are in a shared workspace and this causes UI to not load  visualisations and component list view pages. This happens because the workspace information is not included in the API call so it defaults to user's home workspace.

Solution:
This PR appends workspace information in the tekton-results API request to properly map to a correct workspace.

All tekton-results API calls should contain workspace context eg :
`workspaces/<worksspace-name>/apis/results.tekton.dev/v1alpha2/parents/<namespace>/results/-/records`

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix




## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

1. Switch to a shared workspace and visit application details page or components list pages.


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
