### PR TITLE
fix(commits): Avoid using test pipelineruns for commit details

### DIFF
--- a/src/components/Commits/CommitDetails/CommitDetailsView.tsx
+++ b/src/components/Commits/CommitDetails/CommitDetailsView.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Bullseye, Spinner, Text, TextVariants } from '@patternfly/react-core';
+import { PipelineRunLabel, PipelineRunType } from '../../../consts/pipelinerun';
 import { usePipelineRunsForCommit } from '../../../hooks/usePipelineRuns';
 import { PipelineRunGroupVersionKind } from '../../../models';
 import DetailsPage from '../../../shared/components/details-page/DetailsPage';
@@ -36,11 +37,17 @@ const CommitDetailsView: React.FC<React.PropsWithChildren<CommitDetailsViewProps
     namespace,
     applicationName,
     commitName,
-    1,
   );
 
   const commit = React.useMemo(
-    () => loaded && pipelineruns?.length && createCommitObjectFromPLR(pipelineruns[0]),
+    () =>
+      loaded &&
+      pipelineruns?.length &&
+      createCommitObjectFromPLR(
+        pipelineruns.find(
+          (p) => p.metadata.labels[PipelineRunLabel.PIPELINE_TYPE] === PipelineRunType.BUILD,
+        ),
+      ),
     [loaded, pipelineruns],
   );
 

--- a/src/components/Commits/CommitDetails/__tests__/CommitDetailsView.spec.tsx
+++ b/src/components/Commits/CommitDetails/__tests__/CommitDetailsView.spec.tsx
@@ -74,4 +74,11 @@ describe('CommitDetailsView', () => {
     routerRenderer(<CommitDetailsView applicationName="test-application" commitName="commit123" />);
     screen.getAllByText(getCommitShortName('commit123'));
   });
+
+  it('should not use integration test pipeline to get details', () => {
+    watchResourceMock.mockReturnValue([[pipelineWithCommits[0], pipelineWithCommits[4]], true]);
+    routerRenderer(<CommitDetailsView applicationName="test-application" commitName="commit123" />);
+    expect(screen.getByText('test-title')).toBeVisible();
+    expect(screen.queryByRole('test-title-4')).toBeNull();
+  });
 });


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/RHTAPBUGS-987
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
If using the first available commit pipelinerun for commit details, we accidentaly use the integration test pipeline instead of build pipeline.
Explicitly find the first build pipelinerun instead.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
(No design changes)
![0](https://github.com/openshift/hac-dev/assets/20013884/6eb2302a-e7cc-43e9-96c2-89ec15bf2b64)

<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
Use custom pipeline flow and see commit details
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
