### PR TITLE
Add Deployments tab to the Component Details page

### DIFF
--- a/src/components/Components/ComponentDeployments/ComponentDeploymentsListHeader.tsx
+++ b/src/components/Components/ComponentDeployments/ComponentDeploymentsListHeader.tsx
@@ -1,0 +1,34 @@
+export const componentDeploymentsColumnClasses = {
+  environment: 'pf-m-width-30 wrap-column',
+  componentDeployed: 'pf-m-width-20',
+  snapshot: 'pf-m-width-20',
+  vulnerabilities: 'pf-m-width-20',
+  logs: 'pf-c-table__action',
+};
+
+const ComponentDeploymentsListHeader = () => {
+  return [
+    {
+      title: 'Environment',
+      props: { className: componentDeploymentsColumnClasses.environment },
+    },
+    {
+      title: 'Component deployed',
+      props: { className: componentDeploymentsColumnClasses.componentDeployed },
+    },
+    {
+      title: 'Snapshot',
+      props: { className: componentDeploymentsColumnClasses.snapshot },
+    },
+    {
+      title: 'Vulnerabilities',
+      props: { className: componentDeploymentsColumnClasses.vulnerabilities },
+    },
+    {
+      title: '',
+      props: { className: componentDeploymentsColumnClasses.logs },
+    },
+  ];
+};
+
+export default ComponentDeploymentsListHeader;

--- a/src/components/Components/ComponentDeployments/ComponentDeploymentsListRow.scss
+++ b/src/components/Components/ComponentDeployments/ComponentDeploymentsListRow.scss
@@ -1,0 +1,5 @@
+@import '../../../shared/style/vars';
+
+.component-deploy-list--dim {
+  color: $color-text-muted;
+}

--- a/src/components/Components/ComponentDeployments/ComponentDeploymentsListRow.tsx
+++ b/src/components/Components/ComponentDeployments/ComponentDeploymentsListRow.tsx
@@ -1,0 +1,131 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { useComponentDeployment } from '../../../hooks/useComponentDeployment';
+import { getScanResults } from '../../../hooks/useScanResults';
+import { useTaskRuns } from '../../../hooks/useTaskRuns';
+import { RowFunctionArgs, TableData } from '../../../shared';
+import CommitLabel from '../../../shared/components/commit-label/CommitLabel';
+import ExternalLink from '../../../shared/components/links/ExternalLink';
+import { EnvironmentKind } from '../../../types';
+import { getComponentRouteWebURL } from '../../../utils/route-utils';
+import { useWorkspaceInfo } from '../../../utils/workspace-context-utils';
+import { ScanStatus } from '../../PipelineRunListView/ScanStatus';
+import PodLogsButton from '../../PodLogs/PodLogsButton';
+import { componentDeploymentsColumnClasses } from './ComponentDeploymentsListHeader';
+
+import './ComponentDeploymentsListRow.scss';
+
+type ScanResultsColumnProps = {
+  namespace: string;
+  pipelineRunName: string;
+};
+
+const ScanResultsColumn: React.FC<ScanResultsColumnProps> = ({ namespace, pipelineRunName }) => {
+  const [taskRuns, taskRunsLoaded] = useTaskRuns(namespace, pipelineRunName);
+  const [scanResults] = taskRunsLoaded ? getScanResults(taskRuns) : [undefined];
+
+  return <ScanStatus scanResults={scanResults} />;
+};
+
+const ComponentDeploymentsListRow: React.FC<RowFunctionArgs<EnvironmentKind>> = ({
+  obj: environment,
+  customData,
+}) => {
+  const { workspace, namespace } = useWorkspaceInfo();
+  const { component, snapshotEBs, commit, pipelineRunName, routes } = customData;
+  const application = component.spec.application;
+
+  const snapshotEB = React.useMemo(
+    () =>
+      snapshotEBs
+        ? snapshotEBs.find(
+            (seb) =>
+              seb.spec.components?.find((c) => c.name === component.spec.componentName) &&
+              seb.metadata.labels?.['appstudio.environment'] === environment.metadata.name,
+          )
+        : [],
+    [component.spec.componentName, environment.metadata.name, snapshotEBs],
+  );
+
+  const isDevEnv = environment.metadata?.name === 'development';
+
+  const [deployment, deploymentLoaded, deploymentLoadError] = useComponentDeployment(
+    namespace,
+    component.metadata.name,
+    snapshotEB,
+  );
+
+  const podSelector = React.useMemo(
+    () => isDevEnv && !deploymentLoadError && deploymentLoaded && deployment?.spec?.selector,
+    [isDevEnv, deploymentLoadError, deploymentLoaded, deployment?.spec?.selector],
+  );
+  const routeURL = isDevEnv ? getComponentRouteWebURL(routes, component.metadata.name) : null;
+
+  return (
+    <>
+      <TableData
+        data-testid="environment-cell"
+        className={componentDeploymentsColumnClasses.environment}
+      >
+        <Link
+          to={`/application-pipeline/workspaces/${workspace}/applications/${component.spec.application}/deployments?name=${environment.metadata?.name}`}
+        >
+          {environment?.spec.displayName || environment?.metadata?.name}
+        </Link>
+        <div>
+          {routeURL ? (
+            <ExternalLink href={routeURL}>{routeURL}</ExternalLink>
+          ) : (
+            <div className="component-deploy-list--dim">No URL for this component.</div>
+          )}
+        </div>
+      </TableData>
+      <TableData className={componentDeploymentsColumnClasses.componentDeployed}>
+        {commit ? (
+          <>
+            <Link
+              to={`/application-pipeline/workspaces/${workspace}/applications/${commit.application}/commit/${commit.sha}`}
+            >
+              {commit.isPullRequest ? `#${commit.pullRequestNumber}` : ''} {commit.shaTitle}
+            </Link>
+            {commit.shaURL && (
+              <>
+                {' '}
+                <CommitLabel
+                  gitProvider={commit.gitProvider}
+                  sha={commit.sha}
+                  shaURL={commit.shaURL}
+                />
+              </>
+            )}
+          </>
+        ) : (
+          '-'
+        )}
+      </TableData>
+      <TableData className={componentDeploymentsColumnClasses.snapshot}>
+        {snapshotEB ? (
+          <Link
+            to={`/application-pipeline/workspaces/${workspace}/applications/${application}/snapshots/${snapshotEB.spec.snapshot}`}
+          >
+            {snapshotEB.spec.snapshot}
+          </Link>
+        ) : (
+          '-'
+        )}
+      </TableData>
+      <TableData className={componentDeploymentsColumnClasses.vulnerabilities}>
+        {isDevEnv ? (
+          <ScanResultsColumn namespace={namespace} pipelineRunName={pipelineRunName} />
+        ) : (
+          '-'
+        )}
+      </TableData>
+      <TableData className={componentDeploymentsColumnClasses.logs}>
+        <PodLogsButton component={component} podSelector={podSelector} showDisabled />
+      </TableData>
+    </>
+  );
+};
+
+export default ComponentDeploymentsListRow;

