### PR TITLE
Fix create button flickering after component detection

### DIFF
--- a/src/components/ImportForm/GitImportActions.tsx
+++ b/src/components/ImportForm/GitImportActions.tsx
@@ -31,7 +31,6 @@ const GitImportActions: React.FunctionComponent<GitImportActionsProps> = ({
     isValid,
     dirty,
     isSubmitting,
-    isValidating,
     setErrors,
     handleSubmit,
   } = useFormikContext<ImportFormValues>();
@@ -54,8 +53,8 @@ const GitImportActions: React.FunctionComponent<GitImportActionsProps> = ({
             <Button
               type="submit"
               onClick={() => handleSubmit()}
-              isDisabled={!isValid || !dirty || isSubmitting || isValidating}
-              isLoading={isSubmitting || isValidating}
+              isDisabled={!isValid || !dirty || isSubmitting}
+              isLoading={isSubmitting}
             >
               {reviewMode ? (inAppContext ? 'Add component' : 'Create application') : 'Import code'}
             </Button>


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
- https://issues.redhat.com/browse/RHTAPBUGS-583

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- `isValidating` gets updated multiple times as soon as detected components are added to formik values. We don't need to disable the submit button while validating because there's no async validation happening on the form.

## Type of change
<!-- Please delete options that are not relevant. -->


- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before ---

https://github.com/openshift/hac-dev/assets/6041994/01b19de9-2752-4b4d-946d-91aa57825de5


After ---

https://github.com/openshift/hac-dev/assets/6041994/9cd9ffb5-34c9-48a3-944c-cb1b62fce833



## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
