### PR TITLE
use cdq and cluster defaults to determine in resource limit validation.

### DIFF
--- a/src/components/ImportForm/GitImportForm.tsx
+++ b/src/components/ImportForm/GitImportForm.tsx
@@ -11,6 +11,7 @@ import {
   Divider,
 } from '@patternfly/react-core';
 import { Formik } from 'formik';
+import { useResourceLimits } from '../../hooks/useLimitRange';
 import applicationIcon from '../../imgs/Application.svg';
 import integrationIcon from '../../imgs/Integration-test.svg';
 import { ComponentKind } from '../../types';
@@ -40,6 +41,8 @@ const GitImportForm: React.FunctionComponent<GitImportFormProps> = ({
   const track = useTrackEvent();
   const navigate = useNavigate();
   const { namespace, workspace } = useWorkspaceInfo();
+  const limit = useResourceLimits(namespace);
+  const maxlimit = useResourceLimits(namespace, true);
 
   const initialValues: ImportFormValues = {
     application: applicationName || '',
@@ -56,6 +59,10 @@ const GitImportForm: React.FunctionComponent<GitImportFormProps> = ({
     secret: '',
     importSecrets: [],
     newSecrets: [],
+    resourceLimits: {
+      min: limit,
+      max: maxlimit,
+    },
   };
 
   const showModal = useModalLauncher();
@@ -171,6 +178,7 @@ const GitImportForm: React.FunctionComponent<GitImportFormProps> = ({
       onSubmit={reviewMode ? handleSubmit : handleNext}
       initialValues={initialValues}
       validationSchema={reviewMode ? reviewValidationSchema : sourceValidationSchema}
+      enableReinitialize
     >
       {(formikProps) => (
         <>

--- a/src/components/ImportForm/ReviewSection/ReviewComponentCard.tsx
+++ b/src/components/ImportForm/ReviewSection/ReviewComponentCard.tsx
@@ -16,7 +16,7 @@ import {
   TitleSizes,
   ValidatedOptions,
 } from '@patternfly/react-core';
-import { useField } from 'formik';
+import { useField, useFormikContext } from 'formik';
 import {
   EnvironmentField,
   InputField,
@@ -28,7 +28,8 @@ import ExternalLink from '../../../shared/components/links/ExternalLink';
 import GitRepoLink from '../../GitLink/GitRepoLink';
 import HelpPopover from '../../HelpPopover';
 import SecretSection from '../SecretSection/SecretSection';
-import { CPUUnits, DetectedFormComponent, MemoryUnits } from '../utils/types';
+import { convertBaseValueToUnits, convertUnitValueToBaseValue } from '../utils/conversion-utils';
+import { CPUUnits, DetectedFormComponent, ImportFormValues, MemoryUnits } from '../utils/types';
 import { RuntimeSelector } from './RuntimeSelector';
 
 import './ReviewComponentCard.scss';
@@ -57,7 +58,9 @@ export const ReviewComponentCard: React.FC<ReviewComponentCardProps> = ({
   const [, { value: selectedRuntime }] = useField<string>(
     `components[${detectedComponentIndex}].selectedRuntime`,
   );
-  const [, { value: selectedUnitName }] = useField<string>(`${fieldPrefix}.resources.memoryUnit`);
+  const {
+    values: { resourceLimits, components },
+  } = useFormikContext<ImportFormValues>();
 
   return (
     <Card isFlat isCompact isSelected={expandedComponent} isExpanded={expandedComponent}>
@@ -169,6 +172,15 @@ export const ReviewComponentCard: React.FC<ReviewComponentCardProps> = ({
                 unitName={`${fieldPrefix}.resources.cpuUnit`}
                 label="CPU"
                 minValue={0}
+                maxValue={
+                  convertBaseValueToUnits(
+                    convertUnitValueToBaseValue(
+                      resourceLimits?.max?.cpu,
+                      resourceLimits?.max?.cpuUnit,
+                    ).value,
+                    components?.[detectedComponentIndex]?.componentStub?.resources?.cpuUnit,
+                  ).value
+                }
                 unitOptions={CPUUnits}
                 helpText="Amount of CPU the container is guaranteed"
               />
@@ -177,7 +189,15 @@ export const ReviewComponentCard: React.FC<ReviewComponentCardProps> = ({
                 unitName={`${fieldPrefix}.resources.memoryUnit`}
                 label="Memory"
                 minValue={0}
-                maxValue={selectedUnitName === MemoryUnits.Gi ? 2 : 256}
+                maxValue={
+                  convertBaseValueToUnits(
+                    convertUnitValueToBaseValue(
+                      resourceLimits?.max?.memory,
+                      resourceLimits?.max?.memoryUnit,
+                    ).value,
+                    components?.[detectedComponentIndex]?.componentStub?.resources?.memoryUnit,
+                  ).value
+                }
                 unitOptions={MemoryUnits}
                 helpText="Amount of memory the container is guaranteed"
               />

--- a/src/components/ImportForm/ReviewSection/ReviewSection.tsx
+++ b/src/components/ImportForm/ReviewSection/ReviewSection.tsx
@@ -54,6 +54,7 @@ const ReviewSection: React.FunctionComponent = () => {
         git: { url: sourceUrl, revision, context },
       },
       secret,
+      resourceLimits: { min: defaultResourceLimits } = {},
     },
     isSubmitting,
     setFieldValue,
@@ -76,18 +77,6 @@ const ReviewSection: React.FunctionComponent = () => {
   );
 
   const [validAppName] = useValidApplicationName(sourceUrl);
-
-  const getObjectPaths = React.useCallback((obj, prefix): string[] => {
-    prefix = prefix ? `${prefix}.` : '';
-    return Object.keys(obj).reduce((path: string[], key: string) => {
-      if (typeof obj[key] === 'object') {
-        path = [...path, ...getObjectPaths(obj[key], prefix + key)];
-      } else {
-        path.push(prefix + key);
-      }
-      return path;
-    }, []);
-  }, []);
 
   React.useEffect(() => {
     if (sourceUrl && gitUrlRegex.test(sourceUrl) && !inAppContext && !isSubmitting) {
@@ -127,25 +116,32 @@ const ReviewSection: React.FunctionComponent = () => {
     }
 
     if (components) {
-      const transformedComponents = transformComponentValues(components);
+      const transformedComponents = transformComponentValues(
+        components,
+        null,
+        defaultResourceLimits,
+      );
       setFieldValue('isDetected', true);
 
       setFieldValue('detectedComponents', transformedComponents, true);
       setFieldValue('components', transformedComponents, true);
-      getObjectPaths(transformedComponents, 'components').map((path) => setFieldTouched(path));
       cachedComponents.current = transformedComponents;
     }
 
     if ((detectionLoaded || detectionError) && !components) {
-      const transformedComponents = transformComponentValues({
-        myComponent: {
-          componentStub: {
-            componentName: 'my-component',
-            application: 'my-app',
-            source: { git: { url: sourceUrl, revision, context } },
+      const transformedComponents = transformComponentValues(
+        {
+          myComponent: {
+            componentStub: {
+              componentName: 'my-component',
+              application: 'my-app',
+              source: { git: { url: sourceUrl, revision, context } },
+            },
           },
         },
-      });
+        null,
+        defaultResourceLimits,
+      );
 
       setFieldValue('detectedComponents', undefined);
       setFieldValue('components', transformedComponents);
@@ -168,7 +164,7 @@ const ReviewSection: React.FunctionComponent = () => {
     revision,
     context,
     setFieldTouched,
-    getObjectPaths,
+    defaultResourceLimits,
   ]);
 
   if (!cachedComponentsLoaded.current) {

--- a/src/components/ImportForm/ReviewSection/RuntimeSelector.tsx
+++ b/src/components/ImportForm/ReviewSection/RuntimeSelector.tsx
@@ -46,6 +46,7 @@ export const RuntimeSelector: React.FC<RuntimeSelectorProps> = ({ detectedCompon
       detectionFailed,
       initialDetectionLoaded,
       components,
+      resourceLimits: { min: defaultResourceLimits } = {},
     },
     setFieldValue,
     setFieldError,
@@ -196,6 +197,7 @@ export const RuntimeSelector: React.FC<RuntimeSelectorProps> = ({ detectedCompon
       const componentValues = transformComponentValues(
         detectedComponents,
         originalComponentRef.current,
+        defaultResourceLimits,
       )[0];
       const component = patchSourceUrl(componentValues.componentStub, sourceUrl);
       setFieldValue(`${fieldPrefix}.componentStub`, component);
@@ -210,6 +212,7 @@ export const RuntimeSelector: React.FC<RuntimeSelectorProps> = ({ detectedCompon
     setFieldError,
     setFieldValue,
     sourceUrl,
+    defaultResourceLimits,
   ]);
 
   // touch the dropdown field on load so validation error message can be shown

--- a/src/components/ImportForm/__tests__/GitImportForm.actions.spec.tsx
+++ b/src/components/ImportForm/__tests__/GitImportForm.actions.spec.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { render, configure, waitFor } from '@testing-library/react';
 import { Formik } from 'formik';
+import { mockLimitRange } from '../../../hooks/__data__/mock-data';
 import { createApplication } from '../../../utils/create-utils';
 import GitImportForm from '../GitImportForm';
 
@@ -35,9 +37,14 @@ jest.mock('../ReviewSection/ReviewSection', () => () => {
   return <div data-test="review-section" />;
 });
 
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  useK8sWatchResource: jest.fn(),
+}));
+
 const useNavigateMock = useNavigate as jest.Mock;
 const FormikMock = Formik as jest.Mock;
 const createApplicationMock = createApplication as jest.Mock;
+const watchResourceMock = useK8sWatchResource as jest.Mock;
 
 configure({ testIdAttribute: 'data-test' });
 
@@ -49,6 +56,7 @@ describe('GitImportForm actions', () => {
     setReviewModeMock = jest.fn();
     navigateMock = jest.fn();
     useNavigateMock.mockImplementation(() => navigateMock);
+    watchResourceMock.mockReturnValue([[mockLimitRange], true]);
   });
 
   afterEach(() => {

--- a/src/components/ImportForm/__tests__/GitImportForm.rendering.spec.tsx
+++ b/src/components/ImportForm/__tests__/GitImportForm.rendering.spec.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { render, screen, configure } from '@testing-library/react';
+import { mockLimitRange } from '../../../hooks/__data__/mock-data';
 import GitImportForm from '../GitImportForm';
 
 jest.mock('../../../utils/analytics');
@@ -20,13 +22,20 @@ jest.mock('../ReviewSection/ReviewSection', () => () => {
   return <div data-test="review-section" />;
 });
 
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  useK8sWatchResource: jest.fn(),
+}));
+
 configure({ testIdAttribute: 'data-test' });
+
+const watchResourceMock = useK8sWatchResource as jest.Mock;
 
 describe('GitImportForm rendering', () => {
   let setReviewModeMock;
 
   beforeEach(() => {
     setReviewModeMock = jest.fn();
+    watchResourceMock.mockReturnValue([[mockLimitRange], true]);
   });
 
   afterEach(() => {

--- a/src/components/ImportForm/utils/__tests__/conversion-utils.spec.ts
+++ b/src/components/ImportForm/utils/__tests__/conversion-utils.spec.ts
@@ -1,0 +1,41 @@
+import { convertBaseValueToUnits, convertUnitValueToBaseValue } from '../conversion-utils';
+
+describe('converUnitValuetoBaseValue', () => {
+  it('should return the input without any coversion for invalid unit ', () => {
+    expect(convertUnitValueToBaseValue('1000', 'TKi')).toEqual({ value: 1000, unit: 'TKi' });
+    expect(convertUnitValueToBaseValue('1', 'Xyz')).toEqual({ value: 1, unit: 'Xyz' });
+  });
+
+  it('should convert the value to its base value', () => {
+    // memory unit conversion
+    expect(convertUnitValueToBaseValue('1000', 'Ki')).toEqual({ value: 1024000, unit: 'i' });
+    expect(convertUnitValueToBaseValue('10', 'Mi')).toEqual({ value: 10485760, unit: 'i' });
+    expect(convertUnitValueToBaseValue('1', 'Gi')).toEqual({ value: 1073741824, unit: 'i' });
+    expect(convertUnitValueToBaseValue('1', 'Ti')).toEqual({ value: 1099511627776, unit: 'i' });
+
+    // cpu unit conversion
+    expect(convertUnitValueToBaseValue('10', 'millicores')).toEqual({
+      value: 10,
+      unit: 'millicores',
+    });
+    expect(convertUnitValueToBaseValue('10', 'cores')).toEqual({
+      value: 10000,
+      unit: 'millicores',
+    });
+  });
+});
+
+describe('convertBaseValueToUnits', () => {
+  it('should return the input without any coversion for invalid unit ', () => {
+    expect(convertBaseValueToUnits(1000, 'TKi')).toEqual({ value: 1000, unit: 'TKi' });
+    expect(convertBaseValueToUnits(1, 'Xyz')).toEqual({ value: 1, unit: 'Xyz' });
+  });
+
+  it('should convert the base value to the preffered unit value', () => {
+    const baseValue = convertUnitValueToBaseValue('1', 'Gi').value;
+    expect(convertBaseValueToUnits(baseValue, 'Ti')).toEqual({ value: 0.0009765625, unit: 'Ti' });
+    expect(convertBaseValueToUnits(baseValue, 'Gi')).toEqual({ value: 1, unit: 'Gi' });
+    expect(convertBaseValueToUnits(baseValue, 'Mi')).toEqual({ value: 1024, unit: 'Mi' });
+    expect(convertBaseValueToUnits(baseValue, 'Ki')).toEqual({ value: 1048576, unit: 'Ki' });
+  });
+});

--- a/src/components/ImportForm/utils/__tests__/transform-utils.spec.ts
+++ b/src/components/ImportForm/utils/__tests__/transform-utils.spec.ts
@@ -132,4 +132,35 @@ describe('Transform Utils', () => {
     );
     expect(transformedComponentValues[0].componentStub.replicas).toBe(0);
   });
+
+  it('should default to cluster defaults if the detected component resources are empty', () => {
+    const detectedFormComponent: DetectedComponents = {
+      ...mockDetectedComponent,
+      nodejs: {
+        ...mockDetectedComponent.nodejs,
+        componentStub: {
+          ...mockDetectedComponent.nodejs.componentStub,
+          resources: {},
+        },
+      },
+    };
+
+    const clusterDefaults = {
+      cpu: '2000',
+      cpuUnit: CPUUnits.millicores,
+      memory: '10',
+      memoryUnit: MemoryUnits.Gi,
+    };
+
+    const transformedComponentValues = transformComponentValues(
+      detectedFormComponent,
+      mockComponent,
+      clusterDefaults,
+    );
+    expect(transformedComponentValues[0].componentStub.resources.cpu).toBe('2000');
+    expect(transformedComponentValues[0].componentStub.resources.cpuUnit).toBe(CPUUnits.millicores);
+
+    expect(transformedComponentValues[0].componentStub.resources.memory).toBe('10');
+    expect(transformedComponentValues[0].componentStub.resources.memoryUnit).toBe(MemoryUnits.Gi);
+  });
 });

--- a/src/components/ImportForm/utils/conversion-utils.ts
+++ b/src/components/ImportForm/utils/conversion-utils.ts
@@ -1,0 +1,80 @@
+const unitTypes = {
+  memory: {
+    units: ['i', 'Ki', 'Mi', 'Gi', 'Ti'],
+    divisor: 1024,
+  },
+  cpu: {
+    units: ['millicores', 'cores'],
+    divisor: 1000,
+  },
+};
+
+const getUnitType = (initialUnit: string): string | undefined => {
+  let matchedUnit;
+  Object.keys(unitTypes).forEach((unitType) => {
+    if (matchedUnit) return;
+    if (unitTypes[unitType].units.findIndex((k) => k === initialUnit) >= 0) {
+      matchedUnit = unitType;
+    }
+  });
+  return matchedUnit;
+};
+
+export const convertUnitValueToBaseValue = (
+  value: string | number,
+  initialUnit: string,
+): { value: number; unit: string } => {
+  const unitType = getUnitType(initialUnit);
+  let value_ = Number(value);
+  // check if initial Unit is not matched with available types
+  if (!unitType) {
+    return { value: value_, unit: initialUnit };
+  }
+
+  const { units, divisor } = unitTypes[unitType];
+  let units_ = units.slice().reverse();
+
+  // get the numeric value & prepare unit array for conversion
+  units_ = units_.slice(units_.findIndex((unit) => unit === initialUnit));
+
+  let unit = units_.shift();
+  while (units_.length > 0) {
+    value_ = value_ * divisor;
+    unit = units_.shift();
+  }
+
+  return { value: value_, unit };
+};
+
+export const convertBaseValueToUnits = (
+  value: number,
+  preferredUnit: string,
+): { value: number; unit: string } => {
+  const unitType = getUnitType(preferredUnit);
+  const { units, divisor } = unitTypes[unitType] || {};
+
+  if (!units) {
+    return {
+      value,
+      unit: preferredUnit,
+    };
+  }
+
+  const units_ = units.slice();
+  if (preferredUnit || preferredUnit === '') {
+    const unitIndex = units_.indexOf(preferredUnit);
+    if (unitIndex !== -1) {
+      return {
+        value: value / divisor ** unitIndex,
+        unit: preferredUnit,
+      };
+    }
+  }
+
+  let unit = units_.shift();
+  while (value >= divisor && units_.length > 0) {
+    value = value / divisor;
+    unit = units_.shift();
+  }
+  return { value, unit };
+};

--- a/src/components/ImportForm/utils/submit-utils.ts
+++ b/src/components/ImportForm/utils/submit-utils.ts
@@ -65,6 +65,7 @@ export const createResources = async (
     secret,
     namespace,
     importSecrets = [],
+    resourceLimits,
   } = formValues;
   const shouldCreateApplication = !inAppContext;
   let applicationName = application;
@@ -79,7 +80,11 @@ export const createResources = async (
       source.git.context,
       source.git.revision,
     );
-    detectedComponents = transformComponentValues(detectedSampleComponents);
+    detectedComponents = transformComponentValues(
+      detectedSampleComponents,
+      null,
+      resourceLimits?.min,
+    );
     componentAnnotations = { [SAMPLE_ANNOTATION]: 'true' };
   }
 

--- a/src/components/ImportForm/utils/transform-utils.ts
+++ b/src/components/ImportForm/utils/transform-utils.ts
@@ -44,6 +44,7 @@ export const transformResources = (formResources: FormResources): ResourceRequir
 export const transformComponentValues = (
   detectedComponents: DetectedComponents,
   originalComponent?: DetectedFormComponent,
+  defaultResourceLimits?: FormResources,
 ): DetectedFormComponent[] => {
   return Object.values(detectedComponents).map((detectedComponent) => {
     const component = detectedComponent.componentStub;
@@ -57,7 +58,12 @@ export const transformComponentValues = (
             ? originalComponent.componentStub.componentName
             : component.componentName,
         }),
-        resources: createResourceData(component?.resources || {}),
+        resources:
+          component?.resources && Object.keys(component?.resources).length > 0
+            ? createResourceData(component?.resources)
+            : defaultResourceLimits
+            ? defaultResourceLimits
+            : createResourceData({}),
         replicas: component?.replicas === undefined ? 1 : component.replicas,
         targetPort: component?.targetPort || 8080,
       },

--- a/src/components/ImportForm/utils/types.ts
+++ b/src/components/ImportForm/utils/types.ts
@@ -69,4 +69,8 @@ export type ImportFormValues = {
   importSecrets?: ImportSecret[];
   newSecrets?: string[];
   partnerTaskSecrets?: string[];
+  resourceLimits?: {
+    min: FormResources;
+    max: FormResources;
+  };
 };

--- a/src/hooks/__data__/mock-data.ts
+++ b/src/hooks/__data__/mock-data.ts
@@ -1,5 +1,5 @@
 import { EnvironmentKind } from '../../types';
-import { SnapshotEnvironmentBinding } from '../../types/coreBuildService';
+import { LimitRange, SnapshotEnvironmentBinding } from '../../types/coreBuildService';
 import { RouteKind } from '../../types/routes';
 
 export const mockEnvironments: EnvironmentKind[] = [
@@ -451,3 +451,24 @@ export const mockGitOpsDeployment = [
     },
   },
 ];
+
+export const mockLimitRange: LimitRange = {
+  apiVersion: 'v1',
+  kind: 'LimitRange',
+  metadata: { name: 'resource-limits' },
+  spec: {
+    limits: [
+      {
+        default: {
+          cpu: '2',
+          memory: '2Gi',
+        },
+        defaultRequest: {
+          cpu: '10m',
+          memory: '256Mi',
+        },
+        type: 'Container',
+      },
+    ],
+  },
+};

--- a/src/hooks/__tests__/useLimitRange.spec.ts
+++ b/src/hooks/__tests__/useLimitRange.spec.ts
@@ -1,0 +1,136 @@
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { renderHook } from '@testing-library/react-hooks';
+import { mockLimitRange } from '../__data__/mock-data';
+import { useLimitRange, useLimitRanges, useResourceLimits } from '../useLimitRange';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  useK8sWatchResource: jest.fn(),
+}));
+
+jest.mock('../../utils/workspace-context-utils', () => ({
+  useWorkspaceInfo: jest.fn(() => ({ namespace: 'test-ns', workspace: 'test-ws' })),
+}));
+
+const watchResourceMock = useK8sWatchResource as jest.Mock;
+
+describe('useLimitRanges', () => {
+  it('should return all the available limit ranges', () => {
+    watchResourceMock.mockReturnValue([[mockLimitRange], true]);
+    const { result } = renderHook(() => useLimitRanges('test-ns'));
+
+    const [limitRange, loaded] = result.current;
+    expect(watchResourceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        groupVersionKind: expect.objectContaining({ kind: 'LimitRange' }),
+      }),
+    );
+    expect(loaded).toEqual(true);
+    expect(limitRange).toBeDefined();
+  });
+});
+
+describe('useLimitRange', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return null if name is not specified', () => {
+    watchResourceMock.mockReturnValue([null, true]);
+    const { result } = renderHook(() => useLimitRange('test-ns'));
+
+    const [limitRange, loaded] = result.current;
+    expect(watchResourceMock).toHaveBeenCalledWith(undefined);
+    expect(loaded).toEqual(true);
+    expect(limitRange).toBeNull();
+  });
+
+  it('should return null if the returned resource is marked for deletion', () => {
+    const markedForDeletion = {
+      ...mockLimitRange,
+      metadata: {
+        ...mockLimitRange.metadata,
+        deletionTimestamp: new Date(),
+      },
+    };
+
+    watchResourceMock.mockReturnValue([markedForDeletion, true]);
+    const { result } = renderHook(() => useLimitRange('test-ns'));
+
+    const [limitRange, loaded] = result.current;
+    expect(watchResourceMock).toHaveBeenCalledWith(undefined);
+    expect(loaded).toEqual(true);
+    expect(limitRange).toBeNull();
+  });
+
+  it('should return limit range component', () => {
+    watchResourceMock.mockReturnValue([mockLimitRange, true]);
+    const { result } = renderHook(() => useLimitRange('test-ns', 'resource-limits'));
+
+    const [limitRange, loaded] = result.current;
+    expect(watchResourceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        groupVersionKind: expect.objectContaining({ kind: 'LimitRange' }),
+      }),
+    );
+    expect(loaded).toEqual(true);
+    expect(limitRange).toBeDefined();
+  });
+});
+
+describe('useResourceLimits', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return default values the fetch call is in loading state', () => {
+    watchResourceMock.mockReturnValue([null, false]);
+    const { result } = renderHook(() => useResourceLimits('test-ns'));
+
+    const resourceLimit = result.current;
+    expect(resourceLimit).toEqual({
+      cpu: '10',
+      cpuUnit: 'millicores',
+      memory: '256',
+      memoryUnit: 'Mi',
+    });
+  });
+
+  it('should return default values if the resource-limits cr is not present', () => {
+    watchResourceMock.mockReturnValue([null, true]);
+    const { result } = renderHook(() => useResourceLimits('test-ns'));
+
+    const resourceLimit = result.current;
+    expect(resourceLimit).toEqual({
+      cpu: '10',
+      cpuUnit: 'millicores',
+      memory: '50',
+      memoryUnit: 'Mi',
+    });
+  });
+
+  it('should return default values from the limit range resource', () => {
+    watchResourceMock.mockReturnValue([mockLimitRange, true]);
+    const { result } = renderHook(() => useResourceLimits('test-ns'));
+
+    const resourceLimit = result.current;
+    expect(resourceLimit).toEqual({
+      cpu: '10',
+      cpuUnit: 'millicores',
+      memory: '256',
+      memoryUnit: 'Mi',
+    });
+  });
+
+  it('should return maximum cluster default values from the limit range resource', () => {
+    watchResourceMock.mockReturnValue([mockLimitRange, true]);
+    const { result } = renderHook(() => useResourceLimits('test-ns', true));
+
+    const resourceLimit = result.current;
+    expect(resourceLimit).toEqual({
+      cpu: '2',
+      cpuUnit: 'cores',
+      memory: '2',
+      memoryUnit: 'Gi',
+    });
+  });
+});

--- a/src/hooks/useLimitRange.ts
+++ b/src/hooks/useLimitRange.ts
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { createResourceData } from '../components/ImportForm/utils/transform-utils';
+import { FormResources } from '../components/ImportForm/utils/types';
+import { LimitRangeGroupVersionKind } from '../models';
+import { LimitRange } from '../types/coreBuildService';
+
+export const useLimitRanges = (namespace: string): [LimitRange[], boolean, unknown] =>
+  useK8sWatchResource<LimitRange[]>({
+    groupVersionKind: LimitRangeGroupVersionKind,
+    namespace,
+    isList: true,
+  });
+
+export const useLimitRange = (
+  namespace: string,
+  limitRangeName?: string,
+): [LimitRange, boolean, unknown] => {
+  const [limitRange, limitRangeLoaded, error] = useK8sWatchResource<LimitRange>(
+    limitRangeName
+      ? {
+          groupVersionKind: LimitRangeGroupVersionKind,
+          namespace,
+          name: limitRangeName,
+        }
+      : undefined,
+  );
+  return React.useMemo((): [LimitRange, boolean, unknown] => {
+    if (limitRangeLoaded && !error && limitRange?.metadata?.deletionTimestamp) {
+      return [null, limitRangeLoaded, { code: 404 }];
+    }
+    return [limitRange, limitRangeLoaded, error];
+  }, [limitRange, limitRangeLoaded, error]);
+};
+
+export const useResourceLimits = (namespace: string, max?: boolean): FormResources => {
+  const [limitRange, limitRangeLoaded, error] = useLimitRange(namespace, 'resource-limits');
+
+  if (!limitRangeLoaded || error) {
+    return createResourceData({
+      requests: {
+        cpu: '10m',
+        memory: '256Mi',
+      },
+      limits: {
+        cpu: '2000m',
+        memory: '2Gi',
+      },
+    });
+  }
+
+  const limit = limitRange?.spec?.limits?.find((l) => l.type === 'Container');
+  return createResourceData({
+    ...(!max ? { requests: limit?.defaultRequest } : {}),
+    limits: limit?.default,
+  });
+};

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -17,3 +17,4 @@ export * from './snapshot';
 export * from './snapshot-environment-binding';
 export * from './rbac';
 export * from './secret';
+export * from './limit-range';

--- a/src/models/limit-range.ts
+++ b/src/models/limit-range.ts
@@ -1,0 +1,14 @@
+import { K8sModelCommon } from '@openshift/dynamic-plugin-sdk-utils';
+import { K8sGroupVersionKind } from './../dynamic-plugin-sdk';
+
+export const LimitRangeModel: K8sModelCommon = {
+  apiVersion: 'v1',
+  plural: 'limitranges',
+  namespaced: true,
+  kind: 'LimitRange',
+};
+
+export const LimitRangeGroupVersionKind: K8sGroupVersionKind = {
+  version: LimitRangeModel.apiVersion,
+  kind: LimitRangeModel.kind,
+};

--- a/src/types/coreBuildService.ts
+++ b/src/types/coreBuildService.ts
@@ -158,3 +158,20 @@ export type SnapshotEnvironmentBinding = K8sResourceCommon & {
     gitopsRepoConditions?: Condition[];
   };
 };
+
+export type LimitRange = K8sResourceCommon & {
+  spec: {
+    limits: Limit[];
+  };
+};
+
+export interface Limit {
+  default: Default;
+  defaultRequest: Default;
+  type: string;
+}
+
+export interface Default {
+  cpu: string;
+  memory: string;
+}


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/RHTAPBUGS-493

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When cdq returned resource limits, our resource limit validation was preventing user to submit the form until the decrease the values to match our hardcoded defaults. (10m, 256Mi).

This PR covers the following

1.  Fetch limitRange CR to determine the min/max values of the cluster.
2.  Use CDQ defaults if available or fallback to cluster default min limit.
3.  Use cluster default's max limit in the validation utils, so user can increase the value upto this limit.
4.  Added unit conversion utils to convert the values based on selected unit and display right values in the error message. 



## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:

**Form button disabled:**
<img width="1497" alt="Screenshot 2023-07-28 at 6 15 11 PM" src="https://github.com/openshift/hac-dev/assets/9964343/60115a7b-4eb5-4aec-8295-d103d7932108">


After:


<img width="1501" alt="Screenshot 2023-07-28 at 6 14 30 PM" src="https://github.com/openshift/hac-dev/assets/9964343/ed943ea7-817a-43ff-8daf-49099487d59c">

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

1. Use this repository https://github.com/openshift-cnv/cnv-fbc
2. Click on Import, in the review step the create application button should be enabled.


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
