### PR TITLE
fix(e2e): replace github import API with template generation

### DIFF
--- a/integration-tests/tests/advanced-happy-path.spec.ts
+++ b/integration-tests/tests/advanced-happy-path.spec.ts
@@ -27,7 +27,8 @@ describe('Advanced Happy path', () => {
   const componentPage = new ComponentPage();
   const latestCommitsTabPage = new LatestCommitsTabPage();
   const integrationTestsTabPage = new IntegrationTestsTabPage();
-  const sourceCodeRepoLink = 'https://github.com/hac-test/devfile-sample-go-basic';
+  const sourceOwner = 'hac-test';
+  const sourceRepo = 'devfile-sample-go-basic';
   const repoName = Common.generateAppName('devfile-sample-go-basic');
   const repoOwner = 'redhat-hac-qe';
   const repoLink = `https://github.com/${repoOwner}/${repoName}`;
@@ -75,11 +76,10 @@ describe('Advanced Happy path', () => {
   };
 
   before(() => {
-    APIHelper.createGitHubRepository(repoName);
-    APIHelper.importCodeToGitHubRepository(sourceCodeRepoLink, repoName);
+    APIHelper.createRepositoryFromTemplate(sourceOwner, sourceRepo, repoOwner, repoName);
     APIHelper.githubRequest(
       'GET',
-      githubAPIEndpoints.contents('hac-test', 'devfile-sample-go-basic', componentInfo.filePath),
+      githubAPIEndpoints.contents(sourceOwner, sourceRepo, componentInfo.filePath),
     ).then((response) => {
       componentInfo.goFileSHAOriginal = response.body.sha;
       componentInfo.goFileBase64Original = response.body.content;

--- a/integration-tests/utils/APIEndpoints.ts
+++ b/integration-tests/utils/APIEndpoints.ts
@@ -32,8 +32,8 @@ export const hacAPIEndpoints = {
 export const githubAPIEndpoints = {
   orgRepos: `https://api.github.com/orgs/redhat-hac-qe/repos`,
   qeRepos: (repoName: string) => `https://api.github.com/repos/redhat-hac-qe/${repoName}`,
-  repoImport: (toRepoName: string) =>
-    `https://api.github.com/repos/redhat-hac-qe/${toRepoName}/import`,
+  templateRepo: (owner: string, templateName: string) =>
+    `https://api.github.com/repos/${owner}/${templateName}/generate`,
   merge: (owner: string, repoName: string, pullNumber: number) =>
     `https://api.github.com/repos/${owner}/${repoName}/pulls/${pullNumber}/merge`,
   contents: (owner: string, repoName: string, filePath: string) =>

--- a/integration-tests/utils/APIHelper.ts
+++ b/integration-tests/utils/APIHelper.ts
@@ -88,19 +88,20 @@ export class APIHelper {
     this.githubRequest('DELETE', githubAPIEndpoints.qeRepos(repoName));
   }
 
-  static importCodeToGitHubRepository(fromRepoLink: string, toRepoName: string) {
+  static createRepositoryFromTemplate(
+    templateOwner: string,
+    templateRepoName: string,
+    targetOwner: string,
+    targetRepoName: string,
+  ) {
     const body = {
-      vcs: 'git',
-      vcs_url: fromRepoLink,
+      owner: targetOwner,
+      name: targetRepoName,
     };
-    this.githubRequest('PUT', githubAPIEndpoints.repoImport(toRepoName), body);
-    this.checkResponseBodyAndStatusCode(
-      githubAPIEndpoints.repoImport(toRepoName),
-      '"status":"complete"',
-      5000,
-      0,
-      20,
-      this.githubHeaders,
+    this.githubRequest(
+      'POST',
+      githubAPIEndpoints.templateRepo(templateOwner, templateRepoName),
+      body,
     );
   }
 }


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/KFLUXBUGS-1229


## Description
github removed the import API that e2e tests were using, replace it with generating repos from a template
