### PR TITLE
Enable `(!)` cel filter in tekton results API

### DIFF
--- a/src/utils/__tests__/tekton-results.spec.ts
+++ b/src/utils/__tests__/tekton-results.spec.ts
@@ -156,9 +156,7 @@ describe('tekton-results', () => {
             operator: 'DoesNotExist',
           },
         ]),
-        // TODO
-        // ).toStrictEqual('!data.metadata.labels.contains("test")');
-      ).toStrictEqual('');
+      ).toStrictEqual('!data.metadata.labels.contains("test")');
     });
 
     it('should convert NotIn operator', () => {

--- a/src/utils/tekton-results.ts
+++ b/src/utils/tekton-results.ts
@@ -93,8 +93,7 @@ export const expressionsToFilter = (expressions: Omit<MatchExpression, 'value'>[
           case 'Exists':
             return `data.metadata.labels.contains("${expression.key}")`;
           case 'DoesNotExist':
-            // TODO crashes tekton-results and `in` expression does not work
-            return ''; //`!data.metadata.labels.contains("${expression.key}")`;
+            return `!data.metadata.labels.contains("${expression.key}")`;
           case 'NotIn':
             return expression.values?.length > 0
               ? AND(


### PR DESCRIPTION


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

! expression in tekton-results util was disabled because it was crashing the tekton-results service. It is now fixed and working properly, so enabling the filter back.


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Refactoring (no functional changes, no api changes)




<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
