### PR TITLE
fix(test): update Pipeline label value in pipeline run details view

### DIFF
--- a/integration-tests/tests/advanced-happy-path.spec.ts
+++ b/integration-tests/tests/advanced-happy-path.spec.ts
@@ -366,7 +366,7 @@ describe('Advanced Happy path', () => {
         UIhelper.verifyRowInTable('Pipeline run List', testPipelineName, [/^Test$/]);
         UIhelper.clickLink(testPipelineName);
         DetailsTab.waitForPLRAndDownloadAllLogs(false);
-        UIhelper.verifyLabelAndValue('Pipeline', testPipelineName);
+        UIhelper.verifyLabelAndValue('Pipeline', 'enterprise-contract');
         UIhelper.verifyLabelAndValue('Related pipelines', '2 pipelines').click();
         PipelinerunsTabPage.verifyRelatedPipelines(
           integrationTestDetails.passIntegrationTestPipelineRunName,

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -70,8 +70,8 @@ mkdir -p $WORKSPACE/artifacts
 PR_TITLE=$(echo ${ghprbPullTitle} | sed -r 's/\s/_/g')
 GH_COMMENTBODY=$(echo ${ghprbCommentBody} | sed -r 's/\s/_/g')
 
-COMMON_SETUP="-v $WORKSPACE/artifacts:/tmp/artifacts:Z \
-    -v $PWD/integration-tests:/e2e:Z \
+COMMON_SETUP="-v $WORKSPACE/artifacts:/tmp/artifacts:Z,U \
+    -v $PWD/integration-tests:/e2e:Z,U \
     -e CYPRESS_PR_CHECK=true \
     -e CYPRESS_GH_PR_LINK=${ghprbPullLink} \
     -e CYPRESS_HAC_BASE_URL=https://${HOSTNAME}/application-pipeline \


### PR DESCRIPTION
## Description
Advanced tests started to fail when verifying a Pipeline label in the Pipeline run details view for the enterprise contract pipeline. It changed from pipeline name to `enterprise-contract`. 
