### PR TITLE
fix app name auto recommendation when git url has extra spaces

### DIFF
--- a/src/components/ImportForm/ReviewSection/ReviewSection.tsx
+++ b/src/components/ImportForm/ReviewSection/ReviewSection.tsx
@@ -81,7 +81,7 @@ const ReviewSection: React.FunctionComponent = () => {
   const [validAppName] = useValidApplicationName(sourceUrl);
 
   React.useEffect(() => {
-    if (sourceUrl && gitUrlRegex.test(sourceUrl) && !inAppContext && !isSubmitting) {
+    if (sourceUrl && gitUrlRegex.test(sourceUrl.trim()) && !inAppContext && !isSubmitting) {
       setFieldValue('application', validAppName);
     }
   }, [sourceUrl, inAppContext, validAppName, setFieldValue, isSubmitting]);

--- a/src/components/ImportForm/utils/__tests__/useValidApplicationName.spec.ts
+++ b/src/components/ImportForm/utils/__tests__/useValidApplicationName.spec.ts
@@ -23,6 +23,20 @@ describe('useValidApplicationName', () => {
     const { result } = renderHook(() => useValidApplicationName());
     expect(result.current[0]).toBe('my-app-3');
   });
+
+  it('returns the repo name based on given git url', () => {
+    const { result } = renderHook(() =>
+      useValidApplicationName('https://github.com/testapp/testrepo'),
+    );
+    expect(result.current[0]).toBe('testrepo');
+  });
+
+  it('should handle extra space in the start and end of the git url ', () => {
+    const { result } = renderHook(() =>
+      useValidApplicationName('  https://github.com/testapp/testrepo  '),
+    );
+    expect(result.current[0]).toBe('testrepo');
+  });
 });
 
 describe('incrementNameCount', () => {


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


https://issues.redhat.com/browse/RHTAPBUGS-775

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Auto recommendation of applicaiton name was not invoked due to the git regex check failure. Trimming the source url before performing it to git regex fixes it.

## Type of change
<!-- Please delete options that are not relevant. -->


- [x] Bugfix

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
**Before:**

<img width="1743" alt="Screenshot 2023-09-27 at 2 37 30 PM" src="https://github.com/openshift/hac-dev/assets/9964343/7d43a4db-de07-456e-9478-ec11b0fe842b">

**After**

<img width="1783" alt="Screenshot 2023-09-27 at 2 36 29 PM" src="https://github.com/openshift/hac-dev/assets/9964343/a3e47101-cb9a-47da-a6c1-6b77026f79bf">

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

1. Add a git url with extra spaces in the start and end of the url " https://github.com/trustification/trustification/ "
2. Click on `Import  code`
<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
