### PR TITLE
feat: add and use docker-build-oci-ta as default

### DIFF
--- a/src/components/ImportForm/PipelineSection/__tests__/usePipelineTemplate.spec.ts
+++ b/src/components/ImportForm/PipelineSection/__tests__/usePipelineTemplate.spec.ts
@@ -52,12 +52,12 @@ describe('usePipelineTemplate', () => {
           {
             name: 'fbc-builder',
             bundle:
-              'quay.io/redhat-appstudio-tekton-catalog/pipeline-fbc-builder:032a8745d43a942a247f365fc890b06023ccd67d',
+              'quay.io/konflux-ci/tekton-catalog/pipeline-fbc-builder@sha256:33f0a94171afa6ceadfe62a9b0e09bf1b3fe84c20b9fec8d7a28ecd1e771f4c6',
           },
           {
             name: 'docker-build',
             bundle:
-              'quay.io/redhat-appstudio-tekton-catalog/pipeline-docker-build:032a8745d43a942a247f365fc890b06023ccd67d',
+              'quay.io/konflux-ci/tekton-catalog/pipeline-docker-build@sha256:effd08d960f33d9957618982244e0d9c06f89eaaca5d125a434eacfc9851a04f',
           },
         ],
       },

--- a/src/components/ImportForm/PipelineSection/__tests__/usePipelineTemplate.spec.ts
+++ b/src/components/ImportForm/PipelineSection/__tests__/usePipelineTemplate.spec.ts
@@ -47,7 +47,7 @@ describe('usePipelineTemplate', () => {
     const { result } = renderHook(() => usePipelineTemplates());
     expect(result.current).toEqual([
       {
-        defaultPipelineName: 'docker-build',
+        defaultPipelineName: 'docker-build-oci-ta',
         pipelines: [
           {
             name: 'fbc-builder',
@@ -58,6 +58,11 @@ describe('usePipelineTemplate', () => {
             name: 'docker-build',
             bundle:
               'quay.io/konflux-ci/tekton-catalog/pipeline-docker-build@sha256:effd08d960f33d9957618982244e0d9c06f89eaaca5d125a434eacfc9851a04f',
+          },
+          {
+            name: 'docker-build-oci-ta',
+            bundle:
+              'quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta@sha256:9002db310cd002ddc7ccf94e08f8cd9b02c1bdd5dce36b59173fbc6cd4799f97',
           },
         ],
       },

--- a/src/components/ImportForm/PipelineSection/usePipelineTemplate.ts
+++ b/src/components/ImportForm/PipelineSection/usePipelineTemplate.ts
@@ -12,12 +12,12 @@ const PIPELINE_DATA = {
     {
       name: 'fbc-builder',
       bundle:
-        'quay.io/redhat-appstudio-tekton-catalog/pipeline-fbc-builder:032a8745d43a942a247f365fc890b06023ccd67d',
+        'quay.io/konflux-ci/tekton-catalog/pipeline-fbc-builder@sha256:33f0a94171afa6ceadfe62a9b0e09bf1b3fe84c20b9fec8d7a28ecd1e771f4c6',
     },
     {
       name: 'docker-build',
       bundle:
-        'quay.io/redhat-appstudio-tekton-catalog/pipeline-docker-build:032a8745d43a942a247f365fc890b06023ccd67d',
+        'quay.io/konflux-ci/tekton-catalog/pipeline-docker-build@sha256:effd08d960f33d9957618982244e0d9c06f89eaaca5d125a434eacfc9851a04f',
     },
   ],
 };

--- a/src/components/ImportForm/PipelineSection/usePipelineTemplate.ts
+++ b/src/components/ImportForm/PipelineSection/usePipelineTemplate.ts
@@ -7,7 +7,7 @@ type PipelineTemplateItems = {
 
 // [TODO] ConfigMap: remove PIPELINE_DATA once permission issue resolved for build-service namespace
 const PIPELINE_DATA = {
-  'default-pipeline-name': 'docker-build',
+  'default-pipeline-name': 'docker-build-oci-ta',
   pipelines: [
     {
       name: 'fbc-builder',
@@ -18,6 +18,11 @@ const PIPELINE_DATA = {
       name: 'docker-build',
       bundle:
         'quay.io/konflux-ci/tekton-catalog/pipeline-docker-build@sha256:effd08d960f33d9957618982244e0d9c06f89eaaca5d125a434eacfc9851a04f',
+    },
+    {
+      name: 'docker-build-oci-ta',
+      bundle:
+        'quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta@sha256:9002db310cd002ddc7ccf94e08f8cd9b02c1bdd5dce36b59173fbc6cd4799f97',
     },
   ],
 };


### PR DESCRIPTION
## Fixes 

https://issues.redhat.com/browse/EC-739

## Description

Switches the default pipeline to the OCI Trusted Artifacts pipeline. Also includes a bump of other pipeline versions.


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
Imagine different options provided on the drop down.

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

Add a new component and examine the offered pipelines.


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
