### PR TITLE
reset active workspace before listing workspaces

### DIFF
--- a/src/components/PipelineRunListView/PipelineRunListRow.tsx
+++ b/src/components/PipelineRunListView/PipelineRunListRow.tsx
@@ -53,8 +53,17 @@ const BasePipelineRunListRow: React.FC<BasePipelineRunListRowProps> = ({
         />
       </TableData>
       {showVulnerabilities ? (
-        <TableData className={pipelineRunTableColumnClasses.vulnerabilities}>
-          {scanLoaded ? <ScanStatus scanResults={scanResults} /> : <Skeleton />}
+        <TableData
+          data-testid="vulnerabilities"
+          className={pipelineRunTableColumnClasses.vulnerabilities}
+        >
+          {!obj?.status?.completionTime ? (
+            '-'
+          ) : scanLoaded ? (
+            <ScanStatus scanResults={scanResults} />
+          ) : (
+            <Skeleton />
+          )}
         </TableData>
       ) : null}
       <TableData className={pipelineRunTableColumnClasses.duration}>

--- a/src/components/PipelineRunListView/__tests__/PipelineRunListRow.spec.tsx
+++ b/src/components/PipelineRunListView/__tests__/PipelineRunListRow.spec.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { DataState, testPipelineRuns } from '../../../__data__/pipelinerun-data';
+import { PipelineRunListRowWithVulnerabilities } from '../PipelineRunListRow';
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => jest.fn(),
+    Link: (props) => <a href={props.to}>{props.children}</a>,
+    useSearchParams: jest.fn(),
+  };
+});
+
+describe('Pipeline run Row', () => {
+  it('should return - when pipelinerun is in running state ', () => {
+    const runningPipelineRun = testPipelineRuns[DataState.RUNNING];
+    const row = render(
+      <PipelineRunListRowWithVulnerabilities obj={runningPipelineRun} columns={[]} />,
+    );
+
+    expect(row.getByText('-')).toBeDefined();
+    expect(row.getByText('Running')).toBeDefined();
+  });
+
+  it('should return - when vulnerabilities is not available ', () => {
+    const succeededPlr = testPipelineRuns[DataState.SUCCEEDED];
+    const plrName = succeededPlr.metadata.name;
+    const row = render(
+      <PipelineRunListRowWithVulnerabilities
+        obj={succeededPlr}
+        customData={{
+          fetchedPipelineRuns: [plrName],
+          vulnerabilities: [{ [plrName]: {} }],
+        }}
+        columns={[]}
+      />,
+    );
+
+    expect(row.getByText('-')).toBeDefined();
+    expect(row.getByText('Succeeded')).toBeDefined();
+  });
+
+  it('should show vulnerabilities when it is available ', () => {
+    const succeededPlr = testPipelineRuns[DataState.SUCCEEDED];
+    const plrName = succeededPlr.metadata.name;
+    const row = render(
+      <PipelineRunListRowWithVulnerabilities
+        obj={succeededPlr}
+        customData={{
+          fetchedPipelineRuns: [plrName],
+          vulnerabilities: {
+            [plrName]: [
+              {
+                vulnerabilities: {
+                  critical: 5,
+                  medium: 0,
+                  high: 0,
+                  low: 0,
+                },
+              },
+            ],
+          },
+        }}
+        columns={[]}
+      />,
+    );
+
+    expect(row.getByText('Critical')).toBeDefined();
+    expect(row.getByText('5')).toBeDefined();
+    expect(row.getByText('Succeeded')).toBeDefined();
+  });
+});

--- a/src/utils/workspace-context-utils.ts
+++ b/src/utils/workspace-context-utils.ts
@@ -82,6 +82,7 @@ export const useActiveWorkspace = (): WorkspaceContextData => {
     const fetchWorkspaces = async () => {
       let allWorkspaces: Workspace[] = [];
       try {
+        setActiveWorkspace(''); // to fetch root level workspaces
         allWorkspaces = await k8sListResourceItems<Workspace>({
           model: WorkspaceModel,
         });
@@ -93,8 +94,6 @@ export const useActiveWorkspace = (): WorkspaceContextData => {
       if (unmounted) {
         return;
       }
-
-      setActiveWorkspace(''); // to fetch root level workspaces
 
       let ws: string;
       if (Array.isArray(allWorkspaces)) {


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/RHTAPBUGS-568
https://issues.redhat.com/browse/RHTAPBUGS-564

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fetching workspaces returns empty array due to the invalid url.

RCA:

UI makes calls to list the workspaces and sets the active namespace and workspace, but for this call to work properly we should not set the workspace context prior to this call or else this will result in empty array and impact all other subsequent API calls that UI makes.

Solution:

Reset the active workspace before list workspaces


## Type of change
<!-- Please delete options that are not relevant. -->


- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

**Before:**

<img width="897" alt="empty_respsone" src="https://github.com/openshift/hac-dev/assets/9964343/b32513f5-3850-4edf-acb0-c9d9d0d06e70"> <img width="1791" alt="incorrect-workspace-url" src="https://github.com/openshift/hac-dev/assets/9964343/fa1149b0-ed64-412a-9407-05c3dcbecfd5">


**After**:

https://github.com/openshift/hac-dev/assets/9964343/84dd0401-3d2e-4a5b-b1f5-3319af2ce784

<img width="611" alt="Screenshot 2023-08-08 at 12 20 05 PM" src="https://github.com/openshift/hac-dev/assets/9964343/854269c6-1e25-4872-829d-aaf3446a8e34">


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
