### PR TITLE
Use new git location for ec pipeline definition

### DIFF
--- a/src/components/IntegrationTest/IntegrationTestForm/const.ts
+++ b/src/components/IntegrationTest/IntegrationTestForm/const.ts
@@ -1,4 +1,4 @@
-export const EC_INTEGRATION_TEST_URL = 'https://github.com/redhat-appstudio/build-definitions';
+export const EC_INTEGRATION_TEST_URL = 'https://github.com/konflux-ci/build-definitions';
 export const EC_INTEGRATION_TEST_REVISION = 'main';
 export const EC_INTEGRATION_TEST_PATH = 'pipelines/enterprise-contract.yaml';
 export const EC_INTEGRATION_TEST_KIND = 'enterprise-contract';


### PR DESCRIPTION
## Fixes 

* https://issues.redhat.com/browse/EC-668

## Description

The build-definitions repo moved over to the new konflux-ci org in GitHub. Update the pipeline definition git resolver url accordingly.

## Type of change

One-liner to update a git url.

## Screen shots / Gifs for design review 

Should be zero visible change.

## How to test or reproduce?

I expect the risk is almost zero here. CI might be enough, but to test it, create a component and make sure the automatically created Enterprise Contract Integration Test Scenario is create and runs as expected.
