### PR TITLE
fix(test): don't remove repo if test failed to easy failure debugging

### DIFF
--- a/integration-tests/tests/basic-happy-path.spec.ts
+++ b/integration-tests/tests/basic-happy-path.spec.ts
@@ -40,8 +40,6 @@ describe('Basic Happy Path', () => {
   });
 
   after(function () {
-    APIHelper.deleteGitHubRepository(repoName);
-
     // If some test failed, don't remove the app
     let allTestsSucceeded = true;
     this.test.parent.eachTest((test) => {
@@ -57,6 +55,7 @@ describe('Basic Happy Path', () => {
       cy.get(actions.deleteModalInput).clear().type(applicationName);
       cy.get(actions.deleteModalButton).click();
       cy.get(`[data-id="${applicationName}"]`).should('not.exist');
+      APIHelper.deleteGitHubRepository(repoName);
     }
   });
 


### PR DESCRIPTION
## Description
Don't remove the GitHub repository, if a test fails. It may ease the debugging of a failure.