### PR TITLE
feat: add kind annotation to EC ITS

### DIFF
--- a/src/components/IntegrationTest/IntegrationTestForm/const.ts
+++ b/src/components/IntegrationTest/IntegrationTestForm/const.ts
@@ -1,3 +1,4 @@
 export const EC_INTEGRATION_TEST_URL = 'https://github.com/redhat-appstudio/build-definitions';
 export const EC_INTEGRATION_TEST_REVISION = 'main';
 export const EC_INTEGRATION_TEST_PATH = 'pipelines/enterprise-contract.yaml';
+export const EC_INTEGRATION_TEST_KIND = 'enterprise-contract';

--- a/src/components/IntegrationTest/IntegrationTestForm/types.ts
+++ b/src/components/IntegrationTest/IntegrationTestForm/types.ts
@@ -16,6 +16,7 @@ export type IntegrationTestFormValues = {
 
 export enum IntegrationTestAnnotations {
   DISPLAY_NAME = 'app.kubernetes.io/display-name',
+  KIND = 'test.appstudio.openshift.io/kind',
 }
 
 export enum IntegrationTestLabels {

--- a/src/components/IntegrationTest/IntegrationTestForm/utils/__tests__/create-utils.spec.ts
+++ b/src/components/IntegrationTest/IntegrationTestForm/utils/__tests__/create-utils.spec.ts
@@ -1,7 +1,13 @@
 import { k8sCreateResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { IntegrationTestScenarioModel } from '../../../../../models';
 import { MockIntegrationTestsWithGit } from '../../../IntegrationTestsListView/__data__/mock-integration-tests';
-import { IntegrationTestLabels } from '../../types';
+import {
+  EC_INTEGRATION_TEST_KIND,
+  EC_INTEGRATION_TEST_PATH,
+  EC_INTEGRATION_TEST_REVISION,
+  EC_INTEGRATION_TEST_URL,
+} from '../../const';
+import { IntegrationTestAnnotations, IntegrationTestLabels } from '../../types';
 import {
   ResolverRefParams,
   createIntegrationTest,
@@ -189,6 +195,24 @@ describe('Create Utils', () => {
     expect(getURLForParam(k8sResource.spec.resolverRef.params, ResolverRefParams.PATH)).toBe(
       'https://github.com/redhat-appstudio/integration-examples/tree/main/pipelines/integration_pipeline_pass.yaml',
     );
+  });
+
+  it('Should set EC kind annotation', async () => {
+    createResourceMock.mockImplementation(({ resource }) => resource);
+    const resource = await createIntegrationTest(
+      {
+        name: 'app-enterprise-contract',
+        revision: EC_INTEGRATION_TEST_REVISION,
+        url: EC_INTEGRATION_TEST_URL,
+        path: EC_INTEGRATION_TEST_PATH,
+        optional: false,
+      },
+      'Test Application',
+      'test-ns',
+    );
+    expect(resource.metadata.annotations).toStrictEqual({
+      [IntegrationTestAnnotations.KIND]: EC_INTEGRATION_TEST_KIND,
+    });
   });
 });
 

--- a/src/components/IntegrationTest/IntegrationTestForm/utils/create-utils.ts
+++ b/src/components/IntegrationTest/IntegrationTestForm/utils/create-utils.ts
@@ -11,8 +11,15 @@ import {
   ResolverType,
 } from '../../../../types/coreBuildService';
 import {
+  EC_INTEGRATION_TEST_KIND,
+  EC_INTEGRATION_TEST_PATH,
+  EC_INTEGRATION_TEST_REVISION,
+  EC_INTEGRATION_TEST_URL,
+} from '../const';
+import {
   ENVIRONMENTS,
   FormValues,
+  IntegrationTestAnnotations,
   IntegrationTestFormValues,
   IntegrationTestLabels,
 } from '../types';
@@ -110,6 +117,10 @@ export const createIntegrationTest = (
 ): Promise<IntegrationTestScenarioKind> => {
   const { name, url, revision, path, optional, environmentName, environmentType, params } =
     integrationTestValues;
+  const isEC =
+    url === EC_INTEGRATION_TEST_URL &&
+    revision === EC_INTEGRATION_TEST_REVISION &&
+    path === EC_INTEGRATION_TEST_PATH;
   const integrationTestResource: IntegrationTestScenarioKind = {
     apiVersion: `${IntegrationTestScenarioGroupVersionKind.group}/${IntegrationTestScenarioGroupVersionKind.version}`,
     kind: IntegrationTestScenarioGroupVersionKind.kind,
@@ -117,6 +128,7 @@ export const createIntegrationTest = (
       name,
       namespace,
       ...(optional && { labels: { [IntegrationTestLabels.OPTIONAL]: optional.toString() } }),
+      ...(isEC && { annotations: { [IntegrationTestAnnotations.KIND]: EC_INTEGRATION_TEST_KIND } }),
     },
     spec: {
       application,


### PR DESCRIPTION
## Fixes 
[<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->](https://issues.redhat.com/browse/HACBS-2547)


## Description

The auto-created Enterprise Contract IntegrationTestScenarios are now annotated with `test.appstudio.openshift.io/kind: enterprise-contract` annotation.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
n/a

## How to test or reproduce?
Create an Application, and check that the auto-generated Enterprise Contract IntegrationTestScenario has the `test.appstudio.openshift.io/kind: enterprise-contract` annotation.

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
This change should be browser independent, it only contains logic changes and doesn't touch the browser.

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


## Checklist:

- [x] Code follows the style guidelines
- [x] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [x] Changes generate no new warnings
- [x] Added tests that prove this fix is effective or that the feature works
- [x] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
