### PR TITLE
Avoid stripping "." from hidden context paths

### DIFF
--- a/src/components/GitLink/GitRepoLink.tsx
+++ b/src/components/GitLink/GitRepoLink.tsx
@@ -14,7 +14,7 @@ type Props = {
 const GitRepoLink: React.FC<Props> = ({ url, revision, context }) => {
   const parsed = gitUrlParse(url);
   const icon = getGitIcon(parsed.source);
-  const path = context?.replace(/^\.?\/?/g, '');
+  const path = context?.replace(/^(\.?\/)?/g, '');
   const fullUrl = `https://${parsed.source}/${parsed.owner}/${parsed.name}${getGitPath(
     parsed.source,
     revision,

--- a/src/components/GitLink/__tests__/GitRepoLink.spec.tsx
+++ b/src/components/GitLink/__tests__/GitRepoLink.spec.tsx
@@ -24,4 +24,21 @@ describe('GitRepoLink', () => {
     const result = render(<GitRepoLink url="https://github.com/myorg/myproject" context="./src" />);
     expect(result.baseElement).toHaveTextContent('(src)');
   });
+
+  it('should strip leading "/" from context', () => {
+    const result = render(<GitRepoLink url="https://github.com/myorg/myproject" context="/src" />);
+    expect(result.baseElement).toHaveTextContent('(src)');
+  });
+
+  it('should strip leading "./" from context', () => {
+    const result = render(<GitRepoLink url="https://github.com/myorg/myproject" context="./src" />);
+    expect(result.baseElement).toHaveTextContent('(src)');
+  });
+
+  it('should not strip leading "." from context', () => {
+    const result = render(
+      <GitRepoLink url="https://github.com/myorg/myproject" context=".hidden_dir" />,
+    );
+    expect(result.baseElement).toHaveTextContent('(.hidden_dir)');
+  });
 });


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/RHTAPBUGS-463
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
Fix context path regex to only remove leading `./` for git urls.
Updated regex: https://regex101.com/r/bKQsRG/1

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
![0](https://github.com/openshift/hac-dev/assets/20013884/fc7444d2-f77d-4643-b3df-afd327a88997)
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
Use git url with context path starting with "."

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