--- a/src/components/Components/ComponentDeployments/ComponentDeploymentsListView.tsx
+++ b/src/components/Components/ComponentDeployments/ComponentDeploymentsListView.tsx
@@ -1,0 +1,136 @@
+import * as React from 'react';
+import {
+  SearchInput,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+  EmptyStateBody,
+} from '@patternfly/react-core';
+import { useAllEnvironments } from '../../../hooks/useAllEnvironments';
+import { useApplicationRoutes } from '../../../hooks/useApplicationRoutes';
+import { useLatestSuccessfulBuildPipelineRunForComponent } from '../../../hooks/usePipelineRuns';
+import { useSearchParam } from '../../../hooks/useSearchParam';
+import { useSnapshotsEnvironmentBindings } from '../../../hooks/useSnapshotsEnvironmentBindings';
+import emptyStateImgUrl from '../../../imgs/Commit.svg';
+import { Table } from '../../../shared';
+import AppEmptyState from '../../../shared/components/empty-state/AppEmptyState';
+import FilteredEmptyState from '../../../shared/components/empty-state/FilteredEmptyState';
+import { ComponentKind } from '../../../types';
+import { getCommitsFromPLRs } from '../../../utils/commits-utils';
+import { useWorkspaceInfo } from '../../../utils/workspace-context-utils';
+import ComponentDeploymentsListHeader from './ComponentDeploymentsListHeader';
+import ComponentDeploymentsListRow from './ComponentDeploymentsListRow';
+
+type DeploymentsToolbarProps = {
+  nameFilter: string;
+  onNameInput: (value: string) => void;
+};
+
+const DeploymentsToolbar: React.FC<DeploymentsToolbarProps> = React.memo(
+  ({ nameFilter, onNameInput }) => (
+    <Toolbar data-test="commit-list-toolbar" clearAllFilters={() => onNameInput('')}>
+      <ToolbarContent>
+        <ToolbarGroup align={{ default: 'alignLeft' }}>
+          <ToolbarItem className="pf-u-ml-0">
+            <SearchInput
+              name="nameInput"
+              data-test="name-input-filter"
+              type="search"
+              aria-label="name filter"
+              placeholder="Filter by name..."
+              onChange={(e, name) => onNameInput(name)}
+              value={nameFilter}
+            />
+          </ToolbarItem>
+        </ToolbarGroup>
+      </ToolbarContent>
+    </Toolbar>
+  ),
+);
+
+interface ComponentDeploymentsListViewProps {
+  component: ComponentKind;
+}
+
+const ComponentDeploymentsListView: React.FC<ComponentDeploymentsListViewProps> = ({
+  component,
+}) => {
+  const { namespace } = useWorkspaceInfo();
+  const [nameFilter, setNameFilter] = useSearchParam('name', '');
+  const application = component.spec.application;
+  const [environments, environmentsLoaded] = useAllEnvironments();
+  const [snapshotEBs, sebLoaded] = useSnapshotsEnvironmentBindings(namespace, application);
+  const [routes, routesLoaded] = useApplicationRoutes(application);
+
+  const [pipelineRun, pipelineRunLoaded] = useLatestSuccessfulBuildPipelineRunForComponent(
+    namespace,
+    component.metadata.name,
+  );
+  const commit = React.useMemo(
+    () => ((pipelineRunLoaded && pipelineRun && getCommitsFromPLRs([pipelineRun], 1)) || [])[0],
+    [pipelineRunLoaded, pipelineRun],
+  );
+
+  const loaded = sebLoaded && environmentsLoaded && pipelineRunLoaded && routesLoaded;
+
+  const filteredEnvironments = React.useMemo(
+    () =>
+      environments
+        ? environments.filter(
+            (environment) =>
+              !nameFilter ||
+              (environment.spec?.displayName || environment.metadata?.name)
+                .toLowerCase()
+                .indexOf(nameFilter.toLowerCase()) !== -1,
+          )
+        : [],
+    [environments, nameFilter],
+  );
+
+  return (
+    <div data-testid="component-deployments-list-view">
+      {loaded && (!environments || environments.length === 0) ? (
+        <AppEmptyState
+          emptyStateImg={emptyStateImgUrl}
+          title="Monitor the component builds that are currently deployed to your environments."
+        >
+          <EmptyStateBody>
+            Monitor any activity that happens once you push a commit. We’ll build and test your
+            source code, for both pull requests and merged code.
+            <br />
+            To get started, add a component and merge its pull request for a build pipeline.
+          </EmptyStateBody>
+        </AppEmptyState>
+      ) : (
+        <>
+          <DeploymentsToolbar nameFilter={nameFilter} onNameInput={setNameFilter} />
+          {filteredEnvironments.length > 0 || !loaded ? (
+            <Table
+              data-testid="test-test-test"
+              data={filteredEnvironments}
+              aria-label="Deployments List"
+              Header={ComponentDeploymentsListHeader}
+              Row={ComponentDeploymentsListRow}
+              loaded={loaded}
+              customData={{
+                component,
+                snapshotEBs,
+                commit,
+                pipelineRunName: pipelineRun?.metadata?.name,
+                routes,
+              }}
+              getRowProps={(obj) => ({
+                id: obj.sha,
+              })}
+            />
+          ) : (
+            <FilteredEmptyState onClearFilters={() => setNameFilter('')} />
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default ComponentDeploymentsListView;

--- a/src/components/Components/ComponentDeployments/__tests__/ComponentDeploymentsListRow.spec.tsx
+++ b/src/components/Components/ComponentDeployments/__tests__/ComponentDeploymentsListRow.spec.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { configure } from '@testing-library/react';
+import { GitOpsDeploymentGroupVersionKind } from '../../../../models';
+import { routerRenderer } from '../../../../utils/test-utils';
+import { mockCommits } from '../../../Commits/__data__/pipeline-with-commits';
+import {
+  mockComponent,
+  mockEnvironments,
+  mockSnapshotEBs,
+  mockTaskRuns,
+  mockRoutes,
+  mockGitOpsDeploymentCRs,
+} from '../../ComponentDetails/__data__/mockComponentDetails';
+import ComponentDeploymentsListRow from '../ComponentDeploymentsListRow';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  useK8sWatchResource: jest.fn(),
+  getActiveWorkspace: jest.fn(() => 'test-ws'),
+}));
+
+jest.mock('../../../../utils/workspace-context-utils', () => ({
+  useWorkspaceInfo: jest.fn(() => ({ namespace: 'test-ns', workspace: 'test-ws' })),
+}));
+
+const watchResourceMock = useK8sWatchResource as jest.Mock;
+
+configure({ testIdAttribute: 'data-testid' });
+
+describe('ComponentDeploymentsListRow', () => {
+  let customData;
+
+  beforeEach(() => {
+    watchResourceMock.mockImplementation(({ groupVersionKind, isList }) => {
+      if (groupVersionKind === GitOpsDeploymentGroupVersionKind) {
+        return [mockGitOpsDeploymentCRs, true];
+      }
+      if (isList) {
+        return [[], true];
+      }
+      return [{}, true];
+    });
+    customData = {
+      component: mockComponent,
+      snapshotEBs: mockSnapshotEBs,
+      commit: mockCommits[0],
+      taskRuns: mockTaskRuns,
+      routes: mockRoutes,
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the environment and route', () => {
+    const wrapper = routerRenderer(
+      <ComponentDeploymentsListRow
+        obj={mockEnvironments[0]}
+        columns={[]}
+        customData={customData}
+      />,
+      {
+        container: document.createElement('tr'),
+      },
+    );
+    const cells = wrapper.container.getElementsByTagName('td');
+    expect(cells.length).toEqual(5);
+
+    expect(cells[0].children[0].innerHTML).toEqual(mockEnvironments[0]?.spec.displayName);
+    const routeLink = cells[0].children[1].children[0] as HTMLElement;
+    expect(routeLink.getAttribute('href')).toBe(
+      'https://nodejs-test.apps.appstudio-stage.x99m.p1.openshiftapps.com',
+    );
+    const commitLink = cells[1].children[0] as HTMLElement;
+    expect(commitLink.getAttribute('href')).toBe(
+      '/application-pipeline/workspaces/test-ws/applications/sample-application/commit/comm0123456789abcdefghijklmnopqrstuvwxyz',
+    );
+    const snapshotLink = cells[2].children[0] as HTMLElement;
+    expect(snapshotLink.getAttribute('href')).toBe(
+      '/application-pipeline/workspaces/test-ws/applications/test-application/snapshots/test-application-xrvgq',
+    );
+  });
+});

--- a/src/components/Components/ComponentDetails/ComponentDetailsView.tsx
+++ b/src/components/Components/ComponentDetails/ComponentDetailsView.tsx
@@ -22,6 +22,7 @@ import { GettingStartedCard } from '../../GettingStartedCard/GettingStartedCard'
 import { useModalLauncher } from '../../modal/ModalProvider';
 import { componentDeleteModal } from '../../modal/resource-modals';
 import { ComponentActivityTab } from './tabs/ComponentActivityTab';
+import { ComponentDeploymentsTab } from './tabs/ComponentDeploymentsTab';
 import ComponentDetailsTab from './tabs/ComponentDetailsTab';
 
 import './ComponentDetailsView.scss';
@@ -148,6 +149,11 @@ const ComponentDetailsView: React.FC<ComponentDetailsViewProps> = ({
             key: 'activity',
             label: 'Activity',
             component: <ComponentActivityTab component={component} />,
+          },
+          {
+            key: 'deployments',
+            label: 'Deployments',
+            component: <ComponentDeploymentsTab component={component} />,
           },
         ]}
       />

--- a/src/components/Components/ComponentDetails/__data__/mockComponentDetails.ts
+++ b/src/components/Components/ComponentDetails/__data__/mockComponentDetails.ts
@@ -1,4 +1,4 @@
-import { ComponentKind } from '../../../../types';
+import { ComponentKind, RouteKind } from '../../../../types';
 
 export const mockComponent: ComponentKind = {
   apiVersion: 'appstudio.redhat.com/v1alpha1',
@@ -7566,3 +7566,118 @@ export const mockDeployment = {
     ],
   },
 };
+
+export const mockRoutes: RouteKind[] = [
+  {
+    apiVersion: 'route.openshift.io/v1',
+    kind: 'Route',
+    metadata: {
+      annotations: {
+        'kubectl.kubernetes.io/last-applied-configuration':
+          '{"apiVersion":"route.openshift.io/v1","kind":"Route","metadata":{"annotations":{},"creationTimestamp":null,"labels":{"app.kubernetes.io/created-by":"application-service","app.kubernetes.io/instance":"gitopsdepl-f56e3027-168b-43cf-aa3a-99d784d69b05","app.kubernetes.io/managed-by":"kustomize","app.kubernetes.io/name":"nodejs","app.kubernetes.io/part-of":"new-application"},"name":"nodejs","namespace":"rorai"},"spec":{"port":{"targetPort":3000},"tls":{"insecureEdgeTerminationPolicy":"Redirect","termination":"edge"},"to":{"kind":"Service","name":"nodejs","weight":100}},"status":{}}\n',
+        'openshift.io/host.generated': 'true',
+      },
+      creationTimestamp: '2022-05-16T09:52:33Z',
+      labels: {
+        'app.kubernetes.io/created-by': 'application-service',
+        'app.kubernetes.io/instance': 'gitopsdepl-f56e3027-168b-43cf-aa3a-99d784d69b05',
+        'app.kubernetes.io/managed-by': 'kustomize',
+        'app.kubernetes.io/name': 'human-resources',
+        'app.kubernetes.io/part-of': 'new-application',
+      },
+      name: 'nodejs',
+      namespace: 'test',
+      resourceVersion: '515569114',
+      uid: '3d3e557d-34c8-4f1f-9a9b-9b199d96c6b3',
+    },
+    spec: {
+      host: 'nodejs-test.apps.appstudio-stage.x99m.p1.openshiftapps.com',
+      port: {
+        targetPort: 3000,
+      },
+      tls: {
+        insecureEdgeTerminationPolicy: 'Redirect',
+        termination: 'edge',
+      },
+      to: {
+        kind: 'Service',
+        name: 'nodejs',
+        weight: 100,
+      },
+      wildcardPolicy: 'None',
+    },
+    status: {
+      ingress: [
+        {
+          conditions: [
+            {
+              lastTransitionTime: '2022-05-16T09:52:33Z',
+              status: 'True',
+              type: 'Admitted',
+            },
+          ],
+          host: 'nodejs-test.apps.appstudio-stage.x99m.p1.openshiftapps.com',
+          routerCanonicalHostname: 'router-default.apps.appstudio-stage.x99m.p1.openshiftapps.com',
+          routerName: 'default',
+          wildcardPolicy: 'None',
+        },
+      ],
+    },
+  },
+  {
+    apiVersion: 'route.openshift.io/v1',
+    kind: 'Route',
+    metadata: {
+      annotations: {
+        'kubectl.kubernetes.io/last-applied-configuration':
+          '{"apiVersion":"route.openshift.io/v1","kind":"Route","metadata":{"annotations":{},"creationTimestamp":null,"labels":{"app.kubernetes.io/created-by":"application-service","app.kubernetes.io/instance":"gitopsdepl-3d00e628-1320-4e5e-b927-49329b9ca800","app.kubernetes.io/managed-by":"kustomize","app.kubernetes.io/name":"java-quarkus","app.kubernetes.io/part-of":"test-application"},"name":"java-quarkus","namespace":"rorai"},"spec":{"port":{"targetPort":8080},"tls":{"insecureEdgeTerminationPolicy":"Redirect","termination":"edge"},"to":{"kind":"Service","name":"java-quarkus","weight":100}},"status":{}}\n',
+        'openshift.io/host.generated': 'true',
+      },
+      creationTimestamp: '2022-05-06T16:06:28Z',
+      labels: {
+        'app.kubernetes.io/created-by': 'application-service',
+        'app.kubernetes.io/instance': 'gitopsdepl-3d00e628-1320-4e5e-b927-49329b9ca800',
+        'app.kubernetes.io/managed-by': 'kustomize',
+        'app.kubernetes.io/name': 'java-quarkus',
+        'app.kubernetes.io/part-of': 'test-application',
+      },
+      name: 'java-quarkus',
+      namespace: 'test',
+      resourceVersion: '437696426',
+      uid: '6f8cbe58-7274-4061-b68a-ed4d9afc57fd',
+    },
+    spec: {
+      host: 'java-quarkus-test.apps.appstudio-stage.x99m.p1.openshiftapps.com',
+      port: {
+        targetPort: 8080,
+      },
+      tls: {
+        insecureEdgeTerminationPolicy: 'Redirect',
+        termination: 'edge',
+      },
+      to: {
+        kind: 'Service',
+        name: 'java-quarkus',
+        weight: 100,
+      },
+      wildcardPolicy: 'None',
+    },
+    status: {
+      ingress: [
+        {
+          conditions: [
+            {
+              lastTransitionTime: '2022-05-06T16:06:28Z',
+              status: 'True',
+              type: 'Admitted',
+            },
+          ],
+          host: 'java-quarkus-test.apps.appstudio-stage.x99m.p1.openshiftapps.com',
+          routerCanonicalHostname: 'router-default.apps.appstudio-stage.x99m.p1.openshiftapps.com',
+          routerName: 'default',
+          wildcardPolicy: 'None',
+        },
+      ],
+    },
+  },
+];

--- a/src/components/Components/ComponentDetails/__tests__/ComponentActivityTab.spec.tsx
+++ b/src/components/Components/ComponentDetails/__tests__/ComponentActivityTab.spec.tsx
@@ -41,7 +41,7 @@ const useParamsMock = useParams as jest.Mock;
 
 configure({ testIdAttribute: 'data-testid' });
 
-describe('ComponentDetailsView', () => {
+describe('ComponentActivityTab', () => {
   let navigateMock: jest.Mock;
 
   beforeEach(() => {

--- a/src/components/Components/ComponentDetails/__tests__/ComponentDeploymentsTab.spec.tsx
+++ b/src/components/Components/ComponentDetails/__tests__/ComponentDeploymentsTab.spec.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { screen, configure } from '@testing-library/react';
+import { useAllEnvironments } from '../../../../hooks/useAllEnvironments';
+import { useApplicationRoutes } from '../../../../hooks/useApplicationRoutes';
+import { useLatestSuccessfulBuildPipelineRunForComponent } from '../../../../hooks/usePipelineRuns';
+import { useSnapshotsEnvironmentBindings } from '../../../../hooks/useSnapshotsEnvironmentBindings';
+import { useTaskRuns } from '../../../../hooks/useTaskRuns';
+import { routerRenderer } from '../../../../utils/test-utils';
+import {
+  mockComponent,
+  mockEnvironments,
+  mockLatestSuccessfulBuild,
+  mockSnapshotEBs,
+  mockTaskRuns,
+  mockRoutes,
+} from '../__data__/mockComponentDetails';
+import { ComponentDeploymentsTab } from '../tabs/ComponentDeploymentsTab';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: jest.fn(() => ({ t: (x) => x })),
+}));
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  useK8sWatchResource: jest.fn(),
+  getActiveWorkspace: jest.fn(() => 'test-ws'),
+}));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual<any>('react-router-dom'),
+  useNavigate: jest.fn(),
+  useParams: jest.fn(),
+}));
+
+jest.mock('../../../../utils/workspace-context-utils', () => ({
+  useWorkspaceInfo: jest.fn(() => ({ namespace: 'test-ns', workspace: 'test-ws' })),
+}));
+
+jest.mock('../../../../hooks/useAllEnvironments', () => ({
+  useAllEnvironments: jest.fn(),
+}));
+const useAllEnvironmentsMock = useAllEnvironments as jest.Mock;
+
+jest.mock('../../../../hooks/useSnapshotsEnvironmentBindings', () => ({
+  ...jest.requireActual<any>('../../../../hooks/useSnapshotsEnvironmentBindings'),
+  useSnapshotsEnvironmentBindings: jest.fn(),
+}));
+
+jest.mock('../../../../hooks/useApplicationRoutes', () => ({
+  useApplicationRoutes: jest.fn(),
+}));
+
+jest.mock('../../../../hooks/usePipelineRuns', () => ({
+  ...jest.requireActual<any>('../../../../hooks/usePipelineRuns'),
+  useLatestSuccessfulBuildPipelineRunForComponent: jest.fn(),
+}));
+jest.mock('../../../../hooks/useTaskRuns', () => ({
+  useTaskRuns: jest.fn(),
+}));
+const useSnapshotsEnvironmentBindingsMock = useSnapshotsEnvironmentBindings as jest.Mock;
+const applicationRoutesMock = useApplicationRoutes as jest.Mock;
+const useLatestSuccessfulBuildPipelineRunForComponentMock =
+  useLatestSuccessfulBuildPipelineRunForComponent as jest.Mock;
+const watchResourceMock = useK8sWatchResource as jest.Mock;
+const useNavigateMock = useNavigate as jest.Mock;
+const useParamsMock = useParams as jest.Mock;
+const useTaskRunsMock = useTaskRuns as jest.Mock;
+
+configure({ testIdAttribute: 'data-testid' });
+
+describe('ComponentDeploymentsTab', () => {
+  let navigateMock: jest.Mock;
+
+  beforeEach(() => {
+    useAllEnvironmentsMock.mockReturnValue([mockEnvironments, true]);
+    useSnapshotsEnvironmentBindingsMock.mockReturnValue([mockSnapshotEBs, true]);
+    applicationRoutesMock.mockReturnValue([mockRoutes, true]);
+    useLatestSuccessfulBuildPipelineRunForComponentMock.mockReturnValue([
+      mockLatestSuccessfulBuild,
+      true,
+    ]);
+    useTaskRunsMock.mockReturnValue([mockTaskRuns, true]);
+    watchResourceMock.mockReturnValue([{}, true]);
+    navigateMock = jest.fn();
+    useNavigateMock.mockImplementation(() => navigateMock);
+    useParamsMock.mockReturnValue({});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the skeleton table if component deployment data is not loaded', () => {
+    useAllEnvironmentsMock.mockReturnValue([[], false]);
+    routerRenderer(<ComponentDeploymentsTab component={mockComponent} />);
+    const listView = screen.getByTestId('component-deployments-list-view');
+    expect(listView.querySelector('.loading-skeleton--table')).toBeTruthy();
+  });
+
+  it('should render the empty state if there are no environments', () => {
+    useAllEnvironmentsMock.mockReturnValue([[], true]);
+    routerRenderer(<ComponentDeploymentsTab component={mockComponent} />);
+    expect(
+      screen.findByText(
+        'Monitor the component builds that are currently deployed to your environments.',
+      ),
+    ).toBeTruthy();
+  });
+
+  it('should render a table when there are integration tests', () => {
+    const wrapper = routerRenderer(<ComponentDeploymentsTab component={mockComponent} />);
+    expect(wrapper.container.getElementsByTagName('table')).toHaveLength(1);
+  });
+});

--- a/src/components/Components/ComponentDetails/tabs/ComponentActivityTab.tsx
+++ b/src/components/Components/ComponentDetails/tabs/ComponentActivityTab.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { Tab, Tabs, TabTitleText, Title } from '@patternfly/react-core';
+import { Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import { PipelineRunLabel } from '../../../../consts/pipelinerun';
 import { useLocalStorage } from '../../../../hooks/useLocalStorage';
+import DetailsSection from '../../../../shared/components/details-page/DetailsSection';
 import { ComponentKind, PipelineRunKind } from '../../../../types';
 import { useWorkspaceInfo } from '../../../../utils/workspace-context-utils';
 import PipelineRunsTab from '../../../ApplicationDetails/tabs/PipelineRunsTab';
@@ -65,53 +66,51 @@ export const ComponentActivityTab: React.FC<ComponentActivityTabProps> = ({ comp
     !plr.spec.params?.find((p) => p.name === 'SNAPSHOT');
 
   return (
-    <>
-      <Title size="xl" headingLevel="h3" className="pf-v5-c-title pf-u-mt-lg pf-u-mb-sm">
-        Activity
-      </Title>
-      <div className="component-details__details-description">
-        Monitor CI/CD activity for this component. Each item in the list represents a process that
-        started by a user, generated a snapshot and deployed.
-      </div>
-      <Tabs
-        style={{
-          width: 'fit-content',
-          marginBottom: 'var(--pf-v5-global--spacer--md)',
-        }}
-        activeKey={currentTab}
-        onSelect={(_, k: string) => {
-          setActiveTab(k);
-        }}
-        data-testid="activities-tabs-id"
-        unmountOnExit
+    <div>
+      <DetailsSection
+        title="Activity"
+        description="Monitor CI/CD activity for this component. Each item in the list represents a process that started by a user, generated a snapshot and deployed."
       >
-        <Tab
-          data-testid={`comp__activity__tabItem commits`}
-          title={<TabTitleText>Commits</TabTitleText>}
-          key="commits"
-          eventKey="latest-commits"
-          className="activity-tab"
+        <Tabs
+          style={{
+            width: 'fit-content',
+            marginBottom: 'var(--pf-v5-global--spacer--md)',
+          }}
+          activeKey={currentTab}
+          onSelect={(_, k: string) => {
+            setActiveTab(k);
+          }}
+          data-testid="activities-tabs-id"
+          unmountOnExit
         >
-          <CommitsListView
-            applicationName={applicationName}
-            componentName={component.spec.componentName}
-          />
-        </Tab>
-        <Tab
-          data-testid={`comp__activity__tabItem pipelineruns`}
-          title={<TabTitleText>Pipeline runs</TabTitleText>}
-          key="pipelineruns"
-          eventKey="pipelineruns"
-          className="activity-tab"
-        >
-          <PipelineRunsTab
-            applicationName={applicationName}
-            componentName={component.spec.componentName}
-            customFilter={nonTestSnapShotFilter}
-          />
-        </Tab>
-      </Tabs>
-    </>
+          <Tab
+            data-testid={`comp__activity__tabItem commits`}
+            title={<TabTitleText>Commits</TabTitleText>}
+            key="commits"
+            eventKey="latest-commits"
+            className="activity-tab"
+          >
+            <CommitsListView
+              applicationName={applicationName}
+              componentName={component.spec.componentName}
+            />
+          </Tab>
+          <Tab
+            data-testid={`comp__activity__tabItem pipelineruns`}
+            title={<TabTitleText>Pipeline runs</TabTitleText>}
+            key="pipelineruns"
+            eventKey="pipelineruns"
+            className="activity-tab"
+          >
+            <PipelineRunsTab
+              applicationName={applicationName}
+              componentName={component.spec.componentName}
+              customFilter={nonTestSnapShotFilter}
+            />
+          </Tab>
+        </Tabs>
+      </DetailsSection>
+    </div>
   );
 };
 

--- a/src/components/Components/ComponentDetails/tabs/ComponentDeploymentsTab.tsx
+++ b/src/components/Components/ComponentDetails/tabs/ComponentDeploymentsTab.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import DetailsSection from '../../../../shared/components/details-page/DetailsSection';
+import { ComponentKind } from '../../../../types';
+import ComponentDeploymentsListView from '../../ComponentDeployments/ComponentDeploymentsListView';
+
+type ComponentDeploymentsTabProps = {
+  component: ComponentKind;
+};
+
+export const ComponentDeploymentsTab: React.FC<ComponentDeploymentsTabProps> = ({ component }) => (
+  <div>
+    <DetailsSection
+      title="Deployments"
+      description="Component builds that are currently deployed to environments."
+    >
+      <ComponentDeploymentsListView component={component} />
+    </DetailsSection>
+  </div>
+);
+
+export default React.memo(ComponentDeploymentsTab);

--- a/src/hooks/useComponentDeployment.ts
+++ b/src/hooks/useComponentDeployment.ts
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { GitOpsDeploymentGroupVersionKind } from '../models';
+import { DeploymentGroupVersionKind } from '../models/deployment';
+import { GitOpsDeploymentKind } from '../types';
+import { SnapshotEnvironmentBinding } from '../types/coreBuildService';
+import { DeploymentKind } from '../types/deployment';
+
+export const useComponentDeployment = (
+  namespace: string,
+  componentName: string,
+  snapshotEB: SnapshotEnvironmentBinding,
+) => {
+  const gitOpsDeploymentData = snapshotEB?.status?.gitopsDeployments?.find(
+    (data) => data.componentName === componentName,
+  );
+  const [gitOpsDeployment, gitOpsDeploymentLoaded] = useK8sWatchResource<GitOpsDeploymentKind>({
+    groupVersionKind: GitOpsDeploymentGroupVersionKind,
+    name: gitOpsDeploymentData?.gitopsDeployment,
+    namespace,
+    isList: false,
+  });
+
+  const deploymentResource =
+    gitOpsDeploymentLoaded &&
+    gitOpsDeployment?.status?.resources?.find((resource) => resource.kind === 'Deployment');
+
+  return useK8sWatchResource<DeploymentKind>(
+    React.useMemo(
+      () => ({
+        groupVersionKind: DeploymentGroupVersionKind,
+        isList: false,
+        name: deploymentResource?.name,
+        namespace: deploymentResource?.namespace,
+      }),
+      [deploymentResource?.name, deploymentResource?.namespace],
+    ),
+  );
+};

--- a/src/shared/components/table/Table.tsx
+++ b/src/shared/components/table/Table.tsx
@@ -9,6 +9,7 @@ import { StatusBox } from '../status-box/StatusBox';
 import { TableRow } from './TableRow';
 import { RowFunctionArgs, VirtualBody, VirtualBodyProps } from './VirtualBody';
 import './Table.scss';
+import '../catalog/utils/skeleton-screen.scss';
 
 export type Filter = { key: string; value: string };
 


### PR DESCRIPTION
## Fixes 
Fixes [HAC-4697](https://issues.redhat.com/browse/HAC-4697)

## Description
Adds a `Deployments` tab to the component details page

## Type of change
- [x] Feature

## Screen shots / Gifs for design review 
![image](https://github.com/openshift/hac-dev/assets/11633780/73218d87-7b6b-4a4a-bd36-5db946288956)

