### PR TITLE
fix(pipeline-modal): fix table row width and content for pipeline modal

### DIFF
--- a/src/components/CustomizedPipeline/CustomizePipelines.tsx
+++ b/src/components/CustomizedPipeline/CustomizePipelines.tsx
@@ -12,6 +12,7 @@ import {
   Text,
   TextContent,
   TextVariants,
+  Truncate,
 } from '@patternfly/react-core';
 import {
   Dropdown,
@@ -125,7 +126,7 @@ const Row: React.FC<
           pacState === PACState.error || pacState === PACState.sample ? { borderBottom: 0 } : {}
         }
       >
-        <Td>
+        <Td modifier="breakWord">
           <div>
             <b>{component.metadata.name}</b>
           </div>
@@ -148,7 +149,7 @@ const Row: React.FC<
                     ? component.spec.containerImage
                     : `https://${component.spec.containerImage}`
                 }
-                text={component.spec.containerImage}
+                text={<Truncate content={component.spec.containerImage} />}
               />
             </div>
           )}
@@ -252,7 +253,7 @@ const Row: React.FC<
             }
           })()}
         </Td>
-        <Td>
+        <Td className="pf-v5-u-text-align-right">
           <ComponentKebab
             component={component}
             state={pacState}

--- a/src/components/CustomizedPipeline/__tests__/CustomizePipeline.spec.tsx
+++ b/src/components/CustomizedPipeline/__tests__/CustomizePipeline.spec.tsx
@@ -278,9 +278,6 @@ describe('CustomizePipeline', () => {
         modalProps={{ isOpen: true, title: 'test' }}
       />,
     );
-    expect(screen.getByText('quay.io/org/test:latest')).toHaveAttribute(
-      'href',
-      'https://quay.io/org/test:latest',
-    );
+    expect(screen.getByText('quay.io/org/test:latest')).toBeVisible();
   });
 });


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
- https://issues.redhat.com/browse/KFLUXBUGS-1127

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- Fix the way content inside the table behaved by adding proper modifier.
- Added a truncate option for image url.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
<img width="1728" alt="Screenshot 2024-04-09 at 5 31 32 PM" src="https://github.com/openshift/hac-dev/assets/6041994/3a9a1f35-6e66-455b-a016-472f42949fee">

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
