### PR TITLE
fix-commit-label-shortname

### DIFF
--- a/src/components/Commits/__tests__/CommitsListRow.spec.tsx
+++ b/src/components/Commits/__tests__/CommitsListRow.spec.tsx
@@ -28,7 +28,7 @@ describe('CommitsListRow', () => {
       <CommitsListRow columns={null} obj={commits[1]} />,
     );
     const expectedDate = dateTime.dateTimeFormatter.format(new Date(commits[1].creationTime));
-    expect(queryByText('commit1')).not.toBeInTheDocument();
+    expect(queryByText('commit1')).toBeInTheDocument();
     expect(getAllByText(`#11 ${commits[1].shaTitle}`)[0]).toBeInTheDocument();
     expect(container).toHaveTextContent(expectedDate.toString());
     expect(getAllByText('branch_1')[0]).toBeInTheDocument();
@@ -40,7 +40,7 @@ describe('CommitsListRow', () => {
       <CommitsListRow columns={null} obj={commits[0]} />,
     );
     const expectedDate = dateTime.dateTimeFormatter.format(new Date(commits[0].creationTime));
-    expect(queryByText('commit1')).not.toBeInTheDocument();
+    expect(queryByText('commit7')).toBeInTheDocument();
     expect(getAllByText('manual build')[0]).toBeInTheDocument();
     expect(container).toHaveTextContent(expectedDate.toString());
     expect(getAllByText('manual-build-component')[0]).toBeInTheDocument();

--- a/src/components/Commits/__tests__/CommitsListView.spec.tsx
+++ b/src/components/Commits/__tests__/CommitsListView.spec.tsx
@@ -96,7 +96,7 @@ describe('CommitsListView', () => {
       <CommitsListRow columns={null} obj={commits[0]} />,
     );
     const expectedDate = dateTime.dateTimeFormatter.format(new Date(commits[0].creationTime));
-    expect(queryByText('commit1')).not.toBeInTheDocument();
+    expect(queryByText('commit1')).toBeInTheDocument();
     expect(getByText('#11 test-title')).toBeInTheDocument();
     expect(container).toHaveTextContent(expectedDate.toString());
     expect(getByText('branch_1')).toBeInTheDocument();

--- a/src/shared/components/commit-label/CommitLabel.tsx
+++ b/src/shared/components/commit-label/CommitLabel.tsx
@@ -3,6 +3,7 @@ import { Label, Tooltip } from '@patternfly/react-core';
 import { BitbucketIcon } from '@patternfly/react-icons/dist/js/icons/bitbucket-icon';
 import { GithubIcon } from '@patternfly/react-icons/dist/js/icons/github-icon';
 import { GitlabIcon } from '@patternfly/react-icons/dist/js/icons/gitlab-icon';
+import { getCommitShortName } from '../../../utils/commits-utils';
 import { GitProvider } from '../../utils/git-utils';
 
 const tipText = {
@@ -22,6 +23,7 @@ type CommitLabelProps = {
   shaURL: string;
 };
 const CommitLabel: React.FC<CommitLabelProps> = ({ gitProvider, sha, shaURL }) => {
+  const commitShortName = getCommitShortName(sha);
   const label = (
     <Label
       className="commit-label"
@@ -34,13 +36,13 @@ const CommitLabel: React.FC<CommitLabelProps> = ({ gitProvider, sha, shaURL }) =
           target="_blank"
           rel="noopener noreferrer"
           className={className}
-          data-test-id={`commit-label-${sha.slice(0, 6)}`}
+          data-test-id={`commit-label-${commitShortName}`}
         >
           {content}
         </a>
       )}
     >
-      {sha.slice(0, 6)}
+      {commitShortName}
     </Label>
   );
   const tooltip = tipText[gitProvider];

--- a/src/shared/components/commit-label/__tests__/CommitLabel.spec.tsx
+++ b/src/shared/components/commit-label/__tests__/CommitLabel.spec.tsx
@@ -25,7 +25,7 @@ configure({ testIdAttribute: 'data-test-id' });
 describe('CommitLabel', () => {
   it('should render commit label', () => {
     const label = render(<CommitLabel gitProvider="github" sha={sha} shaURL={shaURL} />);
-    const link = label.getByTestId(`commit-label-9135b3`);
+    const link = label.getByTestId(`commit-label-9135b3a`);
     expect(link).toBeInTheDocument();
     expect(label.getByRole('link')).toHaveAttribute('href', shaURL);
   });


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/RHTAPBUGS-507

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Fixes commit label shotName to use commit-util functionality

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
<img width="924" alt="Screenshot 2023-08-03 at 5 03 04 PM" src="https://github.com/openshift/hac-dev/assets/24852534/37f3a41b-50e6-4f1c-a58c-4c6ca3a05824">
<img width="788" alt="Screenshot 2023-08-03 at 5 57 52 PM" src="https://github.com/openshift/hac-dev/assets/24852534/0bf061c7-4ee7-43c5-8ae5-35116bea61d3">

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
