### PR TITLE
fix(access): Use RBAC for access page edit actions

### DIFF
--- a/src/components/UserAccess/__tests__/user-access-actions.spec.ts
+++ b/src/components/UserAccess/__tests__/user-access-actions.spec.ts
@@ -1,16 +1,23 @@
 import '@testing-library/jest-dom';
 import { renderHook } from '@testing-library/react-hooks';
+import { useAccessReviewForModel } from '../../../utils/rbac';
 import { useSBRActions } from '../user-access-actions';
 
 jest.mock('../../../utils/rbac', () => ({
-  useAccessReviewForModel: jest.fn(() => [true, true]),
+  useAccessReviewForModel: jest.fn(),
 }));
 
 jest.mock('../../../utils/workspace-context-utils', () => ({
   useWorkspaceInfo: jest.fn(() => ({ workspace: 'test-ws' })),
 }));
 
+const accessReviewMock = useAccessReviewForModel as jest.Mock;
+
 describe('useSBRActions', () => {
+  beforeEach(() => {
+    accessReviewMock.mockReturnValue([true, true]);
+  });
+
   it('should return enabled actions', () => {
     const { result } = renderHook(() =>
       useSBRActions({
@@ -41,6 +48,7 @@ describe('useSBRActions', () => {
   });
 
   it('should return disabled actions due to access', async () => {
+    accessReviewMock.mockReturnValue([false, true]);
     const { result } = renderHook(() =>
       useSBRActions({
         availableActions: [],


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/RHTAPBUGS-1001
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
Use RBAC instead of `availableActions` provided by workspace lister API to check for edit/delete actions on access page.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
(No design changes)
![0](https://github.com/openshift/hac-dev/assets/20013884/63382f9e-a8d2-4a98-b6c7-6dc3acdd5878)
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

## How to test or reproduce?
Try to edit/delete access for a workspace that you have maintainer access in.
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
