### PR TITLE
fix(test): remove sbom-json-check

### DIFF
--- a/integration-tests/support/pages/tabs/PipelinerunsTabPage.ts
+++ b/integration-tests/support/pages/tabs/PipelinerunsTabPage.ts
@@ -170,7 +170,6 @@ export class TaskRunsTab {
         task: 'deprecated-base-image-check',
         status: 'Succeeded',
       },
-      { name: `${pipelineName}-sbom-json-check`, task: 'sbom-json-check', status: 'Succeeded' },
       { name: `${pipelineName}-clair-scan`, task: 'clair-scan', status: 'Succeeded|Test Failures' }, // Adding Test Warnings as some packages might have medium vulnerabilities sometimes
       {
         name: `${pipelineName}-clamav-scan`,


### PR DESCRIPTION
## Description
The advanced test path started to fail as `sbom-json-check` task was removed ([PR#1330](https://github.com/konflux-ci/build-definitions/pull/1330)). Removing the task from tests too.