### PR TITLE
fix(overview): set max height for tooltips on nodes

### DIFF
--- a/src/components/ApplicationDetails/tabs/overview/visualization/nodes/WorkflowNodeTipContent.scss
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/nodes/WorkflowNodeTipContent.scss
@@ -3,10 +3,17 @@
   flex-direction: column;
   gap: var(--pf-v5-global--spacer--md);
   text-align: left;
-  padding: var(--pf-v5-global--spacer--md);
+  padding-top: var(--pf-v5-global--spacer--md);
+  padding-bottom: var(--pf-v5-global--spacer--md);
+  padding-left: var(--pf-v5-global--spacer--md);
+  max-height: 600px;
 
   &-title {
     font-size: var(--pf-v5-global--icon--FontSize--md);
+    padding-right: var(--pf-v5-global--spacer--md);
+  }
+  &-description {
+    padding-right: var(--pf-v5-global--spacer--md);
   }
 
   &-status {
@@ -15,6 +22,9 @@
       grid-template-columns: auto auto auto;
       column-gap: var(--pf-v5-global--spacer--md);
       row-gap: var(--pf-v5-global--spacer--sm);
+      overflow-y: auto;
+      padding-right: var(--pf-v5-global--spacer--md);
+
       .pf-topology-pipelines__status-icon.pf-m-spin {
         > svg {
           filter: blur(0);
@@ -29,5 +39,6 @@
   &-links {
     display: flex;
     gap: var(--pf-v5-global--spacer--md);
+    padding-right: var(--pf-v5-global--spacer--md);
   }
 }


### PR DESCRIPTION
## Fixes 
Fixes [RHTAPBUGS-1080](https://issues.redhat.com/browse/RHTAPBUGS-1080)

## Description
The height of the tooltips was not constrained at all so if there are a lot of builds (or any other items) in a tooltip it would be larger than the view height causing the window to scroll past the current view leaving lots of blank space.

Set the maximum height of the tooltip to be 600 pixels and have the individual items in a scrollable area so the user can view all the items if desired.

## Type of change
- [x] Bugfix

## Screen shots / Gifs for design review 
![image](https://github.com/openshift/hac-dev/assets/11633780/4cac3397-f1cc-4dd7-a56f-70ce0e7aab7f)

## How to test or reproduce?
Create a project with many many builds. Hover over the build node in the overview section.
