### PR TITLE
Add SPI Pact contract test

### DIFF
--- a/pact-tests/contracts/contracts.ts
+++ b/pact-tests/contracts/contracts.ts
@@ -41,8 +41,9 @@ export interface PactContract<T extends K8sResourceCommon> {
  * @param resourceName name of the k8s resource
  * @returns URL path to the given resource within k8s API
  */
-export function getUrlPath(model: K8sModelCommon, namespace: string, resourceName: string) {
-  return `/apis/${model.apiGroup}/${model.apiVersion}/namespaces/${namespace}/${model.plural}/${resourceName}`;
+export function getUrlPath(model: K8sModelCommon, namespace: string, resourceName?: string) {
+  const sufix = resourceName ? `/${resourceName}` : '';
+  return `/apis/${model.apiGroup}/${model.apiVersion}/namespaces/${namespace}/${model.plural}${sufix}`;
 }
 
 /**

--- a/pact-tests/contracts/service-provider-integration/spiaccesscheck.ts
+++ b/pact-tests/contracts/service-provider-integration/spiaccesscheck.ts
@@ -1,0 +1,55 @@
+import { like, regex } from '@pact-foundation/pact/src/v3/matchers';
+import { SPIAccessCheckGroupVersionKind, SPIAccessCheckModel } from '../../../src/models';
+import { SPIAccessCheckKind } from '../../../src/types';
+import { matchers } from '../../matchers';
+import { PactContract, getUrlPath } from '../contracts';
+
+const namespace = 'default';
+const name = 'test-name-';
+const repo = 'https://github.com/hac-test/devfile-sample-code-with-quarkus';
+const path = getUrlPath(SPIAccessCheckModel, namespace);
+
+const requestBody = {
+  apiVersion: `${SPIAccessCheckModel.apiGroup}/${SPIAccessCheckModel.apiVersion}`,
+  kind: SPIAccessCheckModel.kind,
+  metadata: {
+    generateName: name,
+    namespace,
+  },
+  spec: {
+    repoUrl: repo,
+  },
+};
+
+const expectedResponse = {
+  apiVersion: `${SPIAccessCheckModel.apiGroup}/${SPIAccessCheckModel.apiVersion}`,
+  kind: SPIAccessCheckModel.kind,
+  metadata: {
+    creationTimestamp: regex(matchers.dateAndTime, '2022-01-21T13:36:30Z'),
+    generateName: name,
+    name: regex(`^${name}.*`, `${name}9722c`),
+    namespace,
+    resourceVersion: like('782971836'),
+    uid: regex(matchers.uid, '00fbb7cd-fd2d-48f4-bdc5-3289f8d76c77'),
+  },
+  spec: {
+    repoUrl: repo,
+  },
+};
+
+export const contract: PactContract<SPIAccessCheckKind> = {
+  namespace,
+  groupVersionKind: SPIAccessCheckGroupVersionKind,
+  resourceName: name,
+  request: {
+    method: 'POST',
+    path,
+    body: requestBody,
+    headers: { 'Content-Type': 'application/json' },
+  },
+  response: {
+    status: 201,
+    body: expectedResponse,
+  },
+  model: SPIAccessCheckModel,
+};

--- a/pact-tests/spi.pact.spec.ts
+++ b/pact-tests/spi.pact.spec.ts
@@ -1,0 +1,19 @@
+import { pactWith } from 'jest-pact/dist/v3';
+import { mockK8sCreateResource } from './contracts/contracts';
+import { contract } from './contracts/service-provider-integration/spiaccesscheck';
+
+pactWith({ consumer: 'HACdev', provider: 'SPI' }, (interaction) => {
+  interaction('Create spiaccesscheck', ({ provider, execute }) => {
+    beforeEach(() => {
+      provider
+        .uponReceiving('Create spiaccesscheck')
+        .withRequest(contract.request)
+        .willRespondWith(contract.response);
+    });
+
+    execute('Create spiaccesscheck', async (mockserver) => {
+      const product = await mockK8sCreateResource(contract, mockserver);
+      expect(product.kind).toEqual(contract.model.kind);
+    });
+  });
+});

--- a/pact-tests/states/state-params.ts
+++ b/pact-tests/states/state-params.ts
@@ -18,3 +18,9 @@ export type CDQParams = {
   name: string;
   namespace: string;
 };
+
+export type SPIAccessCheckParams = {
+  generateName: string;
+  namespace: string;
+  repo: string;
+};


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-5471

## Description
Introduce SPI contract tests to HAC-dev and SPi repo. Starting with a simple contract of 'spiaccesscheck' creation.
Depends on https://github.com/openshift/hac-dev/pull/808
