### PR TITLE
fix(pipeline): fix pipeline rerun actions to run pac build

### DIFF
--- a/src/components/ApplicationDetails/component-actions.tsx
+++ b/src/components/ApplicationDetails/component-actions.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ComponentModel } from '../../models';
 import { Action } from '../../shared/components/action-menu/types';
 import { ComponentKind } from '../../types';
-import { isPACEnabled, startNewBuild } from '../../utils/component-utils';
+import { startNewBuild } from '../../utils/component-utils';
 import { useAccessReviewForModel } from '../../utils/rbac';
 import { useWorkspaceInfo } from '../../utils/workspace-context-utils';
 import { createCustomizeComponentPipelineModalLauncher } from '../CustomizedPipeline/CustomizePipelinesModal';
@@ -40,9 +40,7 @@ export const useComponentActions = (component: ComponentKind, name: string): Act
           workspace,
         },
       },
-    ];
-    if (!isPACEnabled(component)) {
-      updatedActions.push({
+      {
         cta: () => startNewBuild(component),
         id: 'start-new-build',
         label: 'Start new build',
@@ -55,9 +53,7 @@ export const useComponentActions = (component: ComponentKind, name: string): Act
           app_name: applicationName,
           workspace,
         },
-      });
-    }
-    updatedActions.push(
+      },
       {
         cta: {
           href: `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/components/${name}/deployment-settings`,
@@ -81,7 +77,7 @@ export const useComponentActions = (component: ComponentKind, name: string): Act
         disabled: !canDeleteComponent,
         disabledTooltip: "You don't have access to delete a component",
       },
-    );
+    ];
     return updatedActions;
   }, [
     applicationName,

--- a/src/components/PipelineRunDetailsView/__tests__/PipelineRunDetailsView.spec.tsx
+++ b/src/components/PipelineRunDetailsView/__tests__/PipelineRunDetailsView.spec.tsx
@@ -326,29 +326,6 @@ describe('PipelineRunDetailsView', () => {
     expect(screen.queryByText('Rerun')).toHaveAttribute('aria-disabled', 'true');
   });
 
-  it('should render start new build action', async () => {
-    const navigateMock = jest.fn();
-    useNavigateMock.mockImplementation(() => {
-      return navigateMock;
-    });
-    watchResourceMock
-      .mockReturnValueOnce([testPipelineRuns[DataState.SUCCEEDED], true])
-      .mockReturnValue([[], true]);
-
-    routerRenderer(<PipelineRunDetailsView pipelineRunName={pipelineRunName} />);
-    fireEvent.click(screen.queryByRole('button', { name: 'Actions' }));
-
-    const startNewBuildButton = screen.queryByText('Start new build');
-    expect(startNewBuildButton).toHaveAttribute('aria-disabled', 'false');
-
-    fireEvent.click(startNewBuildButton);
-    await waitFor(() =>
-      expect(navigateMock).toHaveBeenCalledWith(
-        '/application-pipeline/workspaces/test-ws/applications/test-app/activity/pipelineruns?name=mock-component',
-      ),
-    );
-  });
-
   it('should disable Stop and Cancel buttons if user does not have access to patch pipeline run', () => {
     watchResourceMock
       .mockReturnValueOnce([testPipelineRuns[DataState.RUNNING], true])

--- a/src/components/PipelineRunListView/pipelinerun-actions.tsx
+++ b/src/components/PipelineRunListView/pipelinerun-actions.tsx
@@ -6,7 +6,7 @@ import { useSnapshots } from '../../hooks/useSnapshots';
 import { ComponentModel, PipelineRunModel, SnapshotModel } from '../../models';
 import { Action } from '../../shared/components/action-menu/types';
 import { PipelineRunKind } from '../../types';
-import { isPACEnabled, rerunBuildPipeline } from '../../utils/component-utils';
+import { startNewBuild } from '../../utils/component-utils';
 import { pipelineRunCancel, pipelineRunStop } from '../../utils/pipeline-actions';
 import { pipelineRunStatus, runStatus } from '../../utils/pipeline-utils';
 import { useAccessReviewForModel } from '../../utils/rbac';
@@ -48,7 +48,7 @@ export const usePipelinererunAction = (pipelineRun: PipelineRunKind) => {
       runType === PipelineRunType.BUILD
         ? componentLoaded &&
           !componentError &&
-          rerunBuildPipeline(component).then(() => {
+          startNewBuild(component).then(() => {
             navigate(
               `/application-pipeline/workspaces/${workspace}/applications/${component.spec.application}/activity/pipelineruns?name=${component.metadata.name}`,
             );
@@ -62,14 +62,11 @@ export const usePipelinererunAction = (pipelineRun: PipelineRunKind) => {
             );
           }),
     isDisabled:
-      (runType === PipelineRunType.BUILD &&
-        (!canPatchComponent ||
-          (componentLoaded && !componentError && component && !isPACEnabled(component)))) ||
+      (runType === PipelineRunType.BUILD && !canPatchComponent) ||
       (runType === PipelineRunType.TEST && (!canPatchSnapshot || !snapshot || !scenario)),
 
     disabledTooltip:
       (runType === PipelineRunType.BUILD && !canPatchComponent) ||
-      (componentLoaded && !componentError && component && !isPACEnabled(component)) ||
       (runType === PipelineRunType.TEST && !canPatchSnapshot)
         ? "You don't have access to rerun"
         : runType === PipelineRunType.TEST && (!snapshot || !scenario)
@@ -103,7 +100,6 @@ export const usePipelinerunActions = (pipelineRun: PipelineRunKind): Action[] =>
         ? "You don't have access to stop this pipeline"
         : undefined,
     },
-
     {
       cta: () => pipelineRunCancel(pipelineRun),
       id: 'pipelinerun-cancel',

--- a/src/utils/__tests__/component-utils.spec.ts
+++ b/src/utils/__tests__/component-utils.spec.ts
@@ -1,18 +1,29 @@
+import { k8sPatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { renderHook } from '@testing-library/react-hooks';
 import { useApplicationPipelineGitHubApp } from '../../hooks/useApplicationPipelineGitHubApp';
+import { ComponentModel } from '../../models';
 import { ComponentKind } from '../../types';
 import {
   isPACEnabled,
   useURLForComponentPRs,
   useComponentBuildStatus,
   BUILD_STATUS_ANNOTATION,
+  startNewBuild,
+  BUILD_REQUEST_ANNOTATION,
+  BuildRequest,
 } from '../component-utils';
 
 jest.mock('../../hooks/useApplicationPipelineGitHubApp', () => ({
   useApplicationPipelineGitHubApp: jest.fn(),
 }));
 
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sPatchResource: jest.fn(),
+}));
+
 const useApplicationPipelineGitHubAppMock = useApplicationPipelineGitHubApp as jest.Mock;
+
+const k8sPatchResourceMock = k8sPatchResource as jest.Mock;
 
 describe('component-utils', () => {
   it('should detect pac enabled state', () => {
@@ -29,6 +40,68 @@ describe('component-utils', () => {
     expect(isPACEnabled(createComponent(undefined))).toBe(false);
     expect(isPACEnabled(createComponent('enabled'))).toBe(true);
     expect(isPACEnabled(createComponent('disabled'))).toBe(false);
+  });
+
+  it('should start a new PAC build when PAC is enabled', () => {
+    const createComponent = (buildState: string | undefined): ComponentKind => {
+      const result = {
+        metadata: {
+          annotations: {
+            [BUILD_STATUS_ANNOTATION]: buildState && JSON.stringify({ pac: { state: buildState } }),
+          },
+        },
+      };
+      return (result ?? {}) as ComponentKind;
+    };
+
+    const component = createComponent('enabled');
+    startNewBuild(component);
+
+    expect(k8sPatchResourceMock).toHaveBeenCalledWith({
+      model: ComponentModel,
+      queryOptions: {
+        name: component.metadata.name,
+        ns: component.metadata.namespace,
+      },
+      patches: [
+        {
+          op: 'add',
+          path: `/metadata/annotations/${BUILD_REQUEST_ANNOTATION.replace('/', '~1')}`,
+          value: BuildRequest.triggerPACBuild,
+        },
+      ],
+    });
+  });
+
+  it('should start a new simple build when PAC is not enabled', () => {
+    const createComponent = (buildState: string | undefined): ComponentKind => {
+      const result = {
+        metadata: {
+          annotations: {
+            [BUILD_STATUS_ANNOTATION]: buildState && JSON.stringify({ pac: { state: buildState } }),
+          },
+        },
+      };
+      return (result ?? {}) as ComponentKind;
+    };
+
+    const component = createComponent('disabled');
+    startNewBuild(component);
+
+    expect(k8sPatchResourceMock).toHaveBeenCalledWith({
+      model: ComponentModel,
+      queryOptions: {
+        name: component.metadata.name,
+        ns: component.metadata.namespace,
+      },
+      patches: [
+        {
+          op: 'add',
+          path: `/metadata/annotations/${BUILD_REQUEST_ANNOTATION.replace('/', '~1')}`,
+          value: BuildRequest.triggerSimpleBuild,
+        },
+      ],
+    });
   });
 
   it('should create github URL for component PRs', () => {


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
- https://issues.redhat.com/browse/KFLUXBUGS-1136
- https://issues.redhat.com/browse/KFLUXBUGS-1199
- https://issues.redhat.com/browse/KFLUXBUGS-1026

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- Fixed the `Start new build` and `Rerun` action to also trigger PAC builds when PAC is enabled.
- Fixed the rerun action not appearing in Pipeline list view.
- Removed the duplicate `Start new build` action in pipeline run list and details page.
- Fixed the pipeline rerun action getting disabled saying you don't have access to patch the component.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Uploading Screen Recording 2024-04-11 at 9.27.31 PM.mov…



## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
