### PR TITLE
fix(task logs): show logs for skipped or idle tasks if they exist

### DIFF
--- a/src/components/TaskRuns/TaskRunLogs.tsx
+++ b/src/components/TaskRuns/TaskRunLogs.tsx
@@ -13,15 +13,16 @@ type Props = {
 const TaskRunLogs: React.FC<Props> = ({ taskRun, namespace, status }) => {
   const podName = taskRun?.status?.podName;
 
-  if (status === runStatus.Skipped) {
-    return <div>No logs. This task was skipped.</div>;
-  }
-  if (status === runStatus.Idle) {
-    return <div>Waiting on task to start.</div>;
-  }
   if (!podName) {
+    if (status === runStatus.Skipped) {
+      return <div>No logs. This task was skipped.</div>;
+    }
+    if (status === runStatus.Idle) {
+      return <div>Waiting on task to start.</div>;
+    }
     return <div data-test="taskrun-logs-nopod">No logs found.</div>;
   }
+
   return (
     <LogsWrapperComponent
       taskRun={taskRun}


### PR DESCRIPTION
## Fixes 
Fixes [HAC-5103](https://issues.redhat.com/browse/HAC-5103)

## Description
Attempt to get pod logs for skipped or idle tasks. Show existing messages only if the pod does not exist.

## Type of change
- [x] Bugfix
