### PR TITLE
Fix integration name validation issue

### DIFF
--- a/src/components/IntegrationTest/IntegrationTestForm/utils/__tests__/validation-utils.spec.ts
+++ b/src/components/IntegrationTest/IntegrationTestForm/utils/__tests__/validation-utils.spec.ts
@@ -37,7 +37,22 @@ describe('validation-utils', () => {
         },
       }),
     ).rejects.toThrow(
-      'Must start with a letter or number and end with a letter or number. Valid characters include lowercase letters from a to z, numbers from 0 to 9, and hyphens ( - ).',
+      'Must start with a letter and end with a letter or number. Valid characters include lowercase letters from a to z, numbers from 0 to 9, and hyphens ( - ).',
+    );
+  });
+
+  it('should fail when component name has extra spaces', async () => {
+    await expect(
+      integrationTestValidationSchema.validate({
+        integrationTest: {
+          name: ' test-first  ',
+          url: 'test-url',
+          path: 'test-path',
+          revision: 'revision',
+        },
+      }),
+    ).rejects.toThrow(
+      'Must start with a letter and end with a letter or number. Valid characters include lowercase letters from a to z, numbers from 0 to 9, and hyphens ( - ).',
     );
   });
 

--- a/src/components/IntegrationTest/IntegrationTestForm/utils/validation-utils.ts
+++ b/src/components/IntegrationTest/IntegrationTestForm/utils/validation-utils.ts
@@ -1,17 +1,12 @@
 import * as yup from 'yup';
-
-const k8sResourceNameRegex =
-  /^\s*?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\s*?$/;
+import {
+  RESOURCE_NAME_REGEX_MSG,
+  resourceNameRegex,
+} from '../../../ImportForm/utils/validation-utils';
 
 export const integrationTestValidationSchema = yup.object({
   integrationTest: yup.object({
-    name: yup
-      .string()
-      .required('Required')
-      .matches(
-        k8sResourceNameRegex,
-        'Must start with a letter or number and end with a letter or number. Valid characters include lowercase letters from a to z, numbers from 0 to 9, and hyphens ( - ).',
-      ),
+    name: yup.string().matches(resourceNameRegex, RESOURCE_NAME_REGEX_MSG).required('Required'),
     url: yup
       .string()
       .required('Required')


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/RHTAPBUGS-767

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Add resource name validation for Integration test resource form, users should not be able to click on Create button until they fix the validation error.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Show validation error when a extra space is added:

<img width="883" alt="Screenshot 2023-09-27 at 3 03 15 PM" src="https://github.com/openshift/hac-dev/assets/9964343/368f7cfa-0216-4c11-ba15-fa5273ff7ea4">


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Add integration test name with a extra space in the end.

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
