### PR TITLE
fix(access): Use username API to validate usernames in access form

### DIFF
--- a/src/components/UserAccess/UserAccessForm/__tests__/UsernameSection.spec.tsx
+++ b/src/components/UserAccess/UserAccessForm/__tests__/UsernameSection.spec.tsx
@@ -1,8 +1,15 @@
 import * as React from 'react';
 import '@testing-library/jest-dom';
-import { fireEvent, screen } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { formikRenderer } from '../../../../utils/test-utils';
+import { validateUsername } from '../form-utils';
 import { UsernameSection } from '../UsernameSection';
+
+jest.mock('../form-utils', () => ({
+  validateUsername: jest.fn(),
+}));
+
+const validateMock = validateUsername as jest.Mock;
 
 describe('UsernameSection', () => {
   it('should show usernames field', () => {
@@ -12,16 +19,56 @@ describe('UsernameSection', () => {
     expect(screen.getByRole('searchbox')).toBeVisible();
   });
 
-  it('should add username chip when entered', () => {
+  it('should add username chip when entered', async () => {
+    validateMock.mockResolvedValue(true);
     formikRenderer(<UsernameSection />, { usernames: [] });
-    fireEvent.input(screen.getByRole('searchbox'), { target: { value: 'user1' } });
-    fireEvent.blur(screen.getByRole('searchbox'));
-    expect(screen.getByRole('list', { name: 'Chip group category' })).toBeVisible();
+    await act(async () => {
+      fireEvent.input(screen.getByRole('searchbox'), { target: { value: 'user1' } });
+    });
+    await waitFor(() =>
+      expect(screen.getByRole('list', { name: 'Chip group category' })).toBeVisible(),
+    );
     expect(screen.getByText('user1')).toBeVisible();
-    fireEvent.click(screen.getByRole('button', { name: 'Remove user1' }));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Remove user1' }));
+    });
     expect(screen.queryByText('user1')).not.toBeInTheDocument();
-    fireEvent.input(screen.getByRole('searchbox'), { target: { value: 'user2' } });
-    fireEvent.blur(screen.getByRole('searchbox'));
+
+    validateMock.mockResolvedValue(true);
+    await act(async () => {
+      fireEvent.input(screen.getByRole('searchbox'), { target: { value: 'user2' } });
+    });
+    await waitFor(() => expect(screen.getByText('user2')).toBeVisible());
     expect(screen.getByText('user2')).toBeVisible();
+  });
+
+  it('should show correct field status while entering', async () => {
+    validateMock.mockResolvedValue(false);
+    formikRenderer(<UsernameSection />, { usernames: [] });
+    expect(
+      screen.getByText('Provide RHTAP usernames for the users you want to invite.'),
+    ).toBeVisible();
+    await act(async () => {
+      fireEvent.input(screen.getByRole('searchbox'), { target: { value: 'user!@#' } });
+    });
+    await waitFor(() => expect(screen.getByText('Invalid username format.')).toBeVisible());
+
+    await act(async () => {
+      fireEvent.input(screen.getByRole('searchbox'), { target: { value: 'user' } });
+    });
+    await waitFor(() => expect(screen.getByText('Validating...')).toBeVisible());
+    await waitFor(() => expect(screen.getByText('Username not found.')).toBeVisible());
+
+    validateMock.mockResolvedValue(true);
+    await act(async () => {
+      fireEvent.input(screen.getByRole('searchbox'), { target: { value: 'user1' } });
+    });
+    await waitFor(() => expect(screen.getByText('Validating...')).toBeVisible());
+    await waitFor(() => expect(screen.getByText('Validated')).toBeVisible());
+    await waitFor(() =>
+      expect(screen.getByRole('list', { name: 'Chip group category' })).toBeVisible(),
+    );
+    expect(screen.getByText('user1')).toBeVisible();
   });
 });

--- a/src/components/UserAccess/UserAccessForm/form-utils.ts
+++ b/src/components/UserAccess/UserAccessForm/form-utils.ts
@@ -10,6 +10,16 @@ export type UserAccessFormValues = {
   role: Role;
 };
 
+export const validateUsername = async (username: string) => {
+  try {
+    const res = await fetch(`/api/k8s/registration/api/v1/usernames/${username}`);
+    const [data]: [{ username: string }] = await res.json();
+    return data.username === username;
+  } catch {
+    return false;
+  }
+};
+
 export const userAccessFormSchema = yup.object({
   usernames: yup
     .array()


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/RHTAPBUGS-900
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
Use username API to validate usernames.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

https://github.com/openshift/hac-dev/assets/20013884/f763d78c-da69-46cc-91ab-6e1ce0f8c252

<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
Add access to users with grant access form.
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
