### PR TITLE
e2e: Remove the xpath plugin and update the tests

### DIFF
--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -8,7 +8,6 @@
       "name": "@hac-dev/integration-tests",
       "version": "0.0.1",
       "devDependencies": {
-        "@cypress/xpath": "^2.0.3",
         "@reportportal/agent-js-cypress": "^5.1.2",
         "@types/fs-extra": "^9.0.13",
         "@types/node": "^17.0.13",
@@ -101,13 +100,6 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
-    },
-    "node_modules/@cypress/xpath": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@cypress/xpath/-/xpath-2.0.3.tgz",
-      "integrity": "sha512-Seilxmws+yty5lZSbwbjEOOiEbr7O1bCxKy2FC4jwMssC22yjByb5orDfBZPLZXYfmWZafJjvZFwts4Q3CzQAg==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true
     },
     "node_modules/@cypress/xvfb": {
       "version": "1.2.4",
@@ -4624,12 +4616,6 @@
           "dev": true
         }
       }
-    },
-    "@cypress/xpath": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@cypress/xpath/-/xpath-2.0.3.tgz",
-      "integrity": "sha512-Seilxmws+yty5lZSbwbjEOOiEbr7O1bCxKy2FC4jwMssC22yjByb5orDfBZPLZXYfmWZafJjvZFwts4Q3CzQAg==",
-      "dev": true
     },
     "@cypress/xvfb": {
       "version": "1.2.4",

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -9,7 +9,6 @@
     "cy:open": "cypress open"
   },
   "devDependencies": {
-    "@cypress/xpath": "^2.0.3",
     "@reportportal/agent-js-cypress": "^5.1.2",
     "@types/fs-extra": "^9.0.13",
     "@types/node": "^17.0.13",

--- a/integration-tests/support/commands/index.ts
+++ b/integration-tests/support/commands/index.ts
@@ -27,5 +27,4 @@ const logOptions = {
   enableExtendedCollector: true,
 };
 require('cypress-terminal-report/src/installLogsCollector')(logOptions);
-require('@cypress/xpath');
 initPerfMeasuring('cypress/perfstats.json');

--- a/integration-tests/support/pageObjects/global-po.ts
+++ b/integration-tests/support/pageObjects/global-po.ts
@@ -53,4 +53,9 @@ export const UIhelperPO = {
   graphNode: 'g[data-kind="node"]',
   pipelineStatusSuccess: 'g[class="pf-topology-pipelines__pill-status pf-m-success"]',
   pipelineNode: 'g[class^="pf-topology__pipelines__task-node"]',
+  tabs: 'div[data-ouia-component-type="PF4/Tabs"] button span',
+  formGroup: 'div.pf-c-form__group',
+  formGroupLabelText: 'div.pf-c-form__group span.pf-c-form__label-text',
+  listGroup_dt: 'div[class*="list__group"] dt',
+  pf4_button: '[data-ouia-component-type="PF4/Button"]',
 };

--- a/integration-tests/tsconfig.json
+++ b/integration-tests/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
       "target": "es5",
       "lib": ["es5", "dom"],
-      "types": ["cypress", "node", "cypress-axe", "@cypress/xpath"]
+      "types": ["cypress", "node", "cypress-axe"]
     },
     "include": ["./**/*.ts"]
   }

--- a/integration-tests/utils/UIhelper.ts
+++ b/integration-tests/utils/UIhelper.ts
@@ -3,17 +3,17 @@ import { Common } from './Common';
 
 export class UIhelper {
   static clickTab(tabName: string) {
-    cy.xpath(
-      `//div[@data-ouia-component-type="PF4/Tabs"]//button[child::span[text()='${tabName}']]`,
-    ).click();
+    cy.contains(UIhelperPO.tabs, new RegExp(`^\\s*${tabName}\\s*$`)).click();
     Common.waitForLoad();
   }
 
   static inputValueInTextBoxByLabelName(label: string, value: string) {
     return cy
-      .xpath(
-        `//div[contains(@class,"pf-c-form__group") and descendant::*[text()='${label}']]//input`,
-      )
+      .contains(UIhelperPO.formGroupLabelText, new RegExp(`^\\s*${label}\\s*$`))
+      .parentsUntil(UIhelperPO.formGroup)
+      .eq(-1)
+      .parent()
+      .find('input')
       .clear()
       .type(value);
   }
@@ -28,35 +28,31 @@ export class UIhelper {
   static verifyLabelAndValue(label: string, value: string) {
     cy.log(`Validate Label : "${label}" should have value : "${value}"`);
     return cy
-      .xpath(
-        `//div[contains(@class,"list__group") and descendant::dt//*[text()="${label}"]]/dd//*[text()="${value}"]`,
-      )
+      .contains(UIhelperPO.listGroup_dt, new RegExp(`^\\s*${label}\\s*$`))
+      .siblings('dd')
+      .contains(new RegExp(`^\\s*${value}\\s*$`))
       .scrollIntoView()
       .should('be.visible');
   }
 
   static clickButton(label: string, options?: { invoke?: boolean; force?: boolean }) {
     if (options?.invoke) {
-      return cy
-        .xpath(`//*[@data-ouia-component-type="PF4/Button" and text()='${label}']`)
-        .invoke('click');
+      return cy.contains(UIhelperPO.pf4_button, new RegExp(`^\\s*${label}\\s*$`)).invoke('click');
     } else if (options?.force) {
       return cy
-        .xpath(`//*[@data-ouia-component-type="PF4/Button" and text()='${label}']`)
+        .contains(UIhelperPO.pf4_button, new RegExp(`^\\s*${label}\\s*$`))
         .click({ force: true });
     }
-
-    return cy.xpath(`//*[@data-ouia-component-type="PF4/Button" and text()='${label}']`).click();
+    return cy.contains(UIhelperPO.pf4_button, new RegExp(`^\\s*${label}\\s*$`)).click();
   }
 
   static clickLink(link: string, options?: { invoke?: boolean; force?: boolean }) {
     if (options?.invoke) {
-      return cy.xpath(`//a[text()='${link}']`).invoke('click');
+      return cy.contains('a', new RegExp(`^\\s*${link}\\s*$`)).invoke('click');
     } else if (options?.force) {
-      return cy.xpath(`//a[text()='${link}']`).click({ force: true });
+      return cy.contains('a', new RegExp(`^\\s*${link}\\s*$`)).click({ force: true });
     }
-
-    return cy.xpath(`//a[text()='${link}']`).click();
+    return cy.contains('a', new RegExp(`^\\s*${link}\\s*$`)).click();
   }
 
   static getTableRow(tableAriaLabel: string, uniqueRowText: string | RegExp) {


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/HAC-4758

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
As cypress has officially removed the support for xpath plugin remove the deprecated xpath plugin from all the e2e tests.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Test

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
