### PR TITLE
When build is triggered from main branch set BETA to true

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -7,6 +7,12 @@ CI_SERVER_URL=https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test
 if [ ! -d node_modules ]; then
     npm install
 fi
+GIT_BRANCH=${GIT_BRANCH:-}
+
+ENV_BRANCH=$(sed "s/origin\///" <<< "$GIT_BRANCH")
+if [[ "${ENV_BRANCH}" = "master" ||  "${ENV_BRANCH}" = "main" ]]; then
+    BETA=true
+fi
 
 if [[ "${JOB_TYPE}" == "presubmit" ]]; then
        echo "detected PR code coverage job for #${PULL_NUMBER}"


### PR DESCRIPTION
## Fixes 

Broken reference to stable static files from preview environment.


## Description

Since we are utilizing cache buster now, long standing bug has surfaced where we are referencing stable static assets from preview environment. This PR fixes that by setting `BETA=true` if the build has been triggered from `master` or `main` branch.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
