### PR TITLE
fix(logs): Update PLR logs fetch logic to match the new tekton results changes

### DIFF
--- a/src/utils/__tests__/tekton-results.spec.ts
+++ b/src/utils/__tests__/tekton-results.spec.ts
@@ -1,4 +1,4 @@
-import { commonFetchJSON } from '@openshift/dynamic-plugin-sdk-utils';
+import { commonFetchJSON, commonFetchText } from '@openshift/dynamic-plugin-sdk-utils';
 import {
   AND,
   createTektonResultsUrl,
@@ -23,7 +23,7 @@ import {
 jest.mock('@openshift/dynamic-plugin-sdk-utils');
 
 const commonFetchJSONMock = commonFetchJSON as unknown as jest.Mock;
-
+const commonFetchTextMock = commonFetchText as unknown as jest.Mock;
 const sampleOptions: TektonResultsOptions = {
   filter: 'count > 1',
   selector: {
@@ -77,12 +77,7 @@ const mockLogsRecordsList = {
   ],
 } as RecordsList;
 
-const mockLogResponse = {
-  result: {
-    // 'sample log'
-    data: 'c2FtcGxlIGxvZw==',
-  },
-};
+const mockLogResponse = 'sample log';
 
 describe('tekton-results', () => {
   beforeEach(() => {
@@ -529,14 +524,15 @@ describe('tekton-results', () => {
 
   describe('getTaskRunLog', () => {
     it('should return the latest component build task run', async () => {
-      commonFetchJSONMock
-        .mockReturnValueOnce(mockLogsRecordsList)
-        .mockReturnValueOnce(Promise.resolve(mockLogResponse));
+      commonFetchJSONMock.mockReturnValueOnce(mockLogsRecordsList);
+      commonFetchTextMock.mockReturnValueOnce(Promise.resolve(mockLogResponse));
       expect(await getTaskRunLog('test-ws', 'test-ns', 'sample-task-run')).toEqual('sample log');
       expect(commonFetchJSONMock.mock.calls).toEqual([
         [
           '/plugins/tekton-results/workspaces/test-ws/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=5&filter=data_type+%3D%3D+%22results.tekton.dev%2Fv1alpha2.Log%22+%26%26+data.spec.resource.kind+%3D%3D+%22TaskRun%22+%26%26+data.spec.resource.name+%3D%3D+%22sample-task-run%22',
         ],
+      ]);
+      expect(commonFetchTextMock.mock.calls).toEqual([
         [
           '/plugins/tekton-results/workspaces/test-ws/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/b9f43742-3675-4a71-8d73-31c5f5080a74/logs/113298cc-07f9-3ce0-85e3-5cf635eacf62',
         ],

--- a/src/utils/tekton-results.ts
+++ b/src/utils/tekton-results.ts
@@ -1,5 +1,6 @@
 import {
   commonFetchJSON,
+  commonFetchText,
   K8sResourceCommon,
   MatchExpression,
   MatchLabels,
@@ -330,9 +331,7 @@ export const getTaskRuns = (
 ) => getFilteredTaskRuns(workspace, namespace, '', options, nextPageToken, cacheKey);
 
 const getLog = (workspace: string, taskRunPath: string) =>
-  commonFetchJSON<Log>(
-    `${getTRUrlPrefix(workspace)}/${taskRunPath.replace('/records/', '/logs/')}`,
-  );
+  commonFetchText(`${getTRUrlPrefix(workspace)}/${taskRunPath.replace('/records/', '/logs/')}`);
 
 export const getTaskRunLog = (
   workspace: string,
@@ -347,8 +346,6 @@ export const getTaskRunLog = (
     { limit: 1 },
   ).then((x) =>
     x?.[1]?.records.length > 0
-      ? getLog(workspace, x?.[1]?.records[0].name).then((response) =>
-          decodeValue(response.result.data),
-        )
+      ? getLog(workspace, x?.[1]?.records[0].name).catch(() => throw404())
       : throw404(),
   );


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/RHTAPBUGS-1093

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

PipelineRun logs is not streaming properly in the UI because the tekton results logs API is now returning raw logs content directly, so UI doesn't need to decode the value again.

tekton-results PR introduced this change - https://github.com/tektoncd/results/pull/632


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:

<img width="1789" alt="image" src="https://github.com/openshift/hac-dev/assets/9964343/4b0d7d24-dcf0-4852-b2b7-4951fffe1d03">


After:

<img width="1792" alt="image" src="https://github.com/openshift/hac-dev/assets/9964343/af8e715d-696c-4968-a221-25d743d2100f">




## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->
- Visit logs tab in the pipelinerun details page


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
