### PR TITLE
Update computation of deployed application status

### DIFF
--- a/integration-tests/support/pageObjects/pages-po.ts
+++ b/integration-tests/support/pageObjects/pages-po.ts
@@ -1,5 +1,5 @@
 export const applicationsPagePO = {
-  appStatus: '[class="pf-v5-c-label__content"]',
+  appStatus: '[data-test="details__status"]',
   formGroup: 'div[class="pf-v5-c-form__group"]',
   secretKey: 'input[label="Key"]',
   secretValue: 'textarea[id="value"]',

--- a/integration-tests/utils/Applications.ts
+++ b/integration-tests/utils/Applications.ts
@@ -93,9 +93,7 @@ export class Applications {
     });
   }
   static verifyAppstatusIsSucceeded() {
-    cy.contains(applicationsPagePO.appStatus, 'Succeeded', { timeout: 100000 }).should(
-      'be.visible',
-    );
+    cy.contains(applicationsPagePO.appStatus, 'Healthy', { timeout: 100000 }).should('be.visible');
   }
 
   static getComponentListItem(application: string) {

--- a/src/components/ApplicationDetails/ApplicationHeader.tsx
+++ b/src/components/ApplicationDetails/ApplicationHeader.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
-import { Flex, FlexItem, Icon, Text, Truncate } from '@patternfly/react-core';
+import { Flex, FlexItem, Icon, Text, TextVariants, Truncate } from '@patternfly/react-core';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 import { useApplicationHealthStatus } from '../../hooks/useApplicationHealthStatus';
 import { useLatestApplicationRouteURL } from '../../hooks/useLatestApplicationRouteURL';
 import ExternalLink from '../../shared/components/links/ExternalLink';
 import { ApplicationKind } from '../../types';
-import { runStatus } from '../../utils/pipeline-utils';
-import { StatusIconWithTextLabel } from '../topology/StatusIcon';
+import { getGitOpsDeploymentHealthStatusIcon } from '../../utils/gitops-utils';
 import { ApplicationThumbnail } from './ApplicationThumbnail';
 
 export const ApplicationHeader: React.FC<{ application: ApplicationKind }> = ({ application }) => {
@@ -27,7 +26,13 @@ export const ApplicationHeader: React.FC<{ application: ApplicationKind }> = ({ 
           </FlexItem>
           {healthStatusloaded && healthStatus ? (
             <FlexItem>
-              <StatusIconWithTextLabel status={healthStatus.status as runStatus} />
+              <Text
+                data-test="details__status"
+                component={TextVariants.small}
+                style={{ color: 'var(--pf-v5-global--Color--200)' }}
+              >
+                {getGitOpsDeploymentHealthStatusIcon(healthStatus.status)} {healthStatus.status}
+              </Text>
             </FlexItem>
           ) : null}
         </Flex>

--- a/src/components/ApplicationDetails/__data__/WorkflowSnapshotsEnvironmentBindingsData.ts
+++ b/src/components/ApplicationDetails/__data__/WorkflowSnapshotsEnvironmentBindingsData.ts
@@ -126,6 +126,7 @@ export const mockSnapshotsEnvironmentBindings: SnapshotEnvironmentBinding[] = [
           componentName: 'test-nodeapp',
           gitopsDeployment:
             'test-application-development-binding-8h9wl-test-application-development-test-nodeapp',
+          health: 'Healthy',
         },
       ],
       gitopsRepoConditions: [
@@ -208,6 +209,7 @@ export const mockSnapshotsEnvironmentBindings: SnapshotEnvironmentBinding[] = [
           componentName: 'test-nodeapp',
           gitopsDeployment:
             'test-application-development-binding-8h9wl-test-application-development-test-nodeapp',
+          health: 'Progressing',
         },
       ],
       gitopsRepoConditions: [
@@ -290,6 +292,7 @@ export const mockSnapshotsEnvironmentBindings: SnapshotEnvironmentBinding[] = [
           componentName: 'test-nodeapp',
           gitopsDeployment:
             'test-application-development-binding-8h9wl-test-application-development-test-nodeapp',
+          health: 'Degraded',
         },
       ],
       gitopsRepoConditions: [

--- a/src/components/ApplicationDetails/tabs/overview/visualization/hooks/useAppStaticEnvironmentNodes.ts
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/hooks/useAppStaticEnvironmentNodes.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../../../../components/Environment/environment-utils';
 import { useEnvironments } from '../../../../../../hooks/useEnvironments';
 import { useSnapshotsEnvironmentBindings } from '../../../../../../hooks/useSnapshotsEnvironmentBindings';
-import { getComponentDeploymentRunStatus } from '../../../../../../utils/environment-utils';
+import { getEnvironmentRunStatus } from '../../../../../../utils/environment-utils';
 import { WorkflowNodeModel, WorkflowNodeModelData, WorkflowNodeType } from '../types';
 import {
   emptyPipelineNode,
@@ -63,7 +63,7 @@ export const useAppStaticEnvironmentNodes = (
             applicationName,
             WorkflowNodeType.STATIC_ENVIRONMENT,
             prevEnv ? [prevEnv.metadata.uid] : previousTasks,
-            getComponentDeploymentRunStatus(snapshotEB),
+            getEnvironmentRunStatus(snapshotEB),
           );
         })
       : [

--- a/src/hooks/__data__/mock-data.ts
+++ b/src/hooks/__data__/mock-data.ts
@@ -83,6 +83,26 @@ export const mockSnapshotEnvironmentBindings: {
             type: 'GitOpsResourcesGenerated',
           },
         ],
+        gitopsDeployments: [
+          {
+            componentName: 'comp1',
+            gitopsDeployment: 'test-app-prod-binding-dxbcz-test-app-prod-comp1-ccgs',
+            health: 'Progressing',
+            syncStatus: 'Unknown',
+          },
+          {
+            componentName: 'comp2',
+            gitopsDeployment: 'test-app-prod-binding-dxbcz-test-app-prod-comp2-xdss',
+            health: 'Healthy',
+            syncStatus: 'Unknown',
+          },
+          {
+            componentName: 'comp3',
+            gitopsDeployment: 'test-app-prod-binding-dxbcz-test-app-prod-comp3-jkkl',
+            health: 'Healthy',
+            syncStatus: 'Unknown',
+          },
+        ],
       },
     },
   ],
