### PR TITLE
feat(STONEINTG-877): add Fixable to vulnerabilities titles

### DIFF
--- a/integration-tests/support/pages/tabs/PipelinerunsTabPage.ts
+++ b/integration-tests/support/pages/tabs/PipelinerunsTabPage.ts
@@ -97,21 +97,21 @@ export class DetailsTab {
 
   static checkVulScanOnClairDrawer(vulnerabilities: RegExp) {
     cy.get(pipelinerunsTabPO.drawerPanel)
-      .contains(pipelinerunsTabPO.listGroup, 'Vulnerabilities scan')
+      .contains(pipelinerunsTabPO.listGroup, 'Fixable vulnerabilities scan')
       .contains(vulnerabilities)
       .scrollIntoView()
       .should('be.visible');
   }
 
   static checkVulScanOnPipelinerunDetails(vulnerabilities: RegExp) {
-    cy.contains(pipelinerunsTabPO.listGroup, 'Vulnerabilities scan')
+    cy.contains(pipelinerunsTabPO.listGroup, 'Fixable vulnerabilities scan')
       .contains(vulnerabilities)
       .scrollIntoView()
       .should('be.visible');
   }
 
   static clickOnVulScanViewLogs() {
-    cy.contains(pipelinerunsTabPO.listGroup, 'Vulnerabilities scan').contains('View logs').click();
+    cy.contains(pipelinerunsTabPO.listGroup, 'Fixable vulnerabilities scan').contains('View logs').click();
   }
 
   static clickOnDrawerPanelLogsTab() {

--- a/src/components/Components/ComponentDeployments/ComponentDeploymentsListHeader.tsx
+++ b/src/components/Components/ComponentDeployments/ComponentDeploymentsListHeader.tsx
@@ -21,7 +21,7 @@ const ComponentDeploymentsListHeader = () => {
       props: { className: componentDeploymentsColumnClasses.snapshot },
     },
     {
-      title: 'Vulnerabilities',
+      title: 'Fixable vulnerabilities',
       props: { className: componentDeploymentsColumnClasses.vulnerabilities },
     },
     {

--- a/src/components/PipelineRunDetailsView/sidepanels/__tests__/TaskRunDetails.spec.tsx
+++ b/src/components/PipelineRunDetailsView/sidepanels/__tests__/TaskRunDetails.spec.tsx
@@ -57,7 +57,7 @@ describe('TaskRunDetails', () => {
     expect(result.queryByText('Results')).toBeInTheDocument();
     expect(result.queryByText('test-name')).toBeInTheDocument();
     expect(result.queryByText('test-value')).toBeInTheDocument();
-    expect(result.container).not.toHaveTextContent('Vulnerabilities scan');
+    expect(result.container).not.toHaveTextContent('Fixable vulnerabilities scan');
   });
 
   it('should render task run vulnerabilities scan results', () => {
@@ -84,6 +84,6 @@ describe('TaskRunDetails', () => {
         }
       />,
     );
-    expect(container).toHaveTextContent('Vulnerabilities scan');
+    expect(container).toHaveTextContent('Fixable vulnerabilities scan');
   });
 });

--- a/src/components/PipelineRunDetailsView/tabs/ScanDescriptionListGroup.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/ScanDescriptionListGroup.tsx
@@ -103,7 +103,7 @@ const ScanDescriptionListGroup: React.FC<React.PropsWithChildren<Props>> = ({
 
   return (
     <DescriptionListGroup>
-      <DescriptionListTerm>Vulnerabilities scan</DescriptionListTerm>
+      <DescriptionListTerm>Fixable vulnerabilities scan</DescriptionListTerm>
       <DescriptionListDescription>
         {scanResults?.vulnerabilities ? <ScanDetailStatus scanResults={scanResults} /> : '-'}
         {scanResults?.vulnerabilities ? renderLogsLink() : null}

--- a/src/components/PipelineRunDetailsView/tabs/__tests__/ScanDescriptionListGroup.spec.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/__tests__/ScanDescriptionListGroup.spec.tsx
@@ -57,7 +57,7 @@ const mockTaskRun2 = {
 describe('ScanDescriptionListGroup', () => {
   it('should show empty state if results are not available', () => {
     const { container } = render(<ScanDescriptionListGroup taskRuns={[]} />);
-    expect(container).toHaveTextContent('Vulnerabilities scan');
+    expect(container).toHaveTextContent('Fixable vulnerabilities scan');
     expect(container).toHaveTextContent('-');
   });
 
@@ -70,7 +70,7 @@ describe('ScanDescriptionListGroup', () => {
     const { container } = render(
       <ScanDescriptionListGroup taskRuns={[mockTaskRun]} hideIfNotFound />,
     );
-    expect(container).toHaveTextContent('Vulnerabilities scan');
+    expect(container).toHaveTextContent('Fixable vulnerabilities scan');
     expect(screen.getByTestId('scan-status-critical-test-id')).toHaveTextContent('Critical1');
     expect(screen.getByTestId('scan-status-high-test-id')).toHaveTextContent('High2');
     expect(screen.getByTestId('scan-status-medium-test-id')).toHaveTextContent('Medium3');

--- a/src/components/PipelineRunListView/PipelineRunListHeader.ts
+++ b/src/components/PipelineRunListView/PipelineRunListHeader.ts
@@ -22,7 +22,7 @@ const createPipelineRunListHeader = (showVulnerabilities: boolean) => () => {
     ...(showVulnerabilities
       ? [
           {
-            title: 'Vulnerabilities',
+            title: 'Fixable Vulnerabilities',
             props: { className: pipelineRunTableColumnClasses.vulnerabilities },
           },
         ]


### PR DESCRIPTION
* Since STONEINTG-877, the clair-scan task differentiates between fixable and unpatched vulnerabilities in the CLAIR_SCAN_RESULT pipeline result.
* This change clarifies that only a count of Fixable vulnerabilities is currently displayed in the UI in order to prevent confusion.


## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
