### PR TITLE
Fix broken styles on overview page

### DIFF
--- a/src/pages/OverviewPage.tsx
+++ b/src/pages/OverviewPage.tsx
@@ -6,6 +6,11 @@ import InfoBanner from '../components/Overview/InfoBanner';
 import IntroBanner from '../components/Overview/IntroBanner';
 import { FULL_APPLICATION_TITLE } from '../consts/labels';
 
+// PF 5 CSS
+// TODO: Remove when console is at PF 5
+import '@patternfly/patternfly/patternfly.css';
+import '@patternfly/patternfly/patternfly-addons.css';
+
 const OverviewPage: React.FC = () => {
   return (
     <>


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
- https://issues.redhat.com/browse/RHTAPBUGS-734

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- The overview page doesn't use `NamespacePage` which loads PF styles.
- Pulling PF styles now in overview page as well.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
Before - 
<img width="2560" alt="Screenshot 2023-08-28 at 3 58 54 PM" src="https://github.com/openshift/hac-dev/assets/6041994/37e1e39d-fabd-403c-81a7-0491d4e6240d">

After - 
<img width="2560" alt="Screenshot 2023-08-28 at 4 06 37 PM" src="https://github.com/openshift/hac-dev/assets/6041994/1a98950f-d77a-4096-89cb-0a335fa5a932">


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