@@ -123,9 +143,22 @@ export const mockSnapshotEnvironmentBindings: {
         ],
         gitopsDeployments: [
           {
-            componentName: 'devfile-sample-guhp',
-            gitopsDeployment:
-              'my-app-development-binding-w8plb-my-app-development-devfile-sample-guhp',
+            componentName: 'comp1',
+            gitopsDeployment: 'test-app-prod-binding-dxbcz-test-app-prod-comp1-ccgs',
+            health: 'Healthy',
+            syncStatus: 'Unknown',
+          },
+          {
+            componentName: 'comp2',
+            gitopsDeployment: 'test-app-prod-binding-dxbcz-test-app-prod-comp2-xdss',
+            health: 'Healthy',
+            syncStatus: 'Unknown',
+          },
+          {
+            componentName: 'comp3',
+            gitopsDeployment: 'test-app-prod-binding-dxbcz-test-app-prod-comp3-jkkl',
+            health: 'Healthy',
+            syncStatus: 'Unknown',
           },
         ],
         gitopsRepoConditions: [
@@ -179,9 +212,22 @@ export const mockSnapshotEnvironmentBindings: {
         ],
         gitopsDeployments: [
           {
-            componentName: 'test-nodeapp',
-            gitopsDeployment:
-              'test-application-development-binding-8h9wl-test-application-development-test-nodeapp',
+            componentName: 'comp1',
+            gitopsDeployment: 'test-app-prod-binding-dxbcz-test-app-prod-comp1-ccgs',
+            health: 'Healthy',
+            syncStatus: 'Unknown',
+          },
+          {
+            componentName: 'comp2',
+            gitopsDeployment: 'test-app-prod-binding-dxbcz-test-app-prod-comp2-xdss',
+            health: 'Healthy',
+            syncStatus: 'Unknown',
+          },
+          {
+            componentName: 'comp3',
+            gitopsDeployment: 'test-app-prod-binding-dxbcz-test-app-prod-comp3-jkkl',
+            health: 'Progressing',
+            syncStatus: 'Unknown',
           },
         ],
         gitopsRepoConditions: [
@@ -235,9 +281,22 @@ export const mockSnapshotEnvironmentBindings: {
         ],
         gitopsDeployments: [
           {
-            componentName: 'test-nodeapp',
-            gitopsDeployment:
-              'test-application-development-binding-8h9wl-test-application-development-test-nodeapp',
+            componentName: 'comp1',
+            gitopsDeployment: 'test-app-prod-binding-dxbcz-test-app-prod-comp1-ccgs',
+            health: 'Healthy',
+            syncStatus: 'Unknown',
+          },
+          {
+            componentName: 'comp2',
+            gitopsDeployment: 'test-app-prod-binding-dxbcz-test-app-prod-comp2-xdss',
+            health: 'Degraded',
+            syncStatus: 'Unknown',
+          },
+          {
+            componentName: 'comp3',
+            gitopsDeployment: 'test-app-prod-binding-dxbcz-test-app-prod-comp3-jkkl',
+            health: 'Progressing',
+            syncStatus: 'Unknown',
           },
         ],
         gitopsRepoConditions: [

--- a/src/hooks/useApplicationHealthStatus.ts
+++ b/src/hooks/useApplicationHealthStatus.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
-import { getComponentDeploymentRunStatus } from '../utils/environment-utils';
+import { GitOpsDeploymentHealthStatus } from '../types';
+import { getComponentDeploymentStatus } from '../utils/environment-utils';
 import { useWorkspaceInfo } from '../utils/workspace-context-utils';
 import { useSnapshotsEnvironmentBindings } from './useSnapshotsEnvironmentBindings';
 
@@ -8,7 +9,7 @@ const SNAPSHOT_BINDING_ENV_LABEL = 'appstudio.environment';
 export const useApplicationHealthStatus = (
   applicationName: string,
   envName?: string,
-): [{ status: string; envName: string }, boolean, unknown] => {
+): [{ status: GitOpsDeploymentHealthStatus; envName: string }, boolean, unknown] => {
   const { namespace } = useWorkspaceInfo();
   const [snapshotEBs, loaded, error] = useSnapshotsEnvironmentBindings(namespace, applicationName);
   const healthStatus = useMemo(() => {
@@ -17,7 +18,7 @@ export const useApplicationHealthStatus = (
         const seb = snapshotEBs.filter(
           (as) => as.metadata?.labels[SNAPSHOT_BINDING_ENV_LABEL] === envName,
         );
-        return seb ? { status: getComponentDeploymentRunStatus(seb[0]), envName } : null;
+        return seb ? { status: getComponentDeploymentStatus(seb[0]), envName } : null;
       }
       const seb = snapshotEBs.sort(
         (a, b) =>
@@ -27,7 +28,7 @@ export const useApplicationHealthStatus = (
 
       return seb
         ? {
-            status: getComponentDeploymentRunStatus(seb),
+            status: getComponentDeploymentStatus(seb),
             envName: seb.metadata.labels[SNAPSHOT_BINDING_ENV_LABEL],
           }
         : null;

--- a/src/types/coreBuildService.ts
+++ b/src/types/coreBuildService.ts
@@ -144,6 +144,8 @@ export interface GitopsRepository {
 export interface GitopsDeployment {
   componentName: string;
   gitopsDeployment: string;
+  health?: string;
+  syncStatus?: string;
 }
 
 export type SnapshotEnvironmentBinding = K8sResourceCommon & {


### PR DESCRIPTION
## Fixes 
Fixes [RHTAPBUGS-783](https://issues.redhat.com/browse/RHTAPBUGS-783)

## Description
Update the computation of the deployed application status to use status.gitopsDeployment instead of status.componentsDeploymentConditions

## Type of change
- [x] Bugfix

