### PR TITLE
fix: Use exact label match for PAC state check

### DIFF
--- a/src/components/ApplicationDetails/tabs/overview/visualization/utils/node-utils.ts
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/utils/node-utils.ts
@@ -286,7 +286,7 @@ export const getBuildNodeForComponent = (
     );
   }
   const label = `Build for ${component.metadata.name}`;
-  const status = isPACEnabled(component, true) ? runStatus.NeedsMerge : runStatus.Pending;
+  const status = isPACEnabled(component) ? runStatus.NeedsMerge : runStatus.Pending;
   return {
     id: `${component.metadata.uid}-missing`,
     label,

--- a/src/utils/__tests__/component-utils.spec.ts
+++ b/src/utils/__tests__/component-utils.spec.ts
@@ -28,9 +28,7 @@ describe('component-utils', () => {
     };
     expect(isPACEnabled(createComponent(undefined))).toBe(false);
     expect(isPACEnabled(createComponent('enabled'))).toBe(true);
-    expect(isPACEnabled(createComponent('disabled'), true)).toBe(false);
-    expect(isPACEnabled(createComponent('disabled'), false)).toBe(true);
-    expect(isPACEnabled(createComponent('enabled'), true)).toBe(true);
+    expect(isPACEnabled(createComponent('disabled'))).toBe(false);
   });
 
   it('should create github URL for component PRs', () => {

--- a/src/utils/component-utils.ts
+++ b/src/utils/component-utils.ts
@@ -125,10 +125,8 @@ export const getComponentBuildStatus = (component: ComponentKind) => {
 export const getPACProvision = (component: ComponentKind) =>
   getComponentBuildStatus(component)?.pac?.state;
 
-export const isPACEnabled = (component: ComponentKind, done?: boolean) => {
-  const state = getPACProvision(component);
-  return done ? state === ComponentBuildState.enabled : !!state;
-};
+export const isPACEnabled = (component: ComponentKind) =>
+  getPACProvision(component) === ComponentBuildState.enabled;
 
 const GIT_URL_PREFIX = 'https://github.com/';
 


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/RHTAPBUGS-771
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
Use exact label match for checking PAC state, since labels are immediately updated on PAC request and the done check is not relevant anymore.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
(No UI updates)
![0](https://github.com/openshift/hac-dev/assets/20013884/ee9c2728-d661-4100-9068-8e42f0956e3d)
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
1. Create component with custom pipeline
2. Switch to default pipeline
3. Check component kebab menu, it should show "start new build" option
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
