### PR TITLE
feat(secrets): add scm host metadata

### DIFF
--- a/src/components/Secrets/SecretTypeSelector.scss
+++ b/src/components/Secrets/SecretTypeSelector.scss
@@ -1,0 +1,5 @@
+.secret-type-selector {
+  &__dropdown {
+    max-width: 750px;
+  }
+}

--- a/src/components/Secrets/SecretTypeSelector.tsx
+++ b/src/components/Secrets/SecretTypeSelector.tsx
@@ -3,6 +3,7 @@ import { useFormikContext } from 'formik';
 import { DropdownField } from '../../shared';
 import { DropdownItemObject } from '../../shared/components/dropdown/BasicDropdown';
 import { SecretFormValues, SecretTypeDropdownLabel } from '../../types';
+import './SecretTypeSelector.scss';
 
 type SecretTypeSelectorProps = {
   onChange: (type: string) => void;
@@ -32,6 +33,7 @@ const SecretTypeSelector: React.FC<React.PropsWithChildren<SecretTypeSelectorPro
     <DropdownField
       name="type"
       label="Secret type"
+      className="secret-type-selector__dropdown"
       data-testid="secret-type-selector"
       helpText="Tell us the secret type you want to add"
       items={dropdownItems}

--- a/src/components/Secrets/SecretsForm/ImagePullSecretForm.tsx
+++ b/src/components/Secrets/SecretsForm/ImagePullSecretForm.tsx
@@ -20,6 +20,7 @@ export const ImagePullSecretForm: React.FC<React.PropsWithChildren<unknown>> = (
           { key: 'uploadConfigFile', value: ImagePullSecretType.UploadConfigFile },
         ]}
         required
+        className="secret-type-subform__dropdown"
         validateOnChange
       />
       {type === ImagePullSecretType.ImageRegistryCreds ? (

--- a/src/components/Secrets/SecretsForm/SecretTypeSubForm.scss
+++ b/src/components/Secrets/SecretsForm/SecretTypeSubForm.scss
@@ -1,0 +1,5 @@
+.secret-type-subform {
+  &__dropdown {
+    max-width: 750px;
+  }
+}

--- a/src/components/Secrets/SecretsForm/SecretTypeSubForm.tsx
+++ b/src/components/Secrets/SecretsForm/SecretTypeSubForm.tsx
@@ -14,6 +14,7 @@ import {
 import { ImagePullSecretForm } from './ImagePullSecretForm';
 import { KeyValueSecretForm } from './KeyValueSecretForm';
 import { SourceSecretForm } from './SourceSecretForm';
+import './SecretTypeSubForm.scss';
 
 const secretTypes = [
   {
@@ -119,6 +120,7 @@ export const SecretTypeSubForm: React.FC<React.PropsWithChildren<unknown>> = () 
           variant={SelectVariant.typeahead}
           options={options}
           isCreatable
+          className="secret-type-subform__dropdown"
           isInputValuePersisted
           hasOnCreateOption
           required

--- a/src/components/Secrets/SecretsForm/SourceSecretForm.tsx
+++ b/src/components/Secrets/SecretsForm/SourceSecretForm.tsx
@@ -20,6 +20,8 @@ export const SourceSecretForm: React.FC<React.PropsWithChildren<unknown>> = () =
         ]}
         required
       />
+      <InputField name="source.host" label="Host" helpText="Host for the secret" />
+      <InputField name="source.repo" label="Repository" helpText="Repository for the secret" />
       {type === SourceSecretType.basic ? (
         <>
           <InputField

--- a/src/components/Secrets/SecretsForm/SourceSecretForm.tsx
+++ b/src/components/Secrets/SecretsForm/SourceSecretForm.tsx
@@ -19,6 +19,7 @@ export const SourceSecretForm: React.FC<React.PropsWithChildren<unknown>> = () =
           { key: 'ssh', value: SourceSecretType.ssh },
         ]}
         required
+        className="secret-type-subform__dropdown"
       />
       <InputField name="source.host" label="Host" helpText="Host for the secret" />
       <InputField name="source.repo" label="Repository" helpText="Repository for the secret" />

--- a/src/components/Secrets/SecretsListView/SecretsList.tsx
+++ b/src/components/Secrets/SecretsListView/SecretsList.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { Table } from '../../../shared';
-import { RemoteSecretKind } from '../../../types';
+import { SecretKind } from '../../../types';
 import SecretsListHeader from './SecretsListHeader';
 import SecretsListRow from './SecretsListRow';
 
 type SecretsListProps = {
-  secrets: RemoteSecretKind[];
+  secrets: SecretKind[];
 };
 
 const SecretsList: React.FC<React.PropsWithChildren<SecretsListProps>> = ({ secrets }) => {

--- a/src/components/Secrets/SecretsListView/SecretsListRow.tsx
+++ b/src/components/Secrets/SecretsListView/SecretsListRow.tsx
@@ -2,12 +2,12 @@ import * as React from 'react';
 import { Label } from '@patternfly/react-core';
 import { RowFunctionArgs, TableData } from '../../../shared';
 import ActionMenu from '../../../shared/components/action-menu/ActionMenu';
-import { RemoteSecretKind } from '../../../types/secret';
+import { SecretKind } from '../../../types/secret';
 import { useSecretActions } from '../secret-actions';
-import { getSecretRowData } from '../utils/secret-utils';
+import { getSecretRowLabels, getSecretTypetoLabel } from '../utils/secret-utils';
 import { secretsTableColumnClasses } from './SecretsListHeader';
 
-type SecretsListRowProps = RowFunctionArgs<RemoteSecretKind>;
+type SecretsListRowProps = RowFunctionArgs<SecretKind>;
 
 export enum RemoteSecretStatus {
   Succeeded = 'Succeeded',
@@ -17,7 +17,7 @@ export enum RemoteSecretStatus {
 const SecretsListRow: React.FC<React.PropsWithChildren<SecretsListRowProps>> = ({ obj }) => {
   const actions = useSecretActions(obj);
 
-  const { secretName, secretLabels, secretType } = getSecretRowData(obj);
+  const { secretLabels } = getSecretRowLabels(obj);
   const labels =
     secretLabels !== '-'
       ? secretLabels.split(', ').map((s) => <Label key={s}>{s}</Label>)
@@ -25,8 +25,10 @@ const SecretsListRow: React.FC<React.PropsWithChildren<SecretsListRowProps>> = (
 
   return (
     <>
-      <TableData className={secretsTableColumnClasses.secretType}>{secretType}</TableData>
-      <TableData className={secretsTableColumnClasses.name}> {secretName} </TableData>
+      <TableData className={secretsTableColumnClasses.secretType}>
+        {getSecretTypetoLabel(obj) ?? '-'}
+      </TableData>
+      <TableData className={secretsTableColumnClasses.name}> {obj.metadata?.name} </TableData>
       <TableData className={secretsTableColumnClasses.labels}>{labels}</TableData>
       <TableData className={secretsTableColumnClasses.kebab}>
         <ActionMenu actions={actions} />

--- a/src/components/Secrets/SecretsListView/SecretsListView.tsx
+++ b/src/components/Secrets/SecretsListView/SecretsListView.tsx
@@ -9,7 +9,7 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { useRemoteSecrets } from '../../../hooks/UseRemoteSecrets';
+import { useSecrets } from '../../../hooks/UseRemoteSecrets';
 import { useSearchParam } from '../../../hooks/useSearchParam';
 import secretEmptyStateIcon from '../../../imgs/secret.svg';
 import { RemoteSecretModel } from '../../../models';
@@ -27,15 +27,13 @@ type SecretsListViewProps = {
 const SecretsListView: React.FC<React.PropsWithChildren<SecretsListViewProps>> = () => {
   const { namespace, workspace } = useWorkspaceInfo();
 
-  const [secrets, secretsLoaded] = useRemoteSecrets(namespace);
+  const [secrets, secretsLoaded] = useSecrets(namespace);
   const [nameFilter, setNameFilter, unsetNameFilter] = useSearchParam('name', '');
   const [canCreateRemoteSecret] = useAccessReviewForModel(RemoteSecretModel, 'create');
 
   const filteredRemoteSecrets = React.useMemo(() => {
     // apply name filter
-    return nameFilter
-      ? secrets.filter((s) => (s.spec?.secret?.name || s.metadata.name).indexOf(nameFilter) !== -1)
-      : secrets;
+    return nameFilter ? secrets.filter((s) => s.metadata.name.indexOf(nameFilter) !== -1) : secrets;
   }, [secrets, nameFilter]);
 
   const createSecretButton = React.useMemo(() => {

--- a/src/components/Secrets/secret-actions.ts
+++ b/src/components/Secrets/secret-actions.ts
@@ -1,11 +1,11 @@
 import { RemoteSecretModel } from '../../models';
 import { Action } from '../../shared/components/action-menu/types';
-import { RemoteSecretKind } from '../../types';
+import { SecretKind } from '../../types';
 import { useAccessReviewForModel } from '../../utils/rbac';
 import { useModalLauncher } from '../modal/ModalProvider';
 import { secretDeleteModal } from './secret-modal';
 
-export const useSecretActions = (secret: RemoteSecretKind): Action[] => {
+export const useSecretActions = (secret: SecretKind): Action[] => {
   const showModal = useModalLauncher();
   const [canDelete] = useAccessReviewForModel(RemoteSecretModel, 'delete');
   return [

--- a/src/components/Secrets/secret-modal.tsx
+++ b/src/components/Secrets/secret-modal.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { RemoteSecretModel } from '../../models';
-import { RemoteSecretKind } from '../../types';
+import { SecretModel } from '../../models';
+import { SecretKind } from '../../types';
 import { createDeleteModalLauncher } from '../modal/DeleteResourceModal';
 
-export const secretDeleteModal = (secret: RemoteSecretKind) =>
+export const secretDeleteModal = (secret: SecretKind) =>
   createDeleteModalLauncher(secret.kind)({
     obj: secret,
-    model: RemoteSecretModel,
+    model: SecretModel,
     displayName: secret.metadata.name,
     description: (
       <>

--- a/src/components/Secrets/secret-modal.tsx
+++ b/src/components/Secrets/secret-modal.tsx
@@ -1,12 +1,15 @@
 import * as React from 'react';
 import { SecretModel } from '../../models';
-import { SecretKind } from '../../types';
+import { SecretKind, SecretType } from '../../types';
 import { createDeleteModalLauncher } from '../modal/DeleteResourceModal';
+import { unLinkSecretFromServiceAccount } from './utils/service-account-utils';
 
 export const secretDeleteModal = (secret: SecretKind) =>
   createDeleteModalLauncher(secret.kind)({
     obj: secret,
     model: SecretModel,
+    submitCallback:
+      secret.type === SecretType.dockerconfigjson ? unLinkSecretFromServiceAccount : null,
     displayName: secret.metadata.name,
     description: (
       <>

--- a/src/components/Secrets/secret-modal.tsx
+++ b/src/components/Secrets/secret-modal.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { SecretModel } from '../../models';
-import { SecretKind, SecretType } from '../../types';
+import { SecretKind, SecretTypeDisplayLabel } from '../../types';
 import { createDeleteModalLauncher } from '../modal/DeleteResourceModal';
+import { typeToLabel } from './utils/secret-utils';
 import { unLinkSecretFromServiceAccount } from './utils/service-account-utils';
 
 export const secretDeleteModal = (secret: SecretKind) =>
@@ -9,7 +10,9 @@ export const secretDeleteModal = (secret: SecretKind) =>
     obj: secret,
     model: SecretModel,
     submitCallback:
-      secret.type === SecretType.dockerconfigjson ? unLinkSecretFromServiceAccount : null,
+      typeToLabel(secret.type) === SecretTypeDisplayLabel.imagePull
+        ? unLinkSecretFromServiceAccount
+        : null,
     displayName: secret.metadata.name,
     description: (
       <>

--- a/src/components/Secrets/utils/__tests__/service-account-utils.spec.ts
+++ b/src/components/Secrets/utils/__tests__/service-account-utils.spec.ts
@@ -1,0 +1,135 @@
+import '@testing-library/jest-dom';
+import { k8sPatchResource, k8sGetResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { ServiceAccountModel } from '../../../../models';
+import { SecretType } from '../../../../types';
+import {
+  linkSecretToServiceAccount,
+  unLinkSecretFromServiceAccount,
+} from '../service-account-utils';
+
+jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
+  k8sGetResource: jest.fn(),
+  k8sPatchResource: jest.fn(),
+}));
+
+const imagePullSecret = {
+  apiVersion: 'v1',
+  kind: 'secret',
+  metadata: { name: 'test-secret' },
+  type: SecretType.dockerconfigjson,
+};
+
+const k8sPatchResourceMock = k8sPatchResource as jest.Mock;
+const k8sGetResourceMock = k8sGetResource as jest.Mock;
+
+describe('linkSecretToServiceAccount', () => {
+  beforeEach(() => {
+    k8sGetResourceMock.mockReturnValue({
+      metadata: { name: 'test-cdq' },
+      imagePullSecrets: [
+        { name: 'ip-secret1' },
+        { name: 'ip-secret2' },
+        { name: 'ip-secret3' },
+        { name: 'ip-secret4' },
+      ],
+      secrets: [{ name: 'secret1' }, { name: 'secret2' }],
+    });
+  });
+  it('should return early if no namespace ', async () => {
+    await linkSecretToServiceAccount(imagePullSecret, null);
+    expect(k8sPatchResourceMock).not.toHaveBeenCalled();
+  });
+
+  it('should call k8sPatchResource and create an imagePull entry', async () => {
+    k8sPatchResourceMock.mockClear();
+    k8sGetResourceMock.mockReturnValueOnce({
+      metadata: { name: 'test-cdq' },
+      imagePullSecrets: [],
+      secrets: [],
+    });
+    await linkSecretToServiceAccount(imagePullSecret, 'test');
+    expect(k8sPatchResourceMock).toHaveBeenCalled();
+    expect(k8sPatchResourceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: ServiceAccountModel,
+        patches: [
+          {
+            op: 'replace',
+            path: '/imagePullSecrets',
+            value: [{ name: 'test-secret' }],
+          },
+        ],
+      }),
+    );
+  });
+
+  it('should append to imagePull secrets list ', async () => {
+    k8sPatchResourceMock.mockClear();
+    await linkSecretToServiceAccount(imagePullSecret, 'test');
+    expect(k8sPatchResourceMock).toHaveBeenCalled();
+    expect(k8sPatchResourceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: ServiceAccountModel,
+        patches: [
+          {
+            op: 'replace',
+            path: '/imagePullSecrets',
+            value: [
+              { name: 'ip-secret1' },
+              { name: 'ip-secret2' },
+              { name: 'ip-secret3' },
+              { name: 'ip-secret4' },
+              { name: 'test-secret' },
+            ],
+          },
+        ],
+      }),
+    );
+  });
+});
+
+describe('UnLinkSecretFromServiceAccount', () => {
+  beforeEach(() => {
+    k8sGetResourceMock.mockReturnValue({
+      metadata: { name: 'test-cdq' },
+      imagePullSecrets: [
+        { name: 'ip-secret1' },
+        { name: 'ip-secret2' },
+        { name: 'ip-secret3' },
+        { name: 'ip-secret4' },
+      ],
+      secrets: [{ name: 'secret1' }, { name: 'secret2' }],
+    });
+  });
+  it('should return early if no namespace ', async () => {
+    k8sPatchResourceMock.mockClear();
+    await unLinkSecretFromServiceAccount(imagePullSecret, null);
+    expect(k8sPatchResourceMock).not.toHaveBeenCalled();
+  });
+
+  it('should remove correct imagePull secrets list ', async () => {
+    k8sPatchResourceMock.mockClear();
+    await unLinkSecretFromServiceAccount(
+      {
+        metadata: { name: 'ip-secret3' },
+        type: imagePullSecret.type,
+        kind: imagePullSecret.kind,
+        apiVersion: imagePullSecret.apiVersion,
+      },
+      'test',
+    );
+    expect(k8sPatchResourceMock).toHaveBeenCalled();
+    expect(k8sPatchResourceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: ServiceAccountModel,
+        patches: [
+          {
+            op: 'replace',
+            path: '/imagePullSecrets',
+            value: [{ name: 'ip-secret1' }, { name: 'ip-secret2' }, { name: 'ip-secret4' }],
+          },
+        ],
+      }),
+    );
+  });
+});

--- a/src/components/Secrets/utils/secret-utils.ts
+++ b/src/components/Secrets/utils/secret-utils.ts
@@ -251,59 +251,6 @@ export const createSecretResource = async (
     resource: secretResource,
   });
 
-// export const createSecretResourceWithMetadata = (
-//   secret: SecretKind,
-//   namespace: string,
-//   labels: {
-//     secret: { [key: string]: string };
-//     annotations: { [key: string]: string };
-//   },
-//   linkServiceAccount: boolean,
-//   dryRun: boolean,
-// ): Promise<SecretKind> => {
-//   const secretResource: SecretKind = {
-//     apiVersion: `${SecretModel.apiVersion}`,
-//     kind: SecretModel.kind,
-//     metadata: {
-//       name: `${secret.metadata.name}`,
-//       namespace,
-//       labels: {
-//         [SecretByUILabel]: SecretFor.Build,
-//         ...labels?.secret,
-//       },
-//       annotations: labels?.annotations,
-//     },
-//     spec: {
-//       secret: {
-//         ...(linkServiceAccount && {
-//           linkedTo: [
-//             {
-//               serviceAccount: {
-//                 reference: {
-//                   name: PIPELINE_SERVICE_ACCOUNT,
-//                 },
-//               },
-//             },
-//           ],
-//         }),
-//         name: secret.metadata.name,
-//         type: secret.type,
-//         ...(labels?.secret && { labels: labels.secret }),
-//       },
-//     },
-//   };
-
-//   return k8sCreateResource({
-//     model: SecretModel,
-//     queryOptions: {
-//       name: `${secret.metadata.name}`,
-//       ns: namespace,
-//       ...(dryRun && { queryParams: { dryRun: 'All' } }),
-//     },
-//     resource: secretResource,
-//   });
-// };
-
 export const getAddSecretBreadcrumbs = () => {
   return [
     { path: '/application-pipeline/secrets', name: 'Secrets' },

--- a/src/components/Secrets/utils/service-account-utils.ts
+++ b/src/components/Secrets/utils/service-account-utils.ts
@@ -1,0 +1,66 @@
+import { k8sGetResource, k8sPatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import { PIPELINE_SERVICE_ACCOUNT } from '../../../consts/pipeline';
+import { ServiceAccountModel } from '../../../models/service-account';
+import { SecretKind, ServiceAccountKind } from '../../../types';
+
+export const linkSecretToServiceAccount = async (secret: SecretKind, namespace: string) => {
+  if (!secret || (!namespace && !secret.metadata?.namespace)) {
+    return;
+  }
+  const serviceAccount = await k8sGetResource<ServiceAccountKind>({
+    model: ServiceAccountModel,
+    queryOptions: { name: PIPELINE_SERVICE_ACCOUNT, ns: namespace },
+  });
+  const existingSecrets = serviceAccount?.imagePullSecrets as SecretKind[];
+  const secretList = existingSecrets
+    ? [...existingSecrets, { name: secret.metadata.name }]
+    : [{ name: secret.metadata.name }];
+  k8sPatchResource({
+    model: ServiceAccountModel,
+    queryOptions: {
+      name: PIPELINE_SERVICE_ACCOUNT,
+      ns: namespace,
+    },
+    patches: [
+      {
+        op: 'replace',
+        path: `/imagePullSecrets`,
+        value: secretList,
+      },
+    ],
+  });
+};
+
+export const unLinkSecretFromServiceAccount = async (secret: SecretKind, namespace: string) => {
+  if (!secret || (!namespace && !secret.metadata?.namespace)) {
+    return;
+  }
+  const serviceAccount = await k8sGetResource<ServiceAccountKind>({
+    model: ServiceAccountModel,
+    queryOptions: { name: PIPELINE_SERVICE_ACCOUNT, ns: namespace ?? secret.metadata?.namespace },
+  });
+
+  const existingSecrets = serviceAccount?.imagePullSecrets;
+  if (!Array.isArray(existingSecrets) || existingSecrets.length === 0) {
+    return;
+  }
+
+  const secretList = (existingSecrets as { [key: string]: string }[]).filter(
+    (s) => s.name !== secret.metadata?.name,
+  );
+
+  k8sPatchResource({
+    model: ServiceAccountModel,
+    queryOptions: {
+      name: PIPELINE_SERVICE_ACCOUNT,
+      ns: namespace,
+    },
+    patches: [
+      {
+        op: 'replace',
+        path: `/imagePullSecrets`,
+        value: secretList,
+      },
+    ],
+  });
+};

--- a/src/components/modal/DeleteResourceModal.tsx
+++ b/src/components/modal/DeleteResourceModal.tsx
@@ -30,6 +30,7 @@ type DeleteResourceModalProps = ComponentProps & {
   displayName?: string;
   isEntryNotRequired?: boolean;
   description?: React.ReactNode;
+  submitCallback?: (obj: any, namespace?: string) => void;
 };
 
 export const DeleteResourceModal: React.FC<React.PropsWithChildren<DeleteResourceModalProps>> = ({
@@ -39,6 +40,7 @@ export const DeleteResourceModal: React.FC<React.PropsWithChildren<DeleteResourc
   displayName,
   isEntryNotRequired = false,
   description,
+  submitCallback,
 }) => {
   const [error, setError] = React.useState<string>();
   const resourceName = displayName || obj.metadata.name;
@@ -52,6 +54,7 @@ export const DeleteResourceModal: React.FC<React.PropsWithChildren<DeleteResourc
           ns: obj.metadata.namespace,
         },
       });
+      submitCallback && submitCallback(obj, obj.metadata?.namespace);
       onClose(null, { submitClicked: true });
     } catch (e) {
       setError(e.message || e.toString());

--- a/src/hooks/UseRemoteSecrets.ts
+++ b/src/hooks/UseRemoteSecrets.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
-import { RemoteSecretGroupVersionKind } from '../models';
-import { RemoteSecretKind } from '../types';
+import { RemoteSecretGroupVersionKind, SecretGroupVersionKind } from '../models';
+import { RemoteSecretKind, SecretKind } from '../types';
 
 export const useRemoteSecrets = (namespace: string): [RemoteSecretKind[], boolean, unknown] => {
   const [remoteSecrets, loaded, error] = useK8sWatchResource<RemoteSecretKind[]>({
@@ -13,5 +13,18 @@ export const useRemoteSecrets = (namespace: string): [RemoteSecretKind[], boolea
   return React.useMemo(
     () => [remoteSecrets.filter((rs) => !rs.metadata.deletionTimestamp), loaded, error],
     [remoteSecrets, loaded, error],
+  );
+};
+
+export const useSecrets = (namespace: string): [SecretKind[], boolean, unknown] => {
+  const [secrets, loaded, error] = useK8sWatchResource<SecretKind[]>({
+    groupVersionKind: SecretGroupVersionKind,
+    namespace,
+    isList: true,
+  });
+
+  return React.useMemo(
+    () => [secrets.filter((rs) => !rs.metadata.deletionTimestamp), loaded, error],
+    [secrets, loaded, error],
   );
 };

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -17,6 +17,7 @@ export * from './snapshot';
 export * from './snapshot-environment-binding';
 export * from './rbac';
 export * from './secret';
+export * from './service-account';
 export * from './limit-range';
 export * from './remotesecret';
 export * from './workspace';

--- a/src/models/service-account.ts
+++ b/src/models/service-account.ts
@@ -1,0 +1,14 @@
+import { K8sModelCommon } from '@openshift/dynamic-plugin-sdk-utils';
+import { K8sGroupVersionKind } from '../dynamic-plugin-sdk';
+
+export const ServiceAccountModel: K8sModelCommon = {
+  apiVersion: 'v1',
+  plural: 'serviceaccounts',
+  namespaced: true,
+  kind: 'ServiceAccount',
+};
+
+export const ServiceAccountGroupVersionKind: K8sGroupVersionKind = {
+  version: 'v1',
+  kind: 'ServiceAccount',
+};

--- a/src/types/secret.ts
+++ b/src/types/secret.ts
@@ -117,6 +117,12 @@ export enum SecretType {
   tls = 'kubernetes.io/tls',
 }
 
+export type ServiceAccountKind = {
+  automountServiceAccountToken?: boolean;
+  imagePullSecrets?: SecretKind[] | { [key: string]: string }[];
+  secrets?: SecretKind[] | { [key: string]: string };
+} & K8sResourceCommon;
+
 export enum SecretTypeAbstraction {
   generic = 'generic',
   source = 'source',

--- a/src/types/secret.ts
+++ b/src/types/secret.ts
@@ -9,6 +9,13 @@ export enum SecretSPILabel {
   COMPONENT = 'appstudio.openshift.io/component',
 }
 
+export enum SecretLabels {
+  CREDENTIAL_LABEL = 'appstudio.redhat.com/credentials',
+  CREDENTIAL_VALUE = 'scm',
+  HOST_LABEL = 'appstudio.redhat.com/scm.host',
+  REPO_ANNOTATION = 'appstudio.redhat.com/scm.repository',
+}
+
 export enum TargetDropdownDefaults {
   ALL_ENVIRONMENTS = 'All environments',
   ALL_COMPONENTS = 'All components',
@@ -175,6 +182,8 @@ export interface Source {
   authType: string;
   username?: string;
   password?: string;
+  host?: string;
+  repo?: string;
 }
 
 export interface Targets {

--- a/src/utils/create-utils.ts
+++ b/src/utils/create-utils.ts
@@ -14,6 +14,7 @@ import {
 import { ImportSecret } from '../components/ImportForm/utils/types';
 import {
   createRemoteSecretResource,
+  getAnnotationForSecret,
   getLabelsForSecret,
   getSecretFormData,
   getTargetLabelsForRemoteSecret,
@@ -307,6 +308,7 @@ export const createSecretResource = async (
   const labels = {
     secret: getLabelsForSecret(values),
     remoteSecret: getTargetLabelsForRemoteSecret(values),
+    annotations: getAnnotationForSecret(values),
   };
   await createRemoteSecretResource(
     secretResource,
@@ -346,12 +348,6 @@ export const createSecret = async (
     metadata: {
       name: secret.secretName,
       namespace,
-      labels: {
-        'appstudio.redhat.com/upload-secret': 'remotesecret',
-      },
-      annotations: {
-        'appstudio.redhat.com/remotesecret-name': `${secret.secretName}`,
-      },
     },
     type: K8sSecretType[secret.type],
     stringData: secret.keyValues.reduce((acc, s) => {

--- a/src/utils/create-utils.ts
+++ b/src/utils/create-utils.ts
@@ -16,6 +16,7 @@ import {
   getAnnotationForSecret,
   getLabelsForSecret,
   getSecretFormData,
+  typeToLabel,
 } from '../components/Secrets/utils/secret-utils';
 import { linkSecretToServiceAccount } from '../components/Secrets/utils/service-account-utils';
 import {
@@ -33,9 +34,7 @@ import {
   K8sSecretType,
   SecretKind,
   AddSecretFormValues,
-  SecretByUILabel,
-  SecretFor,
-  SecretType,
+  SecretTypeDisplayLabel,
 } from '../types';
 import { ComponentSpecs } from './../types/component';
 import { BuildRequest, BUILD_REQUEST_ANNOTATION } from './component-utils';
@@ -314,14 +313,13 @@ export const createSecretResource = async (
     metadata: {
       ...secretResource.metadata,
       labels: {
-        [SecretByUILabel]: SecretFor.Build,
         ...labels?.secret,
       },
       annotations,
     },
   };
   // if image pull secret, link to service account
-  if (secretResource.type === SecretType.dockerconfigjson) {
+  if (typeToLabel(secretResource.type) === SecretTypeDisplayLabel.imagePull) {
     linkSecretToServiceAccount(secretResource, namespace);
   }
 

--- a/src/utils/create-utils.ts
+++ b/src/utils/create-utils.ts
@@ -17,6 +17,7 @@ import {
   getLabelsForSecret,
   getSecretFormData,
 } from '../components/Secrets/utils/secret-utils';
+import { linkSecretToServiceAccount } from '../components/Secrets/utils/service-account-utils';
 import {
   ApplicationModel,
   ComponentModel,
@@ -34,6 +35,7 @@ import {
   AddSecretFormValues,
   SecretByUILabel,
   SecretFor,
+  SecretType,
 } from '../types';
 import { ComponentSpecs } from './../types/component';
 import { BuildRequest, BUILD_REQUEST_ANNOTATION } from './component-utils';
@@ -307,14 +309,6 @@ export const createSecretResource = async (
     secret: getLabelsForSecret(values),
   };
   const annotations = getAnnotationForSecret(values);
-  // await createSecretResourceWithMetadata(
-  //   secretResource,
-  //   namespace,
-  //   labels,
-  //   typeToDropdownLabel(secretResource.type) === SecretTypeDropdownLabel.image,
-  //   dryRun,
-  // );
-
   const k8sSecretResource = {
     ...secretResource,
     metadata: {
@@ -326,6 +320,11 @@ export const createSecretResource = async (
       annotations,
     },
   };
+  // if image pull secret, link to service account
+  if (secretResource.type === SecretType.dockerconfigjson) {
+    linkSecretToServiceAccount(secretResource, namespace);
+  }
+
   // Todo: K8sCreateResource appends the resource name and errors out.
   // Fix the below code when this sdk-utils issue is resolved https://issues.redhat.com/browse/RHCLOUD-21655.
   return await commonFetch(


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

https://issues.redhat.com/browse/HAC-5715
https://issues.redhat.com/browse/HAC-5717

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- Adds input field for host & repo in AddSecret form.
- removes remote secret labels from Secret creation utils.
- For source secret adds scm labels and annotation in createSecret utils.
- Modifies and adds to related unit tests
- Updates Secret List View & related utils to use K8sSecrets instead of Remote Secrets.
- Links & unlinks Image pull Secrets to Service accounts on creation and deletion

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
![scm-secrets](https://github.com/openshift/hac-dev/assets/24852534/33347bad-9f86-4e01-bac1-e978df851bf6)

<img width="1792" alt="Screenshot 2024-05-14 at 4 48 00 PM" src="https://github.com/openshift/hac-dev/assets/24852534/73924956-a5e6-4152-b5b1-46b39ce72d82">
<img width="1061" alt="Screenshot 2024-05-15 at 5 18 04 PM" src="https://github.com/openshift/hac-dev/assets/24852534/5e955611-7252-48af-8ac0-4401c31d7db0">
<img width="704" alt="Screenshot 2024-05-15 at 6 25 50 PM" src="https://github.com/openshift/hac-dev/assets/24852534/f780c5fd-abb8-4d65-8299-116825250639">



## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
