### PR TITLE
Add Tekton results API error handling and enable cache to avoid refetches on load

### DIFF
--- a/src/components/Commits/CommitsListView.tsx
+++ b/src/components/Commits/CommitsListView.tsx
@@ -8,16 +8,18 @@ import {
 } from '@patternfly/react-core';
 import {
   Select,
-  SelectVariant,
   SelectGroup,
   SelectOption,
+  SelectVariant,
 } from '@patternfly/react-core/deprecated';
 import { FilterIcon } from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import { useBuildPipelines } from '../../hooks/useBuildPipelines';
 import { useComponents } from '../../hooks/useComponents';
 import { useSearchParam } from '../../hooks/useSearchParam';
+import ErrorEmptyState from '../../shared/components/empty-state/ErrorEmptyState';
 import FilteredEmptyState from '../../shared/components/empty-state/FilteredEmptyState';
 import Table from '../../shared/components/table/Table';
+import { HttpError } from '../../shared/utils/error/http-error';
 import { getCommitsFromPLRs, statuses } from '../../utils/commits-utils';
 import { pipelineRunStatus } from '../../utils/pipeline-utils';
 import { useWorkspaceInfo } from '../../utils/workspace-context-utils';
@@ -43,7 +45,7 @@ const CommitsListView: React.FC<React.PropsWithChildren<CommitsListViewProps>> =
     applicationName,
   );
 
