### PR TITLE
Fix namefilter in pipelinerun list page causing memory leaks

### DIFF
--- a/src/hooks/useScanResults.ts
+++ b/src/hooks/useScanResults.ts
@@ -157,7 +157,7 @@ export const usePLRScanResults = (
   const cacheKey = React.useRef('');
 
   React.useEffect(() => {
-    cacheKey.current = pipelineRunNames.sort().join('|');
+    if (pipelineRunNames.length) cacheKey.current = pipelineRunNames.sort().join('|');
   }, [pipelineRunNames]);
 
   const { namespace } = useWorkspaceInfo();
@@ -181,7 +181,9 @@ export const usePLRScanResults = (
       }),
       [pipelineRunNames],
     ),
-    cache ? `useScanResults-${pipelineRunNames.sort().join('|')}` : undefined,
+    cache && pipelineRunNames.length
+      ? `useScanResults-${pipelineRunNames.sort().join('|')}`
+      : undefined,
   );
 
   return React.useMemo(() => {

--- a/src/hooks/useScanResults.ts
+++ b/src/hooks/useScanResults.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { merge, uniq } from 'lodash-es';
+import { difference, merge, uniq } from 'lodash-es';
 import { PipelineRunLabel } from '../consts/pipelinerun';
 import { TektonResourceLabel, TaskRunKind, TektonResultsRun, PipelineRunKind } from '../types';
 import { OR } from '../utils/tekton-results';
@@ -216,7 +216,10 @@ export const usePLRVulnerabilities = (
 
   // enable cache only if the pipeline run has completed
   const [vulnerabilities, vloaded, vlist] = usePLRScanResults(
-    completePLRnames.current.slice((currentPage - 1) * pageSize, completePLRnames.current.length),
+    difference(
+      completePLRnames.current.slice((currentPage - 1) * pageSize, completePLRnames.current.length),
+      loadedPipelineRunNames.current,
+    ),
     true,
   );
   pipelineRunVulnerabilities.current = merge(

--- a/src/hooks/useTektonResults.ts
+++ b/src/hooks/useTektonResults.ts
@@ -25,6 +25,12 @@ const useTRRuns = <Kind extends K8sResourceCommon>(
   cacheKey?: string,
 ): [Kind[], boolean, unknown, GetNextPage] => {
   const [nextPageToken, setNextPageToken] = React.useState<string>(null);
+  const [localCacheKey, setLocalCacheKey] = React.useState(cacheKey);
+
+  if (cacheKey !== localCacheKey) {
+    //force update local cache key
+    setLocalCacheKey(cacheKey);
+  }
   const { workspace } = useWorkspaceInfo();
 
   const [result, setResult] = React.useState<[Kind[], boolean, unknown, GetNextPage]>([
@@ -49,7 +55,7 @@ const useTRRuns = <Kind extends K8sResourceCommon>(
             namespace,
             options,
             nextPageToken,
-            cacheKey,
+            localCacheKey,
           );
           if (!disposed) {
             const token = tkPipelineRuns[1].nextPageToken;
@@ -92,7 +98,7 @@ const useTRRuns = <Kind extends K8sResourceCommon>(
         disposed = true;
       };
     }
-  }, [workspace, namespace, options, nextPageToken, cacheKey, getRuns]);
+  }, [workspace, namespace, options, nextPageToken, localCacheKey, getRuns]);
   return result;
 };
 

--- a/src/hooks/useTektonResults.ts
+++ b/src/hooks/useTektonResults.ts
@@ -37,7 +37,7 @@ const useTRRuns = <Kind extends K8sResourceCommon>(
   // reset token if namespace or options change
   React.useEffect(() => {
     setNextPageToken(null);
-  }, [namespace, options]);
+  }, [namespace, options, cacheKey]);
 
   React.useEffect(() => {
     let disposed = false;
@@ -55,27 +55,28 @@ const useTRRuns = <Kind extends K8sResourceCommon>(
             const token = tkPipelineRuns[1].nextPageToken;
             const callInflight = !!tkPipelineRuns?.[2];
             const loaded = callInflight ? false : true;
-
-            setResult((cur) => [
-              nextPageToken ? [...cur[0], ...tkPipelineRuns[0]] : tkPipelineRuns[0],
-              loaded,
-              undefined,
-              token
-                ? (() => {
-                    // ensure we can only call this once
-                    let executed = false;
-                    return () => {
-                      if (!disposed && !executed) {
-                        executed = true;
-                        // trigger the update
-                        setNextPageToken(token);
-                        return true;
-                      }
-                      return false;
-                    };
-                  })()
-                : undefined,
-            ]);
+            if (!callInflight) {
+              setResult((cur) => [
+                nextPageToken ? [...cur[0], ...tkPipelineRuns[0]] : tkPipelineRuns[0],
+                loaded,
+                undefined,
+                token
+                  ? (() => {
+                      // ensure we can only call this once
+                      let executed = false;
+                      return () => {
+                        if (!disposed && !executed) {
+                          executed = true;
+                          // trigger the update
+                          setNextPageToken(token);
+                          return true;
+                        }
+                        return false;
+                      };
+                    })()
+                  : undefined,
+              ]);
+            }
           }
         } catch (e) {
           if (!disposed) {

--- a/src/utils/__tests__/tekton-results.spec.ts
+++ b/src/utils/__tests__/tekton-results.spec.ts
@@ -16,6 +16,8 @@ import {
   OR,
   RecordsList,
   getTaskRunLog,
+  nameFilter,
+  selectorToFilter,
 } from '../tekton-results';
 
 jest.mock('@openshift/dynamic-plugin-sdk-utils');
@@ -180,6 +182,50 @@ describe('tekton-results', () => {
       ).toStrictEqual('data.metadata.labels["test"] != "a" && data.metadata.labels["test"] != "b"');
     });
 
+    describe('selectorToFilter', () => {
+      it('should return the name filters', () => {
+        expect(
+          selectorToFilter({
+            filterByName: 'resource-name',
+          }),
+        ).toStrictEqual('data.metadata.labels["filterByName"] == "resource-name"');
+      });
+
+      it('should return the label filter', () => {
+        expect(
+          selectorToFilter({
+            matchLabels: {
+              'test-label': 'resource-label',
+            },
+          }),
+        ).toStrictEqual('data.metadata.labels["test-label"] == "resource-label"');
+      });
+
+      it('should return the expression filter', () => {
+        expect(
+          selectorToFilter({
+            matchExpressions: [
+              {
+                key: 'names',
+                operator: 'In',
+                values: ['resource-name-1', 'resource-name-2'],
+              },
+            ],
+          }),
+        ).toStrictEqual('data.metadata.labels["names"] in ["resource-name-1","resource-name-2"]');
+      });
+    });
+
+    describe('nameFilter', () => {
+      it('should return the name filter', () => {
+        expect(nameFilter('test-resource-name')).toStrictEqual(
+          'data.metadata.name.startsWith("test-resource-name")',
+        );
+        expect(nameFilter('TEST-RESOURCE-name')).toStrictEqual(
+          'data.metadata.name.startsWith("test-resource-name")',
+        );
+      });
+    });
     it('should convert In operator', () => {
       expect(
         expressionsToFilter([

--- a/src/utils/tekton-results.ts
+++ b/src/utils/tekton-results.ts
@@ -85,6 +85,9 @@ export const labelsToFilter = (labels?: MatchLabels): string =>
       )
     : '';
 
+export const nameFilter = (name?: string): string =>
+  name ? AND(`data.metadata.name.startsWith("${name.trim().toLowerCase()}")`) : '';
+
 export const expressionsToFilter = (expressions: Omit<MatchExpression, 'value'>[]): string =>
   AND(
     ...expressions
@@ -137,7 +140,12 @@ export const expressionsToFilter = (expressions: Omit<MatchExpression, 'value'>[
 export const selectorToFilter = (selector?: Selector) => {
   let filter = '';
   if (selector) {
-    const { matchLabels, matchExpressions } = selector;
+    const { matchLabels, matchExpressions, filterByName } = selector;
+
+    if (filterByName) {
+      filter = AND(filter, nameFilter(filterByName as string));
+    }
+
     if (matchLabels || matchExpressions) {
       if (matchLabels) {
         filter = AND(filter, labelsToFilter(matchLabels));


### PR DESCRIPTION

## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/RHTAPBUGS-578
https://issues.redhat.com/browse/RHTAPBUGS-584 

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

when a user tries to use the name filter the browser goes unresponsive.



## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


https://github.com/openshift/hac-dev/assets/9964343/540297c1-463b-48d1-a5fa-f5911d9f38f0

https://github.com/openshift/hac-dev/assets/9964343/aa8bd028-1073-45ce-a8a2-89c04b3852a6

Commit pipelineruns tab:

![image](https://github.com/openshift/hac-dev/assets/9964343/73674080-e7b8-4f41-9063-0ecf48d2de52)


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

