### PR TITLE
fix(test): stabilise vulnerabilities 

### DIFF
--- a/integration-tests/tests/advanced-happy-path.spec.ts
+++ b/integration-tests/tests/advanced-happy-path.spec.ts
@@ -160,6 +160,10 @@ describe('Advanced Happy path', () => {
   });
 
   describe('Verify CVE scan', () => {
+    before(() => {
+      cy.reload();
+      Common.waitForLoad();
+    });
     it('Verify clair scan node details on drawer Panel', () => {
       DetailsTab.clickOnNode('clair-scan');
       DetailsTab.checkVulScanOnClairDrawer(vulnerabilities);
@@ -419,6 +423,8 @@ describe('Advanced Happy path', () => {
       Applications.clickBreadcrumbLink(applicationName);
       Applications.goToComponentsTab();
       ComponentsTabPage.openComponent(componentName);
+      cy.reload();
+      Common.waitForLoad();
     });
 
     it('Verify Commit Trigger', () => {

--- a/integration-tests/tests/advanced-happy-path.spec.ts
+++ b/integration-tests/tests/advanced-happy-path.spec.ts
@@ -160,10 +160,6 @@ describe('Advanced Happy path', () => {
   });
 
   describe('Verify CVE scan', () => {
-    before(() => {
-      cy.reload();
-      Common.waitForLoad();
-    });
     it('Verify clair scan node details on drawer Panel', () => {
       DetailsTab.clickOnNode('clair-scan');
       DetailsTab.checkVulScanOnClairDrawer(vulnerabilities);
@@ -423,8 +419,6 @@ describe('Advanced Happy path', () => {
       Applications.clickBreadcrumbLink(applicationName);
       Applications.goToComponentsTab();
       ComponentsTabPage.openComponent(componentName);
-      cy.reload();
-      Common.waitForLoad();
     });
 
     it('Verify Commit Trigger', () => {

--- a/src/components/Commits/tabs/CommitsPipelineRunTab.tsx
+++ b/src/components/Commits/tabs/CommitsPipelineRunTab.tsx
@@ -62,6 +62,7 @@ const CommitsPipelineRunTab: React.FC<React.PropsWithChildren<CommitsPipelineRun
         Pipeline runs
       </Title>
       <Table
+        key={`${pipelineRuns.length}-${vulnerabilities.fetchedPipelineRuns.length}`}
         data={pipelineRuns}
         aria-label="Pipelinerun List"
         Header={PipelineRunListHeaderWithVulnerabilities}

--- a/src/components/PipelineRunListView/PipelineRunsListView.tsx
+++ b/src/components/PipelineRunListView/PipelineRunsListView.tsx
@@ -215,6 +215,7 @@ const PipelineRunsListView: React.FC<React.PropsWithChildren<PipelineRunsListVie
   }
   return (
     <Table
+      key={`${pipelineRuns.length}-${vulnerabilities.fetchedPipelineRuns.length}`}
       data={filteredPLRs}
       unfilteredData={pipelineRuns}
       NoDataEmptyMsg={NoDataEmptyMsg}

--- a/src/components/SnapshotDetails/tabs/SnapshotPipelineRunsList.tsx
+++ b/src/components/SnapshotDetails/tabs/SnapshotPipelineRunsList.tsx
@@ -196,6 +196,7 @@ const SnapshotPipelineRunsList: React.FC<React.PropsWithChildren<SnapshotPipelin
       </Toolbar>
       {filteredPLRs.length > 0 ? (
         <Table
+          key={`${snapshotPipelineRuns.length}-${vulnerabilities.fetchedPipelineRuns.length}`}
           data={filteredPLRs}
           aria-label="Pipeline run List"
           customData={vulnerabilities}


### PR DESCRIPTION
## Description
Advanced Happy Path test suite is constantly failing during the nightly job to load the Vulnerabilities. Stabilize the loading of Vulnerabilities by refreshing the page during the Advanced Happy Path test suite.
