### PR TITLE
fix(test): remove menu item Learning resources

### DIFF
--- a/integration-tests/support/constants/PageTitle.ts
+++ b/integration-tests/support/constants/PageTitle.ts
@@ -11,7 +11,6 @@ export enum NavItem {
   overview = 'Overview',
   applications = 'Applications',
   environments = 'Environments',
-  learning = 'Learning Resources',
   secrets = 'Secrets',
 }
 


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/HAC-5659

## Description
The "Learning resources" item was removed from a Menu. Removing it from tests.