### PR TITLE
fix(applications): Use SnapshotEnvironmentBindings directly to get last deploy date

### DIFF
--- a/src/components/ApplicationListView/ApplicationListRow.tsx
+++ b/src/components/ApplicationListView/ApplicationListRow.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { pluralize, Skeleton } from '@patternfly/react-core';
-import { useAllApplicationEnvironmentsWithHealthStatus } from '../../hooks/useAllApplicationEnvironmentsWithHealthStatus';
 import { useComponents } from '../../hooks/useComponents';
+import { useSnapshotsEnvironmentBindings } from '../../hooks/useSnapshotsEnvironmentBindings';
 import ActionMenu from '../../shared/components/action-menu/ActionMenu';
 import { RowFunctionArgs, TableData } from '../../shared/components/table';
 import { Timestamp } from '../../shared/components/timestamp/Timestamp';
@@ -15,19 +15,21 @@ const ApplicationListRow: React.FC<React.PropsWithChildren<RowFunctionArgs<Appli
   obj,
 }) => {
   const [components, loaded] = useComponents(obj.metadata.namespace, obj.metadata.name);
+  const { namespace } = useWorkspaceInfo();
 
-  const [allEnvironments, environmentsLoaded] = useAllApplicationEnvironmentsWithHealthStatus(
+  const [snapshotsEnvironmentBindings, snapshotsLoaded] = useSnapshotsEnvironmentBindings(
+    namespace,
     obj.metadata.name,
   );
-  const lastDeployedTimestamp = React.useMemo(
-    () =>
-      environmentsLoaded
-        ? allEnvironments?.sort?.(
-            (a, b) => new Date(b.lastDeploy).getTime() - new Date(a.lastDeploy).getTime(),
-          )?.[0]?.lastDeploy
-        : '-',
-    [environmentsLoaded, allEnvironments],
-  );
+  const lastDeployedTimestamp = React.useMemo(() => {
+    const snapshotsEnvironmentBinding = snapshotsEnvironmentBindings?.sort(
+      (a, b) =>
+        Date.parse(b?.status?.componentDeploymentConditions?.[0]?.lastTransitionTime) -
+        Date.parse(a?.status?.componentDeploymentConditions?.[0]?.lastTransitionTime),
+    )?.[0];
+    return snapshotsEnvironmentBinding?.status?.componentDeploymentConditions?.[0]
+      ?.lastTransitionTime;
+  }, [snapshotsEnvironmentBindings]);
 
   const actions = useApplicationActions(obj);
   const { workspace } = useWorkspaceInfo();
@@ -52,7 +54,11 @@ const ApplicationListRow: React.FC<React.PropsWithChildren<RowFunctionArgs<Appli
         )}
       </TableData>
       <TableData className={applicationTableColumnClasses.lastDeploy}>
-        <Timestamp timestamp={lastDeployedTimestamp} />
+        {snapshotsLoaded ? (
+          <Timestamp timestamp={lastDeployedTimestamp} />
+        ) : (
+          <Skeleton width="50%" screenreaderText="Loading deploy time" />
+        )}
       </TableData>
       <TableData className={applicationTableColumnClasses.kebab}>
         <ActionMenu actions={actions} />

--- a/src/components/ApplicationListView/__tests__/ApplicationListRow.spec.tsx
+++ b/src/components/ApplicationListView/__tests__/ApplicationListRow.spec.tsx
@@ -131,6 +131,13 @@ describe('Application List Row', () => {
     expect(getByText('Loading component count')).toBeInTheDocument();
   });
 
+  it('renders skeleton in the last deploy column if the snapshots are not loaded', () => {
+    watchResourceMock.mockReturnValue([components, true]);
+    useSnapshotsEnvironmentBindingsMock.mockReturnValue([[], false]);
+    const { getByText } = render(<ApplicationListRow columns={null} obj={application} />);
+    expect(getByText('Loading deploy time')).toBeInTheDocument();
+  });
+
   it('should render metadata name if there is no display name', () => {
     watchResourceMock.mockReturnValue([[], false]);
     const { getByRole } = render(


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/RHTAPBUGS-815
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
Use SnapshotEnvironmentBindings directly instead of fetching all environment bindings to get an application's last deploy date.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
![Screenshot 2023-11-22 at 21-25-32 Applications Red Hat Trusted Application Pipeline](https://github.com/openshift/hac-dev/assets/20013884/2c7470eb-b1c6-4eb7-bce5-fc436283bdef)
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
Create applications, and check last deploy date.
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
