### PR TITLE
update TR Api query filter and page size in lifecycle graph 

### DIFF
--- a/src/components/ApplicationDetails/tabs/overview/visualization/hooks/__tests__/useAppIntegrationTestNodes.spec.ts
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/hooks/__tests__/useAppIntegrationTestNodes.spec.ts
@@ -1,6 +1,7 @@
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import '@testing-library/jest-dom';
 import { renderHook } from '@testing-library/react-hooks';
+import { useComponents } from '../../../../../../../hooks/useComponents';
 import { mockIntegrationTestScenariosData } from '../../../../../__data__';
 import { testPipelineRuns } from '../__data__/test-pipeline-data';
 import { useAppApplicationTestNodes } from '../useAppApplicationTestNodes';
@@ -12,10 +13,14 @@ jest.mock('@openshift/dynamic-plugin-sdk-utils', () => {
     useK8sWatchResource: jest.fn(),
   };
 });
+jest.mock('../../../../../../../hooks/useComponents', () => ({
+  useComponents: jest.fn(),
+}));
 
 jest.mock('../../../../../../../hooks/useTektonResults');
 
 const useK8sWatchResourceMock = useK8sWatchResource as jest.Mock;
+const useComponentsMock = useComponents as jest.Mock;
 
 describe('useAppApplicationTestNodes', () => {
   beforeEach(() => {
@@ -23,6 +28,7 @@ describe('useAppApplicationTestNodes', () => {
     useK8sWatchResourceMock
       .mockReturnValueOnce([[mockIntegrationTestScenariosData[0]], true])
       .mockReturnValueOnce([testPipelineRuns, true]);
+    useComponentsMock.mockReturnValue([[], true]);
   });
 
   it('should return integration test nodes', () => {

--- a/src/components/ApplicationDetails/tabs/overview/visualization/hooks/useAppApplicationTestNodes.ts
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/hooks/useAppApplicationTestNodes.ts
@@ -29,6 +29,7 @@ export const useAppApplicationTestNodes = (
   const [testPipelines, testPipelinesLoaded, testPipelinesError] = useTestPipelines(
     namespace,
     applicationName,
+    true,
   );
   const allLoaded = testsLoaded && testPipelinesLoaded;
   const allErrors = [testsError, testPipelinesError].filter((e) => !!e);

--- a/src/components/ApplicationDetails/tabs/overview/visualization/hooks/useAppBuildNodes.ts
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/hooks/useAppBuildNodes.ts
@@ -30,6 +30,8 @@ export const useAppBuildNodes = (
   const [buildPipelines, buildPipelinesLoaded, buildPipelinesError] = useBuildPipelines(
     namespace,
     applicationName,
+    null,
+    true,
   );
   const allResourcesLoaded: boolean = componentsLoaded && buildPipelinesLoaded;
   const allErrors: unknown[] = [componentsError, buildPipelinesError].filter((e) => !!e);

--- a/src/hooks/__tests__/useBuildPipelines.spec.ts
+++ b/src/hooks/__tests__/useBuildPipelines.spec.ts
@@ -1,0 +1,37 @@
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { renderHook } from '@testing-library/react-hooks';
+import { DataState, testPipelineRuns } from '../../__data__/pipelinerun-data';
+import { useBuildPipelines } from '../useBuildPipelines';
+
+jest.mock('../useTektonResults');
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  useK8sWatchResource: jest.fn(() => [[], true]),
+  getActiveWorkspace: jest.fn(),
+}));
+
+const useK8sWatchResourceMock = useK8sWatchResource as jest.Mock;
+
+describe('useBuildPipelines', () => {
+  it('should return empty array', () => {
+    useK8sWatchResourceMock.mockReturnValue([[], false, undefined]);
+    const { result } = renderHook(() => useBuildPipelines('test-ns', 'test-pipelinerun', null));
+
+    expect(result.current).toEqual([[], false, undefined]);
+  });
+
+  it('should return build pipelines', () => {
+    useK8sWatchResourceMock.mockReturnValue([
+      [testPipelineRuns[DataState.RUNNING]],
+      true,
+      undefined,
+    ]);
+    const { result } = renderHook(() =>
+      useBuildPipelines('test-ns', 'test-pipelinerun', null, true),
+    );
+
+    const [pipelineRuns, loaded] = result.current;
+    expect(loaded).toBe(true);
+    expect(pipelineRuns.map((tr) => tr.metadata?.name)).toEqual(['test-caseqfvdj']);
+  });
+});

--- a/src/hooks/useTestPipelines.ts
+++ b/src/hooks/useTestPipelines.ts
@@ -1,15 +1,19 @@
 import * as React from 'react';
 import { PipelineRunLabel, PipelineRunType } from '../consts/pipelinerun';
 import { PipelineRunKind } from '../types';
+import { useComponents } from './useComponents';
 import { usePipelineRuns } from './usePipelineRuns';
 
 // TODO this request can be inefficient
 export const useTestPipelines = (
   namespace: string,
   applicationName: string,
-): [PipelineRunKind[], boolean, unknown] =>
-  usePipelineRuns(
-    namespace,
+  includeComponents?: boolean,
+): [PipelineRunKind[], boolean, unknown] => {
+  const [components, componentsLoaded] = useComponents(namespace, applicationName);
+
+  return usePipelineRuns(
+    includeComponents ? (componentsLoaded ? namespace : null) : namespace,
     React.useMemo(
       () => ({
         selector: {
@@ -17,10 +21,21 @@ export const useTestPipelines = (
             [PipelineRunLabel.APPLICATION]: applicationName,
             [PipelineRunLabel.PIPELINE_TYPE]: PipelineRunType.TEST,
           },
+          ...(includeComponents &&
+            componentsLoaded && {
+              matchExpressions: [
+                {
+                  key: `${PipelineRunLabel.COMPONENT}`,
+                  operator: 'In',
+                  values: components?.map((c) => c.metadata?.name),
+                },
+              ],
+            }),
         },
         // arbitrary limit since this query is unbounded
-        limit: 100,
+        limit: includeComponents ? components.length : 50,
       }),
-      [applicationName],
+      [applicationName, includeComponents, components, componentsLoaded],
     ),
   ) as unknown as [PipelineRunKind[], boolean, unknown];
+};


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/RHTAPBUGS-574

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The default limit for a response in tekton results is 4mb but the lifecycle graph makes call with `100` pagesize so the response is more than the limit and fails to load the graph.

Included the component names in the query filter and also dynamically setting the pageSize based on the number of components in an application.



## Type of change
<!-- Please delete options that are not relevant. -->


- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

**Before**:

![Screenshot 2023-08-09 at 4 00 17 PM](https://github.com/openshift/hac-dev/assets/9964343/8f42644f-fea1-40d9-ad88-a88e002506c9)
![Screenshot 2023-08-09 at 4 00 27 PM](https://github.com/openshift/hac-dev/assets/9964343/6a91ed75-b99e-4f2e-899d-ede6efc569af)

**After**:

![After_fix](https://github.com/openshift/hac-dev/assets/9964343/5dbd2329-fdb8-439d-9f50-03229f201ed8)

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

Visit acm shared workspace application details page to see the graph loading.


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
