### PR TITLE
Add check for all buttons to be ready.

### DIFF
--- a/integration-tests/support/constants/PageTitle.ts
+++ b/integration-tests/support/constants/PageTitle.ts
@@ -4,7 +4,7 @@ export const pageTitles = {
   sampleStart: 'Start with a sample',
   reviewComponent: 'Review your new components',
   componentSettings: 'Component settings',
-  overviewPage: 'Get started with',
+  getStartedPage: 'Get started with',
 };
 
 export enum NavItem {

--- a/integration-tests/support/pageObjects/pages-po.ts
+++ b/integration-tests/support/pageObjects/pages-po.ts
@@ -84,3 +84,7 @@ export const environmentsPagePO = {
   envDeleteBtn: 'button[data-testid="delete-resource"]',
   envCardConnectionLabel: 'div[class="pf-c-card__title"] span[class="pf-c-label__content"]',
 };
+
+export const getStartedPagePO = {
+  createAppButton: '[data-test="create-application"]',
+};

--- a/integration-tests/support/pages/GetStartedPage.ts
+++ b/integration-tests/support/pages/GetStartedPage.ts
@@ -1,0 +1,12 @@
+import { Common } from '../../utils/Common';
+import { pageTitles } from '../constants/PageTitle';
+import { getStartedPagePO } from '../pageObjects/pages-po';
+
+export class GetStartedPage {
+  static waitForLoad() {
+    Common.verifyPageTitle(pageTitles.getStartedPage);
+    cy.get(getStartedPagePO.createAppButton)
+      .should('be.visible')
+      .and('have.attr', 'aria-disabled', 'false');
+  }
+}

--- a/integration-tests/utils/Login.ts
+++ b/integration-tests/utils/Login.ts
@@ -1,5 +1,6 @@
 import { NavItem, pageTitles } from '../support/constants/PageTitle';
 import { loginPO, kcLoginPO } from '../support/pageObjects/global-po';
+import { GetStartedPage } from '../support/pages/GetStartedPage';
 import { Common } from './Common';
 
 export class Login {
@@ -29,7 +30,7 @@ export class Login {
 
   private static waitForApps() {
     Common.waitForLoad();
-    Common.verifyPageTitle(pageTitles.overviewPage);
+    GetStartedPage.waitForLoad();
     Common.navigateTo(NavItem.applications);
     Common.verifyPageTitle(pageTitles.applications);
     Common.waitForLoad();


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-4543

## Description
Tests are stuck on a loading page when the `Applications` are clicked after the login. Add a check for the `Get started` page to be fully loaded to prevent it. 

