### PR TITLE
Fix component details when no container image

### DIFF
--- a/src/components/Components/ComponentDetails/__tests__/ComponentDetails.spec.tsx
+++ b/src/components/Components/ComponentDetails/__tests__/ComponentDetails.spec.tsx
@@ -216,6 +216,20 @@ describe('ComponentDetailsView', () => {
     screen.getByText('404: Page not found');
   });
 
+  it('should indicate when there is no container image', async () => {
+    useComponentMock.mockReturnValue([
+      { ...mockComponent, status: { ...mockComponent.status, containerImage: undefined } },
+      true,
+    ]);
+    routerRenderer(
+      <ComponentDetailsViewWrapper>
+        <ComponentDetailsView applicationName="test-application" componentName="human-resources" />,
+      </ComponentDetailsViewWrapper>,
+    );
+    expect(screen.queryByTestId('sbom-test')).toBeNull();
+    expect(screen.queryByTestId('build-container-image-test')).toBeNull();
+  });
+
   it('should indicate when there are no environment variables', async () => {
     useComponentMock.mockReturnValue([mockComponentWithoutEnvs, true]);
     routerRenderer(

--- a/src/components/Components/ComponentDetails/tabs/ComponentLatestBuild.tsx
+++ b/src/components/Components/ComponentDetails/tabs/ComponentLatestBuild.tsx
@@ -239,17 +239,30 @@ const ComponentLatestBuild: React.FC<ComponentLatestBuildProps> = ({ component }
           <DescriptionListGroup>
             <DescriptionListTerm>SBOM</DescriptionListTerm>
             <DescriptionListDescription>
-              <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied">
-                {`cosign download sbom ${containerImage}`}
-              </ClipboardCopy>
+              {containerImage ? (
+                <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied" data-test="sbom-test">
+                  {`cosign download sbom ${containerImage}`}
+                </ClipboardCopy>
+              ) : (
+                '-'
+              )}
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>
             <DescriptionListTerm>Build container image</DescriptionListTerm>
             <DescriptionListDescription>
-              <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied">
-                {containerImage}
-              </ClipboardCopy>
+              {containerImage ? (
+                <ClipboardCopy
+                  isReadOnly
+                  hoverTip="Copy"
+                  clickTip="Copied"
+                  data-test="build-container-image-test"
+                >
+                  {containerImage}
+                </ClipboardCopy>
+              ) : (
+                '-'
+              )}
             </DescriptionListDescription>
           </DescriptionListGroup>
           <ScanDescriptionListGroup taskRuns={taskRuns} showLogsLink />


### PR DESCRIPTION
## Fixes 
Fixes [RHTAPBUGS-755](https://issues.redhat.com/browse/RHTAPBUGS-755)

## Description
Display the empty indicator when the container image for a component is absent.

## Type of change
- [x] Bugfix

## Screen shots / Gifs for design review 
![image](https://github.com/openshift/hac-dev/assets/11633780/fcbba882-4c62-4a6f-8c4e-0c2837b56406)
