### PR TITLE
fix(secret-list): fix secret list page error when secret is missing status field

### DIFF
--- a/src/components/Secrets/__tests___/secret-utils.spec.ts
+++ b/src/components/Secrets/__tests___/secret-utils.spec.ts
@@ -160,6 +160,24 @@ describe('getSecretRowData', () => {
     });
   });
 
+  it('should not throw error when the status field is missing in the newly created secret', () => {
+    const injectedSecret = sampleRemoteSecrets[RemoteSecretStatusReason.Injected];
+
+    const secretWithoutStatus = {
+      ...injectedSecret,
+      status: undefined,
+    };
+
+    expect(getSecretRowData(secretWithoutStatus, ['development'])).toEqual({
+      secretFor: 'Build',
+      secretLabels: '-',
+      secretName: 'test-secret-two',
+      secretStatus: '-',
+      secretTarget: 'development',
+      secretType: 'Key/value',
+    });
+  });
+
   it('should return the labels data for the given secret', () => {
     const injectedSecret = sampleRemoteSecrets[RemoteSecretStatusReason.Injected];
 

--- a/src/components/Secrets/utils/secret-utils.ts
+++ b/src/components/Secrets/utils/secret-utils.ts
@@ -213,7 +213,8 @@ export const statusFromConditions = (
 
 export const getSecretRowData = (obj: RemoteSecretKind, environmentNames: string[]): any => {
   const type = typeToLabel(obj?.spec?.secret?.type);
-  const keys = obj?.status.secret?.keys;
+
+  const keys = obj?.status?.secret?.keys;
   const secretName = obj?.spec?.secret?.name || '-';
   const secretFor = obj?.metadata?.labels?.[SecretByUILabel] ?? SecretFor.Deployment;
   const secretTarget =


### PR DESCRIPTION


## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/RHTAPBUGS-913

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Secret list page is throwing error when it is redirected from Add secret page. recently created secret is not having status field initially and the list page is looking for the status field to read the number of key/value pairs in the secret which is causing the page to fail.


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


https://github.com/openshift/hac-dev/assets/9964343/8f53643a-d88e-4162-aebd-0376d5158150


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


Add a build secret from the UI and wait for the UI to redirect to the secret list page.

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
