### PR TITLE
use RemoteSecret for creating partner task secrets

### DIFF
--- a/src/components/ComponentSettingsForm/__tests__/ComponentSettingsView.spec.tsx
+++ b/src/components/ComponentSettingsForm/__tests__/ComponentSettingsView.spec.tsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom';
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { render, screen } from '@testing-library/react';
 import { useApplications } from '../../../hooks/useApplications';
+import { useRemoteSecrets } from '../../../hooks/UseRemoteSecrets';
 import { componentCRMocks, mockApplication } from '../../ApplicationDetails/__data__/mock-data';
 import ComponentSettingsView from '../ComponentSettingsView';
 
@@ -36,12 +37,18 @@ jest.mock('../../../utils/rbac', () => ({
   useAccessReviewForModel: jest.fn(() => [true, true]),
 }));
 
+jest.mock('../../../hooks/UseRemoteSecrets', () => ({
+  useRemoteSecrets: jest.fn(),
+}));
+
 const watchResourceMock = useK8sWatchResource as jest.Mock;
 const useApplicationsMock = useApplications as jest.Mock;
+const useRemoteSecretsMock = useRemoteSecrets as jest.Mock;
 
 describe('ComponentSettingsView', () => {
   beforeEach(() => {
     useApplicationsMock.mockReturnValue([[mockApplication], true]);
+    useRemoteSecretsMock.mockReturnValue([[], true]);
   });
   it('should render spinner if component data is not loaded', () => {
     watchResourceMock.mockReturnValue([{}, false]);

--- a/src/shared/components/formik-fields/key-value-file-input-field/KeyValueFileInputField.tsx
+++ b/src/shared/components/formik-fields/key-value-file-input-field/KeyValueFileInputField.tsx
@@ -80,7 +80,7 @@ const KeyValueFileInputField: React.FC<KeyValueEntryFormProps & FieldProps> = ({
                     name={`${name}.${idx.toString()}.key`}
                     label="Key"
                     required
-                    isReadOnly={v.readOnlyKey}
+                    isDisabled={v.readOnlyKey}
                   />
                 </FlexItem>
                 <FlexItem>

--- a/src/types/secret.ts
+++ b/src/types/secret.ts
@@ -2,7 +2,6 @@ import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
 import { ImportSecret } from '../components/ImportForm/utils/types';
 
 export const SecretByUILabel = 'ui.appstudio.redhat.com/secret-for';
-export const SNYK_SPI_TOKEN_ACCESS_BINDING = 'spi-access-token-binding-for-snyk-secret';
 
 export enum SecretFor {
   deployment = 'Deployment',

--- a/src/utils/create-utils.ts
+++ b/src/utils/create-utils.ts
@@ -12,12 +12,7 @@ import {
   THUMBNAIL_ANNOTATION,
 } from '../components/ApplicationDetails/ApplicationThumbnail';
 import { ImportSecret } from '../components/ImportForm/utils/types';
-import {
-  PartnerTask,
-  createRemoteSecretResource,
-  createSecretResource,
-  supportedPartnerTasksSecrets,
-} from '../components/Secrets/secret-utils';
+import { createRemoteSecretResource } from '../components/Secrets/secret-utils';
 import {
   ApplicationModel,
   ComponentModel,
@@ -32,7 +27,6 @@ import {
   SPIAccessTokenBindingKind,
   K8sSecretType,
   SecretTypeDropdownLabel,
-  SNYK_SPI_TOKEN_ACCESS_BINDING,
 } from '../types';
 import { ComponentSpecs } from './../types/component';
 import { BuildRequest, BUILD_REQUEST_ANNOTATION } from './component-utils';
@@ -294,85 +288,12 @@ export const initiateAccessTokenBinding = async (url: string, namespace: string)
   return createAccessTokenBinding(url, namespace);
 };
 
-export const createSupportedPartnerSecret = async (
-  partnerTask: PartnerTask,
-  secret: ImportSecret,
-  namespace: string,
-  dryRun: boolean,
-) => {
-  const spiTokenName = SNYK_SPI_TOKEN_ACCESS_BINDING;
-  const resourcePromises = [];
-  const secretName = `tmp-upload-secret-`;
-  const secretResource = {
-    apiVersion: 'v1',
-    kind: 'Secret',
-    metadata: {
-      generateName: secretName,
-      namespace,
-      labels: {
-        'spi.appstudio.redhat.com/upload-secret': 'token',
-        'spi.appstudio.redhat.com/token-name': spiTokenName,
-      },
-    },
-    type: 'Opaque',
-    data: {},
-    stringData: {
-      spiTokenName,
-      userName: 'my-username', // username field is a required field, so any random name needs to be passed.
-      providerUrl: partnerTask.providerUrl,
-      tokenData: secret.keyValues.find((s) => s.key === partnerTask.tokenKeyName)?.value || '',
-    },
-  };
-
-  resourcePromises.push(createSecretResource(secretResource, namespace, dryRun));
-
-  const spiAccessTokenBinding = {
-    apiVersion: `${SPIAccessTokenBindingModel.apiGroup}/${SPIAccessTokenBindingModel.apiVersion}`,
-    kind: SPIAccessTokenBindingModel.kind,
-    metadata: {
-      name: `spi-access-token-binding-for-${secret.secretName}`,
-      namespace,
-    },
-    spec: {
-      repoUrl: partnerTask.providerUrl,
-      lifetime: '-1',
-      secret: {
-        type: 'Opaque',
-        name: secret.secretName,
-        fields: {
-          token: partnerTask.tokenKeyName,
-        },
-      },
-    },
-  };
-
-  resourcePromises.push(
-    k8sCreateResource({
-      model: SPIAccessTokenBindingModel,
-      queryOptions: {
-        name: spiAccessTokenBinding.metadata.name,
-        ns: namespace,
-        ...(dryRun && { queryParams: { dryRun: 'All' } }),
-      },
-      resource: spiAccessTokenBinding,
-    }),
-  );
-  return Promise.all(resourcePromises);
-};
-
 export const createSecret = async (
   secret: ImportSecret,
   workspace: string,
   namespace: string,
   dryRun: boolean,
 ) => {
-  const partnerTask = Object.values(supportedPartnerTasksSecrets).find(
-    (s) => s.name === secret.secretName,
-  );
-  if (partnerTask) {
-    return createSupportedPartnerSecret(partnerTask, secret, namespace, dryRun);
-  }
-
   const secretResource = {
     apiVersion: SecretModel.apiVersion,
     kind: SecretModel.kind,
@@ -393,31 +314,21 @@ export const createSecret = async (
     }, {}),
   };
 
-  const promiseArray = [];
-  // Create RemoteSecrets
-  promiseArray.push(
-    createRemoteSecretResource(
-      secretResource,
-      namespace,
-      secret.type === SecretTypeDropdownLabel.image,
-      dryRun,
-    ),
+  await createRemoteSecretResource(
+    secretResource,
+    namespace,
+    secret.type === SecretTypeDropdownLabel.image,
+    dryRun,
   );
 
   //Todo: K8sCreateResource appends the resource name and errors out.
   // Fix the below code when this sdk-utils issue is resolved https://issues.redhat.com/browse/RHCLOUD-21655.
-  promiseArray.push(
-    commonFetch(
-      `/workspaces/${workspace}/api/v1/namespaces/${namespace}/secrets${
-        dryRun ? '?dryRun=All' : ''
-      }`,
-      {
-        method: 'POST',
-        body: JSON.stringify(secretResource),
-        headers: { 'Content-type': 'application/json' },
-      },
-    ),
+  return await commonFetch(
+    `/workspaces/${workspace}/api/v1/namespaces/${namespace}/secrets${dryRun ? '?dryRun=All' : ''}`,
+    {
+      method: 'POST',
+      body: JSON.stringify(secretResource),
+      headers: { 'Content-type': 'application/json' },
+    },
   );
-
-  return Promise.all(promiseArray);
 };


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-4696

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Use remoteSecrets while creating partner secrets like snyk, so that the partner secrets will be listed in the secrets list view.

This PR Replaces the spiAccessTokenBindings with RemoteSecret CR

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

No UI changes. Once the build secret is created you should see the secret in the listing page.

<img width="1489" alt="Screenshot 2023-08-31 at 4 53 47 PM" src="https://github.com/openshift/hac-dev/assets/9964343/5694b66c-4b89-4f5f-a108-1c6d57ede5dc">


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

1. Edit a component -> Add secret -> Save.
2. Go to Secret list page and search the created build secret.

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

/cc @rohitkrai03 @rottencandy 