### PR TITLE
chore: move to SCAN_OUTPUT

### DIFF
--- a/src/components/Commits/CommitDetails/visualization/__data__/MockCommitWorkflowData.ts
+++ b/src/components/Commits/CommitDetails/visualization/__data__/MockCommitWorkflowData.ts
@@ -2241,7 +2241,7 @@ export const MockCommit = {
                     exitCode: 0,
                     finishedAt: '2023-03-27T13:46:14Z',
                     message:
-                      '[{"key":"CLAIR_SCAN_RESULT","value":"{\\"vulnerabilities\\":{\\"critical\\":0,\\"high\\":0,\\"medium\\":1,\\"low\\":0}}\\n","type":1},{"key":"TEST_OUTPUT","value":"{\\"result\\":\\"SUCCESS\\",\\"timestamp\\":\\"1679924774\\",\\"note\\":\\"Please refer to result CLAIR_SCAN_RESULT for the vulnerabilities scanned by clair\\",\\"namespace\\":\\"default\\",\\"successes\\":0,\\"failures\\":0,\\"warnings\\":0}\\n","type":1}]',
+                      '[{"key":"SCAN_OUTPUT","value":"{\\"vulnerabilities\\":{\\"critical\\":0,\\"high\\":0,\\"medium\\":1,\\"low\\":0}}\\n","type":1},{"key":"TEST_OUTPUT","value":"{\\"result\\":\\"SUCCESS\\",\\"timestamp\\":\\"1679924774\\",\\"note\\":\\"Please refer to result SCAN_OUTPUT for the vulnerabilities scanned by clair\\",\\"namespace\\":\\"default\\",\\"successes\\":0,\\"failures\\":0,\\"warnings\\":0}\\n","type":1}]',
                     reason: 'Completed',
                     startedAt: '2023-03-27T13:46:14Z',
                   },
@@ -2249,7 +2249,7 @@ export const MockCommit = {
               ],
               taskResults: [
                 {
-                  name: 'CLAIR_SCAN_RESULT',
+                  name: 'SCAN_OUTPUT',
                   type: 'string',
                   value: '{"vulnerabilities":{"critical":0,"high":0,"medium":1,"low":0}}\n',
                 },
@@ -2257,7 +2257,7 @@ export const MockCommit = {
                   name: 'TEST_OUTPUT',
                   type: 'string',
                   value:
-                    '{"result":"SUCCESS","timestamp":"1679924774","note":"Please refer to result CLAIR_SCAN_RESULT for the vulnerabilities scanned by clair","namespace":"default","successes":0,"failures":0,"warnings":0}\n',
+                    '{"result":"SUCCESS","timestamp":"1679924774","note":"Please refer to result SCAN_OUTPUT for the vulnerabilities scanned by clair","namespace":"default","successes":0,"failures":0,"warnings":0}\n',
                 },
               ],
               taskSpec: {
@@ -2287,7 +2287,7 @@ export const MockCommit = {
                   },
                   {
                     description: 'clair scan result',
-                    name: 'CLAIR_SCAN_RESULT',
+                    name: 'SCAN_OUTPUT',
                     type: 'string',
                   },
                 ],
@@ -2335,7 +2335,7 @@ export const MockCommit = {
                     name: 'test-format-result',
                     resources: {},
                     script:
-                      '#!/usr/bin/env bash\n. /utils.sh\n\nif [[ ! -f /tekton/home/clair-vulnerabilities.json ]] || [[ "$(jq \'.[] | has("failures")\' /tekton/home/clair-vulnerabilities.json)" == "false" ]]; then\n  TEST_OUTPUT=$(make_result_json -r "ERROR" -t "/tekton/home/clair-vulnerabilities.json is not generated correctly, please check again")\n  echo "/tekton/home/clair-vulnerabilities.json is not generated correctly, please check again"\n  echo "${TEST_OUTPUT}" | tee /tekton/results/TEST_OUTPUT\n  exit 0\nfi\n\njq -rce \\\n  \'{vulnerabilities:{\n      critical: (.[] | .failures | map(select(.metadata.details.name=="clair_critical_vulnerabilities")) | length),\n      high: (.[] | .failures | map(select(.metadata.details.name=="clair_high_vulnerabilities")) | length),\n      medium: (.[] | .failures | map(select(.metadata.details.name=="clair_medium_vulnerabilities")) | length),\n      low: (.[] | .failures | map(select(.metadata.details.name=="clair_low_vulnerabilities")) | length)\n    }}\' /tekton/home/clair-vulnerabilities.json | tee /tekton/results/CLAIR_SCAN_RESULT\n\nTEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "Please refer to result CLAIR_SCAN_RESULT for the vulnerabilities scanned by clair")\necho "${TEST_OUTPUT}" | tee /tekton/results/TEST_OUTPUT\n',
+                      '#!/usr/bin/env bash\n. /utils.sh\n\nif [[ ! -f /tekton/home/clair-vulnerabilities.json ]] || [[ "$(jq \'.[] | has("failures")\' /tekton/home/clair-vulnerabilities.json)" == "false" ]]; then\n  TEST_OUTPUT=$(make_result_json -r "ERROR" -t "/tekton/home/clair-vulnerabilities.json is not generated correctly, please check again")\n  echo "/tekton/home/clair-vulnerabilities.json is not generated correctly, please check again"\n  echo "${TEST_OUTPUT}" | tee /tekton/results/TEST_OUTPUT\n  exit 0\nfi\n\njq -rce \\\n  \'{vulnerabilities:{\n      critical: (.[] | .failures | map(select(.metadata.details.name=="clair_critical_vulnerabilities")) | length),\n      high: (.[] | .failures | map(select(.metadata.details.name=="clair_high_vulnerabilities")) | length),\n      medium: (.[] | .failures | map(select(.metadata.details.name=="clair_medium_vulnerabilities")) | length),\n      low: (.[] | .failures | map(select(.metadata.details.name=="clair_low_vulnerabilities")) | length)\n    }}\' /tekton/home/clair-vulnerabilities.json | tee /tekton/results/SCAN_OUTPUT\n\nTEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "Please refer to result SCAN_OUTPUT for the vulnerabilities scanned by clair")\necho "${TEST_OUTPUT}" | tee /tekton/results/TEST_OUTPUT\n',
                   },
                 ],
               },
@@ -6810,7 +6810,7 @@ export const MockBuildPipelines = [
                   exitCode: 0,
                   finishedAt: '2023-03-27T13:46:14Z',
                   message:
-                    '[{"key":"CLAIR_SCAN_RESULT","value":"{\\"vulnerabilities\\":{\\"critical\\":0,\\"high\\":0,\\"medium\\":1,\\"low\\":0}}\\n","type":1},{"key":"TEST_OUTPUT","value":"{\\"result\\":\\"SUCCESS\\",\\"timestamp\\":\\"1679924774\\",\\"note\\":\\"Please refer to result CLAIR_SCAN_RESULT for the vulnerabilities scanned by clair\\",\\"namespace\\":\\"default\\",\\"successes\\":0,\\"failures\\":0,\\"warnings\\":0}\\n","type":1}]',
+                    '[{"key":"SCAN_OUTPUT","value":"{\\"vulnerabilities\\":{\\"critical\\":0,\\"high\\":0,\\"medium\\":1,\\"low\\":0}}\\n","type":1},{"key":"TEST_OUTPUT","value":"{\\"result\\":\\"SUCCESS\\",\\"timestamp\\":\\"1679924774\\",\\"note\\":\\"Please refer to result SCAN_OUTPUT for the vulnerabilities scanned by clair\\",\\"namespace\\":\\"default\\",\\"successes\\":0,\\"failures\\":0,\\"warnings\\":0}\\n","type":1}]',
                   reason: 'Completed',
                   startedAt: '2023-03-27T13:46:14Z',
                 },
@@ -6818,7 +6818,7 @@ export const MockBuildPipelines = [
             ],
             taskResults: [
               {
-                name: 'CLAIR_SCAN_RESULT',
+                name: 'SCAN_OUTPUT',
                 type: 'string',
                 value: '{"vulnerabilities":{"critical":0,"high":0,"medium":1,"low":0}}\n',
               },
@@ -6826,7 +6826,7 @@ export const MockBuildPipelines = [
                 name: 'TEST_OUTPUT',
                 type: 'string',
                 value:
-                  '{"result":"SUCCESS","timestamp":"1679924774","note":"Please refer to result CLAIR_SCAN_RESULT for the vulnerabilities scanned by clair","namespace":"default","successes":0,"failures":0,"warnings":0}\n',
+                  '{"result":"SUCCESS","timestamp":"1679924774","note":"Please refer to result SCAN_OUTPUT for the vulnerabilities scanned by clair","namespace":"default","successes":0,"failures":0,"warnings":0}\n',
               },
             ],
             taskSpec: {
@@ -6856,7 +6856,7 @@ export const MockBuildPipelines = [
                 },
                 {
                   description: 'clair scan result',
-                  name: 'CLAIR_SCAN_RESULT',
+                  name: 'SCAN_OUTPUT',
                   type: 'string',
                 },
               ],
@@ -6904,7 +6904,7 @@ export const MockBuildPipelines = [
                   name: 'test-format-result',
                   resources: {},
                   script:
-                    '#!/usr/bin/env bash\n. /utils.sh\n\nif [[ ! -f /tekton/home/clair-vulnerabilities.json ]] || [[ "$(jq \'.[] | has("failures")\' /tekton/home/clair-vulnerabilities.json)" == "false" ]]; then\n  TEST_OUTPUT=$(make_result_json -r "ERROR" -t "/tekton/home/clair-vulnerabilities.json is not generated correctly, please check again")\n  echo "/tekton/home/clair-vulnerabilities.json is not generated correctly, please check again"\n  echo "${TEST_OUTPUT}" | tee /tekton/results/TEST_OUTPUT\n  exit 0\nfi\n\njq -rce \\\n  \'{vulnerabilities:{\n      critical: (.[] | .failures | map(select(.metadata.details.name=="clair_critical_vulnerabilities")) | length),\n      high: (.[] | .failures | map(select(.metadata.details.name=="clair_high_vulnerabilities")) | length),\n      medium: (.[] | .failures | map(select(.metadata.details.name=="clair_medium_vulnerabilities")) | length),\n      low: (.[] | .failures | map(select(.metadata.details.name=="clair_low_vulnerabilities")) | length)\n    }}\' /tekton/home/clair-vulnerabilities.json | tee /tekton/results/CLAIR_SCAN_RESULT\n\nTEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "Please refer to result CLAIR_SCAN_RESULT for the vulnerabilities scanned by clair")\necho "${TEST_OUTPUT}" | tee /tekton/results/TEST_OUTPUT\n',
+                    '#!/usr/bin/env bash\n. /utils.sh\n\nif [[ ! -f /tekton/home/clair-vulnerabilities.json ]] || [[ "$(jq \'.[] | has("failures")\' /tekton/home/clair-vulnerabilities.json)" == "false" ]]; then\n  TEST_OUTPUT=$(make_result_json -r "ERROR" -t "/tekton/home/clair-vulnerabilities.json is not generated correctly, please check again")\n  echo "/tekton/home/clair-vulnerabilities.json is not generated correctly, please check again"\n  echo "${TEST_OUTPUT}" | tee /tekton/results/TEST_OUTPUT\n  exit 0\nfi\n\njq -rce \\\n  \'{vulnerabilities:{\n      critical: (.[] | .failures | map(select(.metadata.details.name=="clair_critical_vulnerabilities")) | length),\n      high: (.[] | .failures | map(select(.metadata.details.name=="clair_high_vulnerabilities")) | length),\n      medium: (.[] | .failures | map(select(.metadata.details.name=="clair_medium_vulnerabilities")) | length),\n      low: (.[] | .failures | map(select(.metadata.details.name=="clair_low_vulnerabilities")) | length)\n    }}\' /tekton/home/clair-vulnerabilities.json | tee /tekton/results/SCAN_OUTPUT\n\nTEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "Please refer to result SCAN_OUTPUT for the vulnerabilities scanned by clair")\necho "${TEST_OUTPUT}" | tee /tekton/results/TEST_OUTPUT\n',
                 },
               ],
             },

--- a/src/components/Components/ComponentDetails/__data__/mockComponentDetails.ts
+++ b/src/components/Components/ComponentDetails/__data__/mockComponentDetails.ts
@@ -4452,7 +4452,7 @@ export const mockTaskRuns = [
           terminated: {
             reason: 'Completed',
             message:
-              '[{"key":"CLAIR_SCAN_RESULT","value":"{\\"vulnerabilities\\":{\\"critical\\":0,\\"high\\":2,\\"medium\\":7,\\"low\\":3}}\\n","type":1},{"key":"TEST_OUTPUT","value":"{\\"result\\":\\"SUCCESS\\",\\"timestamp\\":\\"1690797413\\",\\"note\\":\\"Task clair-scan completed: Refer to Tekton task result CLAIR_SCAN_RESULT for vulnerabilities scanned by Clair.\\",\\"namespace\\":\\"default\\",\\"successes\\":0,\\"failures\\":0,\\"warnings\\":0}\\n","type":1}]',
+              '[{"key":"SCAN_OUTPUT","value":"{\\"vulnerabilities\\":{\\"critical\\":0,\\"high\\":2,\\"medium\\":7,\\"low\\":3}}\\n","type":1},{"key":"TEST_OUTPUT","value":"{\\"result\\":\\"SUCCESS\\",\\"timestamp\\":\\"1690797413\\",\\"note\\":\\"Task clair-scan completed: Refer to Tekton task result SCAN_OUTPUT for vulnerabilities scanned by Clair.\\",\\"namespace\\":\\"default\\",\\"successes\\":0,\\"failures\\":0,\\"warnings\\":0}\\n","type":1}]',
             exitCode: 0,
             startedAt: '2023-07-31T09:56:53Z',
             finishedAt: '2023-07-31T09:56:54Z',
@@ -4500,7 +4500,7 @@ export const mockTaskRuns = [
             image:
               'quay.io/redhat-appstudio/hacbs-test:v1.1.0@sha256:82b43bffe4eacc717239424f64478b18f36528df47c2d11df3a8d031e81a3c67',
             script:
-              '#!/usr/bin/env bash\n. /utils.sh\n\nif [[ ! -f /tekton/home/clair-vulnerabilities.json ]]; then\n  note="Task clair-scan failed: /tekton/home/clair-vulnerabilities.json did not generate. For details, check Tekton task log."\n  TEST_OUTPUT=$(make_result_json -r "ERROR" -t "$note")\n  echo "/tekton/home/clair-vulnerabilities.json did not generate correctly. For details, check conftest command in Tekton task log."\n  echo "${TEST_OUTPUT}" | tee /tekton/results/TEST_OUTPUT\n  exit 0\nfi\n\njq -rce \\\n  \'{vulnerabilities:{\n      critical: (.[] | .warnings? // [] | map(select(.metadata.details.name=="clair_critical_vulnerabilities").metadata."vulnerabilities_number" // 0)| add // 0),\n      high: (.[] | .warnings? // [] | map(select(.metadata.details.name=="clair_high_vulnerabilities").metadata."vulnerabilities_number" // 0)| add // 0),\n      medium: (.[] | .warnings? // [] | map(select(.metadata.details.name=="clair_medium_vulnerabilities").metadata."vulnerabilities_number" // 0)| add // 0),\n      low: (.[] | .warnings? // [] | map(select(.metadata.details.name=="clair_low_vulnerabilities").metadata."vulnerabilities_number" // 0)| add // 0)\n    }}\' /tekton/home/clair-vulnerabilities.json | tee /tekton/results/CLAIR_SCAN_RESULT\n\nnote="Task clair-scan completed: Refer to Tekton task result CLAIR_SCAN_RESULT for vulnerabilities scanned by Clair."\nTEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "$note")\necho "${TEST_OUTPUT}" | tee /tekton/results/TEST_OUTPUT\n',
+              '#!/usr/bin/env bash\n. /utils.sh\n\nif [[ ! -f /tekton/home/clair-vulnerabilities.json ]]; then\n  note="Task clair-scan failed: /tekton/home/clair-vulnerabilities.json did not generate. For details, check Tekton task log."\n  TEST_OUTPUT=$(make_result_json -r "ERROR" -t "$note")\n  echo "/tekton/home/clair-vulnerabilities.json did not generate correctly. For details, check conftest command in Tekton task log."\n  echo "${TEST_OUTPUT}" | tee /tekton/results/TEST_OUTPUT\n  exit 0\nfi\n\njq -rce \\\n  \'{vulnerabilities:{\n      critical: (.[] | .warnings? // [] | map(select(.metadata.details.name=="clair_critical_vulnerabilities").metadata."vulnerabilities_number" // 0)| add // 0),\n      high: (.[] | .warnings? // [] | map(select(.metadata.details.name=="clair_high_vulnerabilities").metadata."vulnerabilities_number" // 0)| add // 0),\n      medium: (.[] | .warnings? // [] | map(select(.metadata.details.name=="clair_medium_vulnerabilities").metadata."vulnerabilities_number" // 0)| add // 0),\n      low: (.[] | .warnings? // [] | map(select(.metadata.details.name=="clair_low_vulnerabilities").metadata."vulnerabilities_number" // 0)| add // 0)\n    }}\' /tekton/home/clair-vulnerabilities.json | tee /tekton/results/SCAN_OUTPUT\n\nnote="Task clair-scan completed: Refer to Tekton task result SCAN_OUTPUT for vulnerabilities scanned by Clair."\nTEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "$note")\necho "${TEST_OUTPUT}" | tee /tekton/results/TEST_OUTPUT\n',
             resources: {},
           },
         ],
@@ -4529,7 +4529,7 @@ export const mockTaskRuns = [
             description: 'Tekton task test output.',
           },
           {
-            name: 'CLAIR_SCAN_RESULT',
+            name: 'SCAN_OUTPUT',
             type: 'string',
             description: 'Clair scan result.',
           },
@@ -4549,7 +4549,7 @@ export const mockTaskRuns = [
       ],
       taskResults: [
         {
-          name: 'CLAIR_SCAN_RESULT',
+          name: 'SCAN_OUTPUT',
           type: 'string',
           value: '{"vulnerabilities":{"critical":0,"high":2,"medium":7,"low":3}}\n',
         },
@@ -4557,7 +4557,7 @@ export const mockTaskRuns = [
           name: 'TEST_OUTPUT',
           type: 'string',
           value:
-            '{"result":"SUCCESS","timestamp":"1690797413","note":"Task clair-scan completed: Refer to Tekton task result CLAIR_SCAN_RESULT for vulnerabilities scanned by Clair.","namespace":"default","successes":0,"failures":0,"warnings":0}\n',
+            '{"result":"SUCCESS","timestamp":"1690797413","note":"Task clair-scan completed: Refer to Tekton task result SCAN_OUTPUT for vulnerabilities scanned by Clair.","namespace":"default","successes":0,"failures":0,"warnings":0}\n',
         },
       ],
       completionTime: '2023-07-31T09:56:55Z',

--- a/src/components/PipelineRunDetailsView/__data__/mockVisualizationData.ts
+++ b/src/components/PipelineRunDetailsView/__data__/mockVisualizationData.ts
@@ -2715,7 +2715,7 @@ export const mockPipelineRun = {
                   exitCode: 0,
                   finishedAt: '2023-03-16T01:01:11Z',
                   message:
-                    '[{"key":"CLAIR_SCAN_RESULT","value":"{\\"vulnerabilities\\":{\\"critical\\":1,\\"high\\":1,\\"medium\\":1,\\"low\\":1}}\\n","type":1},{"key":"TEST_OUTPUT","value":"{\\"result\\":\\"SUCCESS\\",\\"timestamp\\":\\"1678928471\\",\\"note\\":\\"Please refer to result CLAIR_SCAN_RESULT for the vulnerabilities scanned by clair\\",\\"namespace\\":\\"default\\",\\"successes\\":0,\\"failures\\":0,\\"warnings\\":0}\\n","type":1}]',
+                    '[{"key":"SCAN_OUTPUT","value":"{\\"vulnerabilities\\":{\\"critical\\":1,\\"high\\":1,\\"medium\\":1,\\"low\\":1}}\\n","type":1},{"key":"TEST_OUTPUT","value":"{\\"result\\":\\"SUCCESS\\",\\"timestamp\\":\\"1678928471\\",\\"note\\":\\"Please refer to result SCAN_OUTPUT for the vulnerabilities scanned by clair\\",\\"namespace\\":\\"default\\",\\"successes\\":0,\\"failures\\":0,\\"warnings\\":0}\\n","type":1}]',
                   reason: 'Completed',
                   startedAt: '2023-03-16T01:01:11Z',
                 },
@@ -2723,7 +2723,7 @@ export const mockPipelineRun = {
             ],
             results: [
               {
-                name: 'CVE_SCAN_RESULT',
+                name: 'SCAN_OUTPUT',
                 type: 'string',
                 value: '{"vulnerabilities":{"critical":1,"high":1,"medium":1,"low":1}}\n',
               },
@@ -2731,7 +2731,7 @@ export const mockPipelineRun = {
                 name: 'TEST_OUTPUT',
                 type: 'string',
                 value:
-                  '{"result":"SUCCESS","timestamp":"1678928471","note":"Please refer to result CLAIR_SCAN_RESULT for the vulnerabilities scanned by clair","namespace":"default","successes":0,"failures":0,"warnings":0}\n',
+                  '{"result":"SUCCESS","timestamp":"1678928471","note":"Please refer to result SCAN_OUTPUT for the vulnerabilities scanned by clair","namespace":"default","successes":0,"failures":0,"warnings":0}\n',
               },
             ],
             taskSpec: {
@@ -2761,7 +2761,7 @@ export const mockPipelineRun = {
                 },
                 {
                   description: 'clair scan result',
-                  name: 'CLAIR_SCAN_RESULT',
+                  name: 'SCAN_OUTPUT',
                   type: 'string',
                 },
               ],
@@ -2809,7 +2809,7 @@ export const mockPipelineRun = {
                   name: 'test-format-result',
                   resources: {},
                   script:
-                    '#!/usr/bin/env bash\n. /utils.sh\n\nif [[ ! -f /tekton/home/clair-vulnerabilities.json ]] || [[ "$(jq \'.[] | has("failures")\' /tekton/home/clair-vulnerabilities.json)" == "false" ]]; then\n  TEST_OUTPUT=$(make_result_json -r "ERROR" -t "/tekton/home/clair-vulnerabilities.json is not generated correctly, please check again")\n  echo "/tekton/home/clair-vulnerabilities.json is not generated correctly, please check again"\n  echo "${TEST_OUTPUT}" | tee /tekton/results/TEST_OUTPUT\n  exit 0\nfi\n\njq -rce \\\n  \'{vulnerabilities:{\n      critical: (.[] | .failures | map(select(.metadata.details.name=="clair_critical_vulnerabilities")) | length),\n      high: (.[] | .failures | map(select(.metadata.details.name=="clair_high_vulnerabilities")) | length),\n      medium: (.[] | .failures | map(select(.metadata.details.name=="clair_medium_vulnerabilities")) | length),\n      low: (.[] | .failures | map(select(.metadata.details.name=="clair_low_vulnerabilities")) | length)\n    }}\' /tekton/home/clair-vulnerabilities.json | tee /tekton/results/CLAIR_SCAN_RESULT\n\nTEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "Please refer to result CLAIR_SCAN_RESULT for the vulnerabilities scanned by clair")\necho "${TEST_OUTPUT}" | tee /tekton/results/TEST_OUTPUT\n',
+                    '#!/usr/bin/env bash\n. /utils.sh\n\nif [[ ! -f /tekton/home/clair-vulnerabilities.json ]] || [[ "$(jq \'.[] | has("failures")\' /tekton/home/clair-vulnerabilities.json)" == "false" ]]; then\n  TEST_OUTPUT=$(make_result_json -r "ERROR" -t "/tekton/home/clair-vulnerabilities.json is not generated correctly, please check again")\n  echo "/tekton/home/clair-vulnerabilities.json is not generated correctly, please check again"\n  echo "${TEST_OUTPUT}" | tee /tekton/results/TEST_OUTPUT\n  exit 0\nfi\n\njq -rce \\\n  \'{vulnerabilities:{\n      critical: (.[] | .failures | map(select(.metadata.details.name=="clair_critical_vulnerabilities")) | length),\n      high: (.[] | .failures | map(select(.metadata.details.name=="clair_high_vulnerabilities")) | length),\n      medium: (.[] | .failures | map(select(.metadata.details.name=="clair_medium_vulnerabilities")) | length),\n      low: (.[] | .failures | map(select(.metadata.details.name=="clair_low_vulnerabilities")) | length)\n    }}\' /tekton/home/clair-vulnerabilities.json | tee /tekton/results/SCAN_OUTPUT\n\nTEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "Please refer to result SCAN_OUTPUT for the vulnerabilities scanned by clair")\necho "${TEST_OUTPUT}" | tee /tekton/results/TEST_OUTPUT\n',
                 },
               ],
             },
@@ -3944,7 +3944,7 @@ export const mockPipelineRun = {
                 exitCode: 0,
                 finishedAt: '2023-03-16T01:01:11Z',
                 message:
-                  '[{"key":"CLAIR_SCAN_RESULT","value":"{\\"vulnerabilities\\":{\\"critical\\":1,\\"high\\":1,\\"medium\\":1,\\"low\\":1}}\\n","type":1},{"key":"TEST_OUTPUT","value":"{\\"result\\":\\"SUCCESS\\",\\"timestamp\\":\\"1678928471\\",\\"note\\":\\"Please refer to result CLAIR_SCAN_RESULT for the vulnerabilities scanned by clair\\",\\"namespace\\":\\"default\\",\\"successes\\":0,\\"failures\\":0,\\"warnings\\":0}\\n","type":1}]',
+                  '[{"key":"SCAN_OUTPUT","value":"{\\"vulnerabilities\\":{\\"critical\\":1,\\"high\\":1,\\"medium\\":1,\\"low\\":1}}\\n","type":1},{"key":"TEST_OUTPUT","value":"{\\"result\\":\\"SUCCESS\\",\\"timestamp\\":\\"1678928471\\",\\"note\\":\\"Please refer to result SCAN_OUTPUT for the vulnerabilities scanned by clair\\",\\"namespace\\":\\"default\\",\\"successes\\":0,\\"failures\\":0,\\"warnings\\":0}\\n","type":1}]',
                 reason: 'Completed',
                 startedAt: '2023-03-16T01:01:11Z',
               },
@@ -3952,7 +3952,7 @@ export const mockPipelineRun = {
           ],
           results: [
             {
-              name: 'CVE_SCAN_RESULT',
+              name: 'SCAN_OUTPUT',
               type: 'string',
               value: '{"vulnerabilities":{"critical":1,"high":1,"medium":1,"low":1}}\n',
             },
@@ -3960,7 +3960,7 @@ export const mockPipelineRun = {
               name: 'TEST_OUTPUT',
               type: 'string',
               value:
-                '{"result":"SUCCESS","timestamp":"1678928471","note":"Please refer to result CLAIR_SCAN_RESULT for the vulnerabilities scanned by clair","namespace":"default","successes":0,"failures":0,"warnings":0}\n',
+                '{"result":"SUCCESS","timestamp":"1678928471","note":"Please refer to result SCAN_OUTPUT for the vulnerabilities scanned by clair","namespace":"default","successes":0,"failures":0,"warnings":0}\n',
             },
           ],
           taskSpec: {
@@ -3990,7 +3990,7 @@ export const mockPipelineRun = {
               },
               {
                 description: 'clair scan result',
-                name: 'CLAIR_SCAN_RESULT',
+                name: 'SCAN_OUTPUT',
                 type: 'string',
               },
             ],
@@ -4038,7 +4038,7 @@ export const mockPipelineRun = {
                 name: 'test-format-result',
                 resources: {},
                 script:
-                  '#!/usr/bin/env bash\n. /utils.sh\n\nif [[ ! -f /tekton/home/clair-vulnerabilities.json ]] || [[ "$(jq \'.[] | has("failures")\' /tekton/home/clair-vulnerabilities.json)" == "false" ]]; then\n  TEST_OUTPUT=$(make_result_json -r "ERROR" -t "/tekton/home/clair-vulnerabilities.json is not generated correctly, please check again")\n  echo "/tekton/home/clair-vulnerabilities.json is not generated correctly, please check again"\n  echo "${TEST_OUTPUT}" | tee /tekton/results/TEST_OUTPUT\n  exit 0\nfi\n\njq -rce \\\n  \'{vulnerabilities:{\n      critical: (.[] | .failures | map(select(.metadata.details.name=="clair_critical_vulnerabilities")) | length),\n      high: (.[] | .failures | map(select(.metadata.details.name=="clair_high_vulnerabilities")) | length),\n      medium: (.[] | .failures | map(select(.metadata.details.name=="clair_medium_vulnerabilities")) | length),\n      low: (.[] | .failures | map(select(.metadata.details.name=="clair_low_vulnerabilities")) | length)\n    }}\' /tekton/home/clair-vulnerabilities.json | tee /tekton/results/CLAIR_SCAN_RESULT\n\nTEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "Please refer to result CLAIR_SCAN_RESULT for the vulnerabilities scanned by clair")\necho "${TEST_OUTPUT}" | tee /tekton/results/TEST_OUTPUT\n',
+                  '#!/usr/bin/env bash\n. /utils.sh\n\nif [[ ! -f /tekton/home/clair-vulnerabilities.json ]] || [[ "$(jq \'.[] | has("failures")\' /tekton/home/clair-vulnerabilities.json)" == "false" ]]; then\n  TEST_OUTPUT=$(make_result_json -r "ERROR" -t "/tekton/home/clair-vulnerabilities.json is not generated correctly, please check again")\n  echo "/tekton/home/clair-vulnerabilities.json is not generated correctly, please check again"\n  echo "${TEST_OUTPUT}" | tee /tekton/results/TEST_OUTPUT\n  exit 0\nfi\n\njq -rce \\\n  \'{vulnerabilities:{\n      critical: (.[] | .failures | map(select(.metadata.details.name=="clair_critical_vulnerabilities")) | length),\n      high: (.[] | .failures | map(select(.metadata.details.name=="clair_high_vulnerabilities")) | length),\n      medium: (.[] | .failures | map(select(.metadata.details.name=="clair_medium_vulnerabilities")) | length),\n      low: (.[] | .failures | map(select(.metadata.details.name=="clair_low_vulnerabilities")) | length)\n    }}\' /tekton/home/clair-vulnerabilities.json | tee /tekton/results/SCAN_OUTPUT\n\nTEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "Please refer to result SCAN_OUTPUT for the vulnerabilities scanned by clair")\necho "${TEST_OUTPUT}" | tee /tekton/results/TEST_OUTPUT\n',
               },
             ],
           },
@@ -6221,7 +6221,7 @@ export const mockTaskRuns = [
             exitCode: 0,
             finishedAt: '2023-03-16T01:01:11Z',
             message:
-              '[{"key":"CVE_SCAN_RESULT","value":"{\\"vulnerabilities\\":{\\"critical\\":1,\\"high\\":1,\\"medium\\":1,\\"low\\":1}}\\n","type":1},{"key":"TEST_OUTPUT","value":"{\\"result\\":\\"SUCCESS\\",\\"timestamp\\":\\"1678928471\\",\\"note\\":\\"Please refer to result CLAIR_SCAN_RESULT for the vulnerabilities scanned by clair\\",\\"namespace\\":\\"default\\",\\"successes\\":0,\\"failures\\":0,\\"warnings\\":0}\\n","type":1}]',
+              '[{"key":"SCAN_OUTPUT","value":"{\\"vulnerabilities\\":{\\"critical\\":1,\\"high\\":1,\\"medium\\":1,\\"low\\":1}}\\n","type":1},{"key":"TEST_OUTPUT","value":"{\\"result\\":\\"SUCCESS\\",\\"timestamp\\":\\"1678928471\\",\\"note\\":\\"Please refer to result SCAN_OUTPUT for the vulnerabilities scanned by clair\\",\\"namespace\\":\\"default\\",\\"successes\\":0,\\"failures\\":0,\\"warnings\\":0}\\n","type":1}]',
             reason: 'Completed',
             startedAt: '2023-03-16T01:01:11Z',
           },
@@ -6229,7 +6229,7 @@ export const mockTaskRuns = [
       ],
       results: [
         {
-          name: 'CVE_SCAN_RESULT',
+          name: 'SCAN_OUTPUT',
           type: 'string',
           value: '{"vulnerabilities":{"critical":1,"high":1,"medium":1,"low":1}}\n',
         },
@@ -6237,7 +6237,7 @@ export const mockTaskRuns = [
           name: 'TEST_OUTPUT',
           type: 'string',
           value:
-            '{"result":"SUCCESS","timestamp":"1678928471","note":"Please refer to result CVE_SCAN_RESULT for the vulnerabilities scanned by clair","namespace":"default","successes":0,"failures":0,"warnings":0}\n',
+            '{"result":"SUCCESS","timestamp":"1678928471","note":"Please refer to result SCAN_OUTPUT for the vulnerabilities scanned by clair","namespace":"default","successes":0,"failures":0,"warnings":0}\n',
         },
       ],
       taskSpec: {
@@ -6267,7 +6267,7 @@ export const mockTaskRuns = [
           },
           {
             description: 'clair scan result',
-            name: 'CVE_SCAN_RESULT',
+            name: 'SCAN_OUTPUT',
             type: 'string',
           },
         ],
@@ -6314,7 +6314,7 @@ export const mockTaskRuns = [
             name: 'test-format-result',
             resources: {},
             script:
-              '#!/usr/bin/env bash\n. /utils.sh\n\nif [[ ! -f /tekton/home/clair-vulnerabilities.json ]] || [[ "$(jq \'.[] | has("failures")\' /tekton/home/clair-vulnerabilities.json)" == "false" ]]; then\n  TEST_OUTPUT=$(make_result_json -r "ERROR" -t "/tekton/home/clair-vulnerabilities.json is not generated correctly, please check again")\n  echo "/tekton/home/clair-vulnerabilities.json is not generated correctly, please check again"\n  echo "${TEST_OUTPUT}" | tee /tekton/results/TEST_OUTPUT\n  exit 0\nfi\n\njq -rce \\\n  \'{vulnerabilities:{\n      critical: (.[] | .failures | map(select(.metadata.details.name=="clair_critical_vulnerabilities")) | length),\n      high: (.[] | .failures | map(select(.metadata.details.name=="clair_high_vulnerabilities")) | length),\n      medium: (.[] | .failures | map(select(.metadata.details.name=="clair_medium_vulnerabilities")) | length),\n      low: (.[] | .failures | map(select(.metadata.details.name=="clair_low_vulnerabilities")) | length)\n    }}\' /tekton/home/clair-vulnerabilities.json | tee /tekton/results/CLAIR_SCAN_RESULT\n\nTEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "Please refer to result CLAIR_SCAN_RESULT for the vulnerabilities scanned by clair")\necho "${TEST_OUTPUT}" | tee /tekton/results/TEST_OUTPUT\n',
+              '#!/usr/bin/env bash\n. /utils.sh\n\nif [[ ! -f /tekton/home/clair-vulnerabilities.json ]] || [[ "$(jq \'.[] | has("failures")\' /tekton/home/clair-vulnerabilities.json)" == "false" ]]; then\n  TEST_OUTPUT=$(make_result_json -r "ERROR" -t "/tekton/home/clair-vulnerabilities.json is not generated correctly, please check again")\n  echo "/tekton/home/clair-vulnerabilities.json is not generated correctly, please check again"\n  echo "${TEST_OUTPUT}" | tee /tekton/results/TEST_OUTPUT\n  exit 0\nfi\n\njq -rce \\\n  \'{vulnerabilities:{\n      critical: (.[] | .failures | map(select(.metadata.details.name=="clair_critical_vulnerabilities")) | length),\n      high: (.[] | .failures | map(select(.metadata.details.name=="clair_high_vulnerabilities")) | length),\n      medium: (.[] | .failures | map(select(.metadata.details.name=="clair_medium_vulnerabilities")) | length),\n      low: (.[] | .failures | map(select(.metadata.details.name=="clair_low_vulnerabilities")) | length)\n    }}\' /tekton/home/clair-vulnerabilities.json | tee /tekton/results/SCAN_OUTPUT\n\nTEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "Please refer to result SCAN_OUTPUT for the vulnerabilities scanned by clair")\necho "${TEST_OUTPUT}" | tee /tekton/results/TEST_OUTPUT\n',
           },
         ],
       },

--- a/src/components/PipelineRunDetailsView/sidepanels/__tests__/TaskRunDetails.spec.tsx
+++ b/src/components/PipelineRunDetailsView/sidepanels/__tests__/TaskRunDetails.spec.tsx
@@ -75,7 +75,7 @@ describe('TaskRunDetails', () => {
             status: {
               results: [
                 {
-                  name: 'CLAIR_SCAN_RESULTS',
+                  name: 'SCAN_OUTPUT',
                   value: '{"vulnerabilities":{"critical":0,"high":0,"medium":1,"low":0}}',
                 },
               ],

--- a/src/components/PipelineRunDetailsView/tabs/__tests__/ScanDescriptionListGroup.spec.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/__tests__/ScanDescriptionListGroup.spec.tsx
@@ -28,7 +28,7 @@ const mockTaskRun = {
   status: {
     results: [
       {
-        name: 'CVE_SCAN_RESULT',
+        name: 'SCAN_OUTPUT',
         value: '{"vulnerabilities":{"critical":1,"high":2,"medium":3,"low":4}}',
       },
     ],
@@ -47,7 +47,7 @@ const mockTaskRun2 = {
   status: {
     results: [
       {
-        name: 'CVE_SCAN_RESULT',
+        name: 'SCAN_OUTPUT',
         value: '{"vulnerabilities":{"critical":1,"high":2,"medium":3,"low":4}}',
       },
     ],

--- a/src/hooks/__tests__/useScanResults.spec.ts
+++ b/src/hooks/__tests__/useScanResults.spec.ts
@@ -22,7 +22,7 @@ const taskRunData = [
     status: {
       results: [
         {
-          name: 'CVE_SCAN_RESULT',
+          name: 'SCAN_OUTPUT',
           value: '{ "vulnerabilities": { "critical": 1, "high": 2, "medium": 3, "low": 4 } }',
         },
       ],
@@ -36,7 +36,7 @@ const taskRunData = [
     status: {
       results: [
         {
-          name: 'CLAIR_SCAN_RESULT',
+          name: 'SCAN_OUTPUT',
           value: '{ "vulnerabilities": { "critical": 5, "high": 2, "medium": 0, "low": 4 } }',
         },
       ],

--- a/src/hooks/useScanResults.ts
+++ b/src/hooks/useScanResults.ts
@@ -7,22 +7,12 @@ import { OR } from '../utils/tekton-results';
 import { useWorkspaceInfo } from '../utils/workspace-context-utils';
 import { useTRTaskRuns } from './useTektonResults';
 
-export const SCAN_RESULT = 'CLAIR_SCAN_RESULT';
-export const SCAN_RESULTS = 'CLAIR_SCAN_RESULTS';
-export const CVE_SCAN_RESULT = 'CVE_SCAN_RESULT';
-export const TEKTON_SCAN_RESULTS = 'TEKTON_SCAN_RESULTS';
 export const SCAN_OUTPUT = 'SCAN_OUTPUT';
 
-export const CVE_SCAN_RESULT_FIELDS = [
-  SCAN_RESULT,
-  SCAN_RESULTS,
-  CVE_SCAN_RESULT,
-  TEKTON_SCAN_RESULTS,
-  SCAN_OUTPUT,
-];
+export const SCAN_OUTPUT_FIELDS = [SCAN_OUTPUT];
 
 export const isCVEScanResult = (taskRunResults: TektonResultsRun) =>
-  CVE_SCAN_RESULT_FIELDS.includes(taskRunResults?.name);
+  SCAN_OUTPUT_FIELDS.includes(taskRunResults?.name);
 
 export type ScanResults = {
   vulnerabilities: {
@@ -85,7 +75,7 @@ export const useScanResults = (
     React.useMemo(
       () => ({
         filter: OR(
-          ...CVE_SCAN_RESULT_FIELDS.map((field) => `data.status.taskResults.contains("${field}")`),
+          ...SCAN_OUTPUT_FIELDS.map((field) => `data.status.taskResults.contains("${field}")`),
         ),
         selector: {
           matchLabels: {
@@ -170,7 +160,7 @@ export const usePLRScanResults = (
     React.useMemo(
       () => ({
         filter: OR(
-          ...CVE_SCAN_RESULT_FIELDS.map((field) => `data.status.taskResults.contains("${field}")`),
+          ...SCAN_OUTPUT_FIELDS.map((field) => `data.status.taskResults.contains("${field}")`),
         ),
         selector: {
           matchExpressions: [


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

Fixes: https://issues.redhat.com/browse/HAC-5348

Relates to: https://issues.redhat.com/browse/STONEINTG-660

Relates to: https://konflux-ci.dev/architecture/ADR/0030-tekton-results-naming-convention.html

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

I ran `sed` replacing CLAIR_SCAN_RESULT with SCAN_OUTPUT.

## Type of change
<!-- Please delete options that are not relevant. -->

There *is* an API change here, kind of. It's not entirely inert.  But the new task result should get merged into build-definitions after this change goes out.

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

N/A

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

I just ran `npm test`

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
