### PR TITLE
test(e2e): stabilize e2e quarkus sample test

### DIFF
--- a/integration-tests/tests/create-application-from-sample.spec.ts
+++ b/integration-tests/tests/create-application-from-sample.spec.ts
@@ -71,6 +71,7 @@ describe('Create component from sample', () => {
             Cypress.env('appName'),
           );
           cy.contains('Build not started').should('not.exist');
+          cy.wait(1000);
 
           //Delete component
           applicationDetailPage.deleteComponent(quarkusComponentName);


### PR DESCRIPTION
## Fixes 
Followup on https://issues.redhat.com/browse/RHTAPBUGS-1010

## Description
E2E tests for the Quarkus sample are occasionally failing because of page refresh. I'm not sure what to add for the check other than ugly wait.