### PR TITLE
enable passing cypress args to image entrypoint

### DIFF
--- a/integration-tests/Dockerfile
+++ b/integration-tests/Dockerfile
@@ -29,3 +29,4 @@ WORKDIR /tmp/
 COPY --chown=node:root --chmod=775 entrypoint.sh /tmp/
 
 ENTRYPOINT ["/tmp/entrypoint.sh"]
+CMD [""]

--- a/integration-tests/entrypoint.sh
+++ b/integration-tests/entrypoint.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+args="-b chrome";
+for var in "$@"
+do
+  args="$args $var"
+done
 
 if [ -d "/e2e" ]; then
   cd /e2e
@@ -8,7 +13,7 @@ else
   cd /tmp/e2e
 fi
 
-npm run cy:run
+npx cypress run $args
 
 if [ -d "/e2e/cypress" ]; then
   chmod -R a+rwx /e2e/cypress


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-4659

## Description
makes it possible to run e2e test image with arguments passed directly to cypress
