### PR TITLE
Wait for Get started page

### DIFF
--- a/integration-tests/utils/Login.ts
+++ b/integration-tests/utils/Login.ts
@@ -30,6 +30,8 @@ export class Login {
   private static waitForApps() {
     Common.waitForLoad();
     Common.verifyPageTitle(pageTitles.overviewPage);
+    // temporary "fix", wait until overviewPage is loaded
+    cy.wait(5000);
     Common.navigateTo(NavItem.applications);
     Common.verifyPageTitle(pageTitles.applications);
     Common.waitForLoad();


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-4543

## Description
Wait for Get started page by hard timeout as the button is not visible yet [PR#741](https://github.com/openshift/hac-dev/pull/741).
