### PR TITLE
fix(SecretListPage): add workspace breadcrumbs on secrets list page

### DIFF
--- a/config/remotePlugin.js
+++ b/config/remotePlugin.js
@@ -170,6 +170,19 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
+      path: '/application-pipeline/secrets',
+      exact: true,
+      component: {
+        $codeRef: 'WorkspacedPage',
+      },
+    },
+    flags: {
+      required: ['SIGNUP'],
+    },
+  },
+  {
+    type: 'core.page/route',
+    properties: {
       path: '/application-pipeline/access',
       exact: true,
       component: {
@@ -477,7 +490,7 @@ const routeExtensions = [
   {
     type: 'core.page/route',
     properties: {
-      path: '/application-pipeline/secrets',
+      path: '/application-pipeline/secrets/workspaces/:workspaceName',
       exact: true,
       component: {
         $codeRef: 'SecretsListPage',

--- a/src/pages/SecretsListPage.tsx
+++ b/src/pages/SecretsListPage.tsx
@@ -9,10 +9,11 @@ import { FULL_APPLICATION_TITLE } from '../consts/labels';
 import { RemoteSecretModel } from '../models';
 import ExternalLink from '../shared/components/links/ExternalLink';
 import { AccessReviewResources } from '../types';
+import { useWorkspaceBreadcrumbs } from '../utils/breadcrumb-utils';
 
 const SecretsListPage: React.FC<React.PropsWithChildren<unknown>> = () => {
   const accessReviewResources: AccessReviewResources = [{ model: RemoteSecretModel, verb: 'list' }];
-
+  const breadcrumbs = useWorkspaceBreadcrumbs();
   return (
     <NamespacedPage>
       <PageAccessCheck accessReviewResources={accessReviewResources}>
@@ -31,6 +32,13 @@ const SecretsListPage: React.FC<React.PropsWithChildren<unknown>> = () => {
               </ExternalLink>
             </>
           }
+          breadcrumbs={[
+            ...breadcrumbs,
+            {
+              path: '#',
+              name: 'Secrets',
+            },
+          ]}
         >
           <Divider style={{ background: 'white', paddingTop: 'var(--pf-v5-global--spacer--md)' }} />
 

--- a/src/pages/WorkspacedPage.tsx
+++ b/src/pages/WorkspacedPage.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { Navigate, useLocation, useParams } from 'react-router-dom';
 import { setActiveWorkspaceLocalStorage as setActiveWorkspace } from '@openshift/dynamic-plugin-sdk-utils';
-import { useWorkspaceInfo } from '../utils/workspace-context-utils';
+import { WorkspaceContext, useWorkspaceInfo } from '../utils/workspace-context-utils';
 
 const WorkspacedPage: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => {
   const { pathname } = useLocation();
   const name = useParams()?.workspaceName;
   const mainPath = pathname.split('/').pop();
+  const { lastUsedWorkspace } = React.useContext(WorkspaceContext);
 
   const { workspace } = useWorkspaceInfo();
   if (!workspace) {
@@ -16,7 +17,7 @@ const WorkspacedPage: React.FunctionComponent<React.PropsWithChildren<unknown>> 
   const workspacedPath =
     mainPath === 'workspaces'
       ? `${pathname}/${workspace}/applications` // Default path is for applications and starts with workspace context
-      : `${pathname}/workspaces/${workspace}`;
+      : `${pathname}/workspaces/${workspace || lastUsedWorkspace}`;
 
   return <Navigate to={workspacedPath} replace />;
 };

--- a/src/pages/__tests__/SecretsListPage.spec.tsx
+++ b/src/pages/__tests__/SecretsListPage.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import '@testing-library/jest-dom';
+import { BrowserRouter } from 'react-router-dom';
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { configure, screen } from '@testing-library/react';
 import { useAccessReviewForModels } from '../../utils/rbac';
@@ -11,6 +12,7 @@ jest.mock('react-router-dom', () => {
   return {
     ...actual,
     useParams: jest.fn(),
+    useNavigate: jest.fn(),
   };
 });
 
@@ -58,7 +60,13 @@ describe('SecretsListPage', () => {
   it('should render secrets list page', () => {
     accessReviewMock.mockReturnValue([true, true]);
     watchResourceMock.mockReturnValue([[], true, null]);
-    namespaceRenderer(<SecretListPage />, 'test-ns', { workspacesLoaded: true });
+    namespaceRenderer(
+      <BrowserRouter>
+        <SecretListPage />
+      </BrowserRouter>,
+      'test-ns',
+      { workspacesLoaded: true },
+    );
     screen.getByTestId('secrets-list-view');
   });
 });

--- a/src/pages/__tests__/WorkspacedPage.spec.tsx
+++ b/src/pages/__tests__/WorkspacedPage.spec.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { useLocation, useParams } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import { useWorkspaceInfo } from '../../utils/workspace-context-utils';
+import WorkspacedPage from '../WorkspacedPage';
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => () => {},
+    useParams: jest.fn(),
+    useLocation: jest.fn(),
+    Navigate: ({ to }) => <p role="navigate">{to}</p>,
+  };
+});
+
+jest.mock('../../utils/workspace-context-utils', () => ({
+  useWorkspaceInfo: jest.fn(),
+}));
+
+jest.mock('react', () => {
+  const actual = jest.requireActual('react');
+  return {
+    ...actual,
+    useContext: jest.fn(),
+  };
+});
+
+const mockUseParams = useParams as jest.Mock;
+const mockUseLocation = useLocation as jest.Mock;
+const mockUseWorkspaceInfo = useWorkspaceInfo as jest.Mock;
+const mockUseContext = React.useContext as jest.Mock;
+const getMockPathname = () => `/application-pipeline`;
+
+describe('WorkspacedPage', () => {
+  it('should redirect user to a url', () => {
+    mockUseLocation.mockReturnValue({ pathname: getMockPathname() });
+    mockUseParams.mockReturnValue({
+      workspaceName: 'mock-workspace',
+    });
+    mockUseWorkspaceInfo.mockReturnValue({ workspace: 'mock-workspace' });
+    mockUseContext.mockReturnValue({});
+    render(<WorkspacedPage />);
+    const navigate = screen.getByRole('navigate');
+    expect(navigate.innerHTML).toEqual('/application-pipeline/workspaces/mock-workspace');
+  });
+
+  it('should use lastUsedWorkspace in case workspace is not found', () => {
+    mockUseLocation.mockReturnValue({ pathname: getMockPathname() });
+    mockUseParams.mockReturnValue({
+      workspaceName: undefined,
+    });
+    mockUseWorkspaceInfo.mockReturnValue({ workspace: undefined });
+    mockUseContext.mockReturnValue({ lastUsedWorkspace: 'mock-last-used-workspace' });
+    render(<WorkspacedPage />);
+    const navigate = screen.getByRole('navigate');
+    expect(navigate.innerHTML).toEqual('/application-pipeline/workspaces/mock-last-used-workspace');
+  });
+});


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/KFLUXBUGS-1286

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Add workspace switcher on the secret list page

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
![image](https://github.com/openshift/hac-dev/assets/9278015/7524c777-c9bf-45f9-9244-a8da9462582d)


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
