### PR TITLE
fix(e2e): select the correct itest pipeline

### DIFF
--- a/integration-tests/tests/advanced-happy-path.spec.ts
+++ b/integration-tests/tests/advanced-happy-path.spec.ts
@@ -317,6 +317,10 @@ describe('Advanced Happy path', () => {
       PipelinerunsTabPage.getPipelineRunNameByLabel(
         applicationName,
         `test.appstudio.openshift.io/scenario=${integrationTestDetails.integrationTestName}`,
+        {
+          key: 'pac.test.appstudio.openshift.io/event-type',
+          value: 'push',
+        },
       ).then((testPipelineName) => {
         integrationTestDetails.passIntegrationTestPipelineRunName = testPipelineName;
         UIhelper.verifyRowInTable('Pipeline run List', testPipelineName, [/^Test$/]);


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/RHTAPBUGS-951

## Description
Make sure the tests end up on the push triggered pipeline run when checking itests
