### PR TITLE
fix(integration-test): Handle missing revision in git url params

### DIFF
--- a/src/components/IntegrationTest/IntegrationTestForm/utils/__tests__/create-utils.spec.ts
+++ b/src/components/IntegrationTest/IntegrationTestForm/utils/__tests__/create-utils.spec.ts
@@ -195,6 +195,12 @@ describe('Create Utils', () => {
     expect(getURLForParam(k8sResource.spec.resolverRef.params, ResolverRefParams.PATH)).toBe(
       'https://github.com/redhat-appstudio/integration-examples/tree/main/pipelines/integration_pipeline_pass.yaml',
     );
+    expect(
+      getURLForParam(
+        MockIntegrationTestsWithGit[3].spec.resolverRef.params,
+        ResolverRefParams.PATH,
+      ),
+    ).toBe('https://github.com/example/repo/tree/master/.tekton/pipeline.yaml');
   });
 
   it('Should set EC kind annotation', async () => {

--- a/src/components/IntegrationTest/IntegrationTestForm/utils/create-utils.ts
+++ b/src/components/IntegrationTest/IntegrationTestForm/utils/create-utils.ts
@@ -205,7 +205,7 @@ export const getURLForParam = (params: ResolverParam[], paramName: string): stri
   }
   if (paramName === ResolverRefParams.PATH && resolverParam) {
     const branch = params.find((param) => param.name === ResolverRefParams.REVISION);
-    return `${checkedURL}/tree/${branch.value}/${resolverParam.value}`;
+    return `${checkedURL}/tree/${branch.value || 'master'}/${resolverParam.value}`;
   }
   if (paramName === ResolverRefParams.REVISION && resolverParam) {
     return `${checkedURL}/tree/${resolverParam.value}`;

--- a/src/components/IntegrationTest/IntegrationTestsListView/__data__/mock-integration-tests.ts
+++ b/src/components/IntegrationTest/IntegrationTestsListView/__data__/mock-integration-tests.ts
@@ -198,6 +198,29 @@ export const MockIntegrationTestsWithGit: IntegrationTestScenarioKind[] = [
       ],
     },
   },
+  {
+    apiVersion: 'appstudio.redhat.com/v1alpha1',
+    kind: 'IntegrationTestScenario',
+    metadata: {
+      annotations: {
+        'app.kubernetes.io/display-name': 'Test 3',
+      },
+      name: 'test-app-test-4',
+      namespace: 'test-namespace',
+      uid: 'ed722704-74bc-4152-b27b-bee29cc7bfd3',
+    },
+    spec: {
+      application: 'test-app',
+      resolverRef: {
+        resolver: ResolverType.GIT,
+        params: [
+          { name: 'url', value: 'https://github.com/example/repo' },
+          { name: 'revision', value: '' },
+          { name: 'pathInRepo', value: '.tekton/pipeline.yaml' },
+        ],
+      },
+    },
+  },
 ];
 
 export const MockIntegrationTestsWithParams: IntegrationTestScenarioKind[] = [

--- a/src/components/IntegrationTest/tabs/IntegrationTestOverviewTab.tsx
+++ b/src/components/IntegrationTest/tabs/IntegrationTestOverviewTab.tsx
@@ -112,6 +112,9 @@ const IntegrationTestOverviewTab: React.FC<
                       integrationTest.spec.resolverRef.params,
                       param.name,
                     );
+                    if (!param.value) {
+                      return null;
+                    }
                     return (
                       <DescriptionListGroup key={param.name}>
                         <DescriptionListTerm>{getLabelForParam(param.name)}</DescriptionListTerm>

--- a/src/components/IntegrationTest/tabs/__tests__/IntegrationTestOverviewTab.spec.tsx
+++ b/src/components/IntegrationTest/tabs/__tests__/IntegrationTestOverviewTab.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { fireEvent, render, screen, configure } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { useModalLauncher } from '../../../modal/ModalProvider';
 import {
   MockIntegrationTestsWithBundles,
@@ -58,6 +59,11 @@ describe('IntegrationTestOverviewTab', () => {
     expect(screen.getAllByRole('link')[2].getAttribute('href')).toBe(
       'https://test-url2/tree/main2/test-path2',
     ); // path link
+  });
+
+  it('should not render param if value is not given', () => {
+    render(<IntegrationTestOverviewTab integrationTest={MockIntegrationTestsWithGit[3]} />);
+    expect(screen.queryByText('revision')).not.toBeInTheDocument();
   });
 
   it('should use the git url from the spec param', () => {


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/RHTAPBUGS-884
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
- avoid showing params where value is not defined
- use `master` as default branch when revision param is not provided (GH automatically redirects to a valid default branch in this case)
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
![0](https://github.com/openshift/hac-dev/assets/20013884/baeb3078-f0ca-42e3-81ce-e6cc437a8afe)
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
Create an integration test without specifying git revision.
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
