### PR TITLE
fix(commit): Use black color for GH commit logo

### DIFF
--- a/src/shared/components/commit-label/CommitLabel.scss
+++ b/src/shared/components/commit-label/CommitLabel.scss
@@ -1,0 +1,3 @@
+.black-icon {
+  --pf-v5-c-label--m-blue__icon--Color: var(--pf-v5-global--Color--100);
+}

--- a/src/shared/components/commit-label/CommitLabel.tsx
+++ b/src/shared/components/commit-label/CommitLabel.tsx
@@ -3,8 +3,10 @@ import { Label, Tooltip } from '@patternfly/react-core';
 import { BitbucketIcon } from '@patternfly/react-icons/dist/js/icons/bitbucket-icon';
 import { GithubIcon } from '@patternfly/react-icons/dist/js/icons/github-icon';
 import { GitlabIcon } from '@patternfly/react-icons/dist/js/icons/gitlab-icon';
+import { css } from '@patternfly/react-styles';
 import { getCommitShortName } from '../../../utils/commits-utils';
 import { GitProvider } from '../../utils/git-utils';
+import './CommitLabel.scss';
 
 const tipText = {
   [GitProvider.GITHUB]: 'Open in GitHub',
@@ -30,8 +32,8 @@ const CommitLabel: React.FC<React.PropsWithChildren<CommitLabelProps>> = ({
   const commitShortName = getCommitShortName(sha);
   const label = (
     <Label
-      className="commit-label"
       color="blue"
+      className={css('commit-label', gitProvider === GitProvider.GITHUB && 'black-icon')}
       icon={providerIcon[gitProvider]}
       isCompact
       render={({ className, content }) => (

--- a/src/shared/components/commit-label/__tests__/CommitLabel.spec.tsx
+++ b/src/shared/components/commit-label/__tests__/CommitLabel.spec.tsx
@@ -32,7 +32,9 @@ describe('CommitLabel', () => {
   it('should render the correct provider icon', () => {
     let label = render(<CommitLabel gitProvider={GitProvider.GITHUB} sha={sha} shaURL={shaURL} />);
     let icon = label.queryByTestId(`git-hub-icon`);
+    const link = label.getByTestId(`commit-label-9135b3a`);
     expect(icon).toBeInTheDocument();
+    expect(link.parentElement).toHaveClass('black-icon');
     label.unmount();
 
     label = render(<CommitLabel gitProvider={GitProvider.GITLAB} sha={sha} shaURL={shaURL} />);


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/RHTAPBUGS-837
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
Use black color for commit label logo.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
![0](https://github.com/openshift/hac-dev/assets/20013884/9dcfcb45-aeef-4cda-b5ed-24fde297cc04)

<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
Go to a page that uses commit labels.
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