-  const [pipelineRuns, loaded, , getNextPage] = useBuildPipelines(
+  const [pipelineRuns, loaded, error, getNextPage] = useBuildPipelines(
     namespace,
     applicationName,
     undefined,
@@ -163,6 +165,16 @@ const CommitsListView: React.FC<React.PropsWithChildren<CommitsListViewProps>> =
     </Toolbar>
   );
 
+  if (error) {
+    const httpError = HttpError.fromCode(error ? (error as any).code : 404);
+    return (
+      <ErrorEmptyState
+        httpError={httpError}
+        title="Unable to load pipeline runs"
+        body={httpError?.message.length ? httpError?.message : 'Something went wrong'}
+      />
+    );
+  }
   return (
     <Table
       virtualize

--- a/src/components/Commits/__tests__/CommitsListView.spec.tsx
+++ b/src/components/Commits/__tests__/CommitsListView.spec.tsx
@@ -82,6 +82,12 @@ describe('CommitsListView', () => {
     useComponentsMock.mockReturnValue([MockComponents, true]);
   });
 
+  it('should render error state when there is an API error', () => {
+    watchResourceMock.mockReturnValue([[], true, new Error('500: Internal server error')]);
+    render(<CommitsListView applicationName="purple-mermaid-app" />);
+    screen.getByText('Unable to load pipeline runs');
+  });
+
   it('should render empty state if no commits are present', () => {
     watchResourceMock.mockReturnValue([[], true]);
     render(<CommitsListView applicationName="purple-mermaid-app" />);

--- a/src/components/Commits/tabs/__tests__/CommitsPipelineRunTab.spec.tsx
+++ b/src/components/Commits/tabs/__tests__/CommitsPipelineRunTab.spec.tsx
@@ -69,6 +69,21 @@ const commitPlrs = [
 ];
 
 describe('Commit Pipelinerun List', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it('should render error state if the API errors out', () => {
+    usePipelineRunsForCommitMock.mockReturnValue([
+      [],
+      true,
+      new Error('500: Internal server error'),
+    ]);
+
+    render(<CommitsPipelineRunTab applicationName={appName} commitName="test-sha" />);
+
+    screen.getByText('Unable to load pipeline runs');
+  });
+
   it('should render empty state if no pipelinerun is present', () => {
     usePipelineRunsForCommitMock.mockReturnValue([[], true]);
     watchResourceMock.mockReturnValue([[], true]);

--- a/src/components/IntegrationTest/tabs/IntegrationTestPipelineRunTab.tsx
+++ b/src/components/IntegrationTest/tabs/IntegrationTestPipelineRunTab.tsx
@@ -3,6 +3,8 @@ import { Bullseye, Spinner, Title } from '@patternfly/react-core';
 import { PipelineRunLabel } from '../../../consts/pipelinerun';
 import { usePipelineRuns } from '../../../hooks/usePipelineRuns';
 import { Table } from '../../../shared';
+import ErrorEmptyState from '../../../shared/components/empty-state/ErrorEmptyState';
+import { HttpError } from '../../../shared/utils/error/http-error';
 import { PipelineRunKind } from '../../../types';
 import { useWorkspaceInfo } from '../../../utils/workspace-context-utils';
 import PipelineRunEmptyState from '../../PipelineRunDetailsView/PipelineRunEmptyState';
@@ -16,7 +18,8 @@ const IntegrationTestPipelineRunTab: React.FC<
 > = ({ applicationName, testName }) => {
   const { namespace } = useWorkspaceInfo();
 
-  const [pipelineRuns, loaded, , getNextPage] = usePipelineRuns(
+  // Todo add errors here
+  const [pipelineRuns, loaded, error, getNextPage] = usePipelineRuns(
     namespace,
     React.useMemo(
       () => ({
@@ -30,6 +33,17 @@ const IntegrationTestPipelineRunTab: React.FC<
       [applicationName, testName],
     ),
   );
+
+  if (error) {
+    const httpError = HttpError.fromCode(error ? (error as any).code : 404);
+    return (
+      <ErrorEmptyState
+        httpError={httpError}
+        title="Unable to load pipeline runs"
+        body={httpError?.message.length ? httpError?.message : 'Something went wrong'}
+      />
+    );
+  }
 
   if (!loaded) {
     return (

--- a/src/components/IntegrationTest/tabs/__tests__/IntegrationTestPipelineRunTab.spec.tsx
+++ b/src/components/IntegrationTest/tabs/__tests__/IntegrationTestPipelineRunTab.spec.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { usePipelineRuns } from '../../../../hooks/usePipelineRuns';
+import { mockTestPipelinesData } from '../../../ApplicationDetails/__data__';
+import IntegrationTestPipelineRunTab from '../IntegrationTestPipelineRunTab';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  useK8sWatchResource: jest.fn(),
+  getActiveWorkspace: jest.fn(() => 'test-ws'),
+}));
+
+jest.mock('../../../../hooks/usePipelineRuns', () => ({
+  usePipelineRuns: jest.fn(),
+}));
+
+const usePipelineRunsMock = usePipelineRuns as jest.Mock;
+
+describe('Integration Pipelinerun List', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the progressbar if it is still loading', () => {
+    usePipelineRunsMock.mockReturnValue([[], false]);
+    render(
+      <IntegrationTestPipelineRunTab
+        applicationName={'test-app'}
+        testName="integration-test-one"
+      />,
+    );
+    screen.getByRole('progressbar');
+  });
+
+  it('should render the error state incase of any API errors', () => {
+    usePipelineRunsMock.mockReturnValue([[], false, new Error('500: Internal server error')]);
+    render(
+      <IntegrationTestPipelineRunTab
+        applicationName={'test-app'}
+        testName="integration-test-one"
+      />,
+    );
+    screen.getByText('Unable to load pipeline runs');
+  });
+
+  it('should render the empty state if there is not any pipelineruns available', () => {
+    usePipelineRunsMock.mockReturnValue([[], true]);
+    render(
+      <IntegrationTestPipelineRunTab
+        applicationName={'test-app'}
+        testName="integration-test-one"
+      />,
+    );
+    screen.getByText('Add component');
+  });
+
+  it('should render the pipelineruns list', () => {
+    usePipelineRunsMock.mockReturnValue([mockTestPipelinesData, true]);
+    render(
+      <IntegrationTestPipelineRunTab
+        applicationName={'test-app'}
+        testName="integration-test-one"
+      />,
+    );
+    screen.getByLabelText('Pipeline run List');
+  });
+});

--- a/src/components/PipelineRunListView/PipelineRunListRow.tsx
+++ b/src/components/PipelineRunListView/PipelineRunListRow.tsx
@@ -57,7 +57,9 @@ const BasePipelineRunListRow: React.FC<React.PropsWithChildren<BasePipelineRunLi
           data-testid="vulnerabilities"
           className={pipelineRunTableColumnClasses.vulnerabilities}
         >
-          {!obj?.status?.completionTime ? (
+          {customData?.error ? (
+            <>N/A</>
+          ) : !obj?.status?.completionTime ? (
             '-'
           ) : scanLoaded ? (
             <ScanStatus scanResults={scanResults} />

--- a/src/components/PipelineRunListView/PipelineRunsListView.tsx
+++ b/src/components/PipelineRunListView/PipelineRunsListView.tsx
@@ -20,7 +20,9 @@ import { usePipelineRuns } from '../../hooks/usePipelineRuns';
 import { usePLRVulnerabilities } from '../../hooks/useScanResults';
 import { useSearchParam } from '../../hooks/useSearchParam';
 import { Table } from '../../shared';
+import ErrorEmptyState from '../../shared/components/empty-state/ErrorEmptyState';
 import FilteredEmptyState from '../../shared/components/empty-state/FilteredEmptyState';
+import { HttpError } from '../../shared/utils/error/http-error';
 import { PipelineRunKind } from '../../types';
 import { statuses } from '../../utils/commits-utils';
 import { pipelineRunStatus } from '../../utils/pipeline-utils';
@@ -55,7 +57,7 @@ const PipelineRunsListView: React.FC<React.PropsWithChildren<PipelineRunsListVie
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const [pipelineRuns, loaded, , getNextPage] = usePipelineRuns(
+  const [pipelineRuns, loaded, error, getNextPage] = usePipelineRuns(
     componentsLoaded ? namespace : null,
     React.useMemo(
       () => ({
@@ -201,6 +203,16 @@ const PipelineRunsListView: React.FC<React.PropsWithChildren<PipelineRunsListVie
     </Toolbar>
   );
 
+  if (error) {
+    const httpError = HttpError.fromCode(error ? (error as any).code : 404);
+    return (
+      <ErrorEmptyState
+        httpError={httpError}
+        title="Unable to load pipeline runs"
+        body={httpError?.message.length ? httpError?.message : 'Something went wrong'}
+      />
+    );
+  }
   return (
     <Table
       data={filteredPLRs}

--- a/src/components/PipelineRunListView/__tests__/PipelineRunListRow.spec.tsx
+++ b/src/components/PipelineRunListView/__tests__/PipelineRunListRow.spec.tsx
@@ -47,6 +47,24 @@ describe('Pipeline run Row', () => {
     expect(row.getByText('Succeeded')).toBeDefined();
   });
 
+  it('should return N/A when vulnerabilities API errors out ', () => {
+    const succeededPlr = testPipelineRuns[DataState.SUCCEEDED];
+    const plrName = succeededPlr.metadata.name;
+    const row = render(
+      <PipelineRunListRowWithVulnerabilities
+        obj={succeededPlr}
+        customData={{
+          fetchedPipelineRuns: [plrName],
+          vulnerabilities: [{ [plrName]: {} }],
+          error: new Error('500: Internal Server error'),
+        }}
+        columns={[]}
+      />,
+    );
+
+    expect(row.getByText('N/A')).toBeDefined();
+  });
+
   it('should show vulnerabilities when it is available ', () => {
     const succeededPlr = testPipelineRuns[DataState.SUCCEEDED];
     const plrName = succeededPlr.metadata.name;

--- a/src/components/PipelineRunListView/__tests__/PipelineRunListView.spec.tsx
+++ b/src/components/PipelineRunListView/__tests__/PipelineRunListView.spec.tsx
@@ -210,6 +210,12 @@ describe('Pipeline run List', () => {
     );
   });
 
+  it('should render error state when there is an API error', () => {
+    usePipelineRunsMock.mockReturnValue([[], true, new Error('500: Internal server error')]);
+    render(<PipelineRunsListView applicationName="purple-mermaid-app" />);
+    screen.getByText('Unable to load pipeline runs');
+  });
+
   it('should render correct columns when pipelineRuns are present', () => {
     usePipelineRunsMock.mockReturnValue([pipelineRuns, true]);
     render(<PipelineRunsListView applicationName={appName} />);

--- a/src/hooks/__tests__/useScanResults.spec.ts
+++ b/src/hooks/__tests__/useScanResults.spec.ts
@@ -71,13 +71,20 @@ describe('usePLRScanResults', () => {
   it('returns null if results are not fetched', () => {
     useTRTaskRunsMock.mockReturnValue([null, false]);
     const { result } = renderHook(() => usePLRScanResults(['test1']));
-    expect(result.current).toEqual([null, false, []]);
+    expect(result.current).toEqual([null, false, [], undefined]);
   });
 
   it('returns null if scan results are not found in taskrun', () => {
     useTRTaskRunsMock.mockReturnValue([[], true]);
     const { result } = renderHook(() => usePLRScanResults(['test2']));
-    expect(result.current).toEqual([null, true, []]);
+    expect(result.current).toEqual([null, true, [], undefined]);
+  });
+
+  it('returns error if scan results API is failing', () => {
+    const badGatewayError = new Error('502: bad gateway error');
+    useTRTaskRunsMock.mockReturnValue([[], true, badGatewayError]);
+    const { result } = renderHook(() => usePLRScanResults(['test2']));
+    expect(result.current).toEqual([null, true, [], badGatewayError]);
   });
 
   it('returns scan results if taskrun is found', () => {

--- a/src/hooks/__tests__/useTektonResults.spec.ts
+++ b/src/hooks/__tests__/useTektonResults.spec.ts
@@ -145,7 +145,7 @@ describe('useTektonResults', () => {
         });
         const { result } = renderHook(() => useTestHook('test-ns'));
         expect(getRunsMock).toHaveBeenCalledWith('test-ws', 'test-ns', undefined, null, undefined);
-        expect(result.current).toEqual([[], false, error, undefined]);
+        expect(result.current).toEqual([[], true, error, undefined]);
       });
 
       it('should return error when exception thrown when getting next page', async () => {

--- a/src/hooks/useScanResults.ts
+++ b/src/hooks/useScanResults.ts
@@ -153,8 +153,6 @@ export const getScanResultsMap = (
 
 export const usePLRScanResults = (
   pipelineRunNames: string[],
-  // enable cache only if the pipeline run has completed
-  cache?: boolean,
 ): [{ [key: string]: any }, boolean, string[]] => {
   // Fetch directly from tekton-results because a task result is only present on completed tasks runs.
   const cacheKey = React.useRef('');
@@ -184,9 +182,7 @@ export const usePLRScanResults = (
       }),
       [pipelineRunNames],
     ),
-    cache && pipelineRunNames.length
-      ? `useScanResults-${pipelineRunNames.sort().join('|')}`
-      : undefined,
+    pipelineRunNames.length ? `useScanResults-${pipelineRunNames.sort().join('|')}` : undefined,
   );
 
   return React.useMemo(() => {

--- a/src/hooks/useTektonResults.ts
+++ b/src/hooks/useTektonResults.ts
@@ -89,7 +89,7 @@ const useTRRuns = <Kind extends K8sResourceCommon>(
             if (nextPageToken) {
               setResult((cur) => [cur[0], cur[1], e, undefined]);
             } else {
-              setResult([[], false, e, undefined]);
+              setResult([[], true, e, undefined]);
             }
           }
         }


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/KFLUXBUGS-1168
https://issues.redhat.com/browse/KFLUXBUGS-1169 

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR aims to improve the tekton results API fetching and error handling.

The changes includes
1.  Avoiding multiple re-fetches of same API call on load of the pipelinerun list view
2. Add error states in all the pipelinerun list views like commit page, integration page and in activity tab.
3. Incase of error while fetching the taskruns (vulnerability column) then UI will show `N/A` and avoids refetching.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

**Initial load of Pipelinerun/taskruns:**

https://github.com/openshift/hac-dev/assets/9964343/19f2d4e7-a281-43e0-b3b5-a8567bae0e93

_Note: Previously Initial loads used to make two same Taskrun calls, that is now fixed._


---

**Pipelinerun API call failure:**

<img width="1791" alt="plr-error-state" src="https://github.com/openshift/hac-dev/assets/9964343/c6c61a25-255f-4948-a487-da55682ec403">


**Vulnerability Taskrun API call failure:**

<img width="1784" alt="vulnerability-error-state" src="https://github.com/openshift/hac-dev/assets/9964343/f5be9c2e-e2d6-4e41-8ee6-ded970804584">


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->
1. Check the network to see the tekton-results calls on load of pipelinerun list view, there shouldn't be two same API calls happening.
2. To test the error states, Programmatically throw errors in commonFetchJson API call in tekton-results  [here](https://github.com/openshift/hac-dev/blob/main/src/utils/tekton-results.ts#L249) to see the error states.
<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

cc: @rohitkrai03 
