### PR TITLE
Select first failed logs tab by default

### DIFF
--- a/src/shared/components/pipeline-run-logs/__tests__/PipelineRunLogs.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/__tests__/PipelineRunLogs.spec.tsx
@@ -186,4 +186,35 @@ describe('PipelineRunLogs', () => {
       expectTasktoBeOrdered();
     });
   });
+
+  it('should select and render the first failed task log if no active task is given', () => {
+    const failedTaskRun = {
+      ...testTaskRuns[0],
+      metadata: {
+        ...testTaskRuns[0].metadata,
+        name: 'failed-task',
+      },
+      spec: { taskRef: { name: 'failed-task' } },
+      status: {
+        ...testTaskRuns[0].status,
+        conditions: [
+          {
+            ...testTaskRuns[0].status.conditions[0],
+            status: 'False',
+          },
+        ],
+      },
+    };
+
+    render(
+      <PipelineRunLogs
+        workspace="test-ws"
+        obj={pipelineRun}
+        taskRuns={[failedTaskRun, ...testTaskRuns]}
+      />,
+    );
+
+    screen.getByTestId('logs-tasklist');
+    within(screen.getByTestId('logs-taskName')).getByText('failed-task');
+  });
 });


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/RHTAPBUGS-515
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
Select first failed logs tab when active tab is not provided.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

https://github.com/openshift/hac-dev/assets/20013884/5552b9f6-b197-47c5-8d33-43cb3407da6a

<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
Try to open build logs for a component with failed build.
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
