### PR TITLE
fix(KFLUXBUGS-1197): component relationship remove button

### DIFF
--- a/src/components/ComponentRelation/ComponentRelationForm.tsx
+++ b/src/components/ComponentRelation/ComponentRelationForm.tsx
@@ -95,7 +95,12 @@ export const ComponentRelation: React.FC<ComponentRelationProps> = ({
       </GridItem>
       {showRemove && (
         <GridItem span={1}>
-          <Icon status="custom" onClick={onRemove} style={{ cursor: 'pointer' }}>
+          <Icon
+            id={`remove-relation-${index}`}
+            status="custom"
+            onClick={onRemove}
+            style={{ cursor: 'pointer' }}
+          >
             <MinusCircleIcon />
           </Icon>
         </GridItem>

--- a/src/components/ComponentRelation/ComponentRelationForm.tsx
+++ b/src/components/ComponentRelation/ComponentRelationForm.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Bullseye, Flex, FlexItem, Grid, GridItem, Icon, Radio } from '@patternfly/react-core';
+import { Bullseye, Flex, FlexItem, Grid, GridItem, Button, Radio } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/minus-circle-icon';
 import { useField } from 'formik';
 import { HelpTooltipIcon } from '../../shared';
@@ -95,14 +95,9 @@ export const ComponentRelation: React.FC<ComponentRelationProps> = ({
       </GridItem>
       {showRemove && (
         <GridItem span={1}>
-          <Icon
-            id={`remove-relation-${index}`}
-            status="custom"
-            onClick={onRemove}
-            style={{ cursor: 'pointer' }}
-          >
+          <Button id={`remove-relation-${index}`} variant="plain" onClick={onRemove}>
             <MinusCircleIcon />
-          </Icon>
+          </Button>
         </GridItem>
       )}
     </Grid>

--- a/src/components/ComponentRelation/ComponentRelationForm.tsx
+++ b/src/components/ComponentRelation/ComponentRelationForm.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { Bullseye, Flex, FlexItem, Grid, GridItem, Radio } from '@patternfly/react-core';
+import { Bullseye, Flex, FlexItem, Grid, GridItem, Icon, Radio } from '@patternfly/react-core';
+import { MinusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/minus-circle-icon';
 import { useField } from 'formik';
 import { HelpTooltipIcon } from '../../shared';
 import {
@@ -12,12 +13,17 @@ type ComponentRelationProps = {
   componentNames: string[];
   groupedComponents: { [application: string]: string[] };
   index?: Number;
+  removeProps: {
+    showRemove: boolean;
+    onRemove: () => void;
+  };
 };
 
 export const ComponentRelation: React.FC<ComponentRelationProps> = ({
   index,
   componentNames,
   groupedComponents,
+  removeProps: { showRemove, onRemove },
 }) => {
   const sourceName = `relations.${index.toString()}.source`;
   const nudgeName = `relations.${index.toString()}.nudgeType`;
@@ -87,6 +93,13 @@ export const ComponentRelation: React.FC<ComponentRelationProps> = ({
           groupedComponents={groupedComponents}
         />
       </GridItem>
+      {showRemove && (
+        <GridItem span={1}>
+          <Icon status="custom" onClick={onRemove} style={{ cursor: 'pointer' }}>
+            <MinusCircleIcon />
+          </Icon>
+        </GridItem>
+      )}
     </Grid>
   );
 };

--- a/src/components/ComponentRelation/ComponentRelationForm.tsx
+++ b/src/components/ComponentRelation/ComponentRelationForm.tsx
@@ -14,7 +14,7 @@ type ComponentRelationProps = {
   groupedComponents: { [application: string]: string[] };
   index?: Number;
   removeProps: {
-    showRemove: boolean;
+    disableRemove: boolean;
     onRemove: () => void;
   };
 };
@@ -23,7 +23,7 @@ export const ComponentRelation: React.FC<ComponentRelationProps> = ({
   index,
   componentNames,
   groupedComponents,
-  removeProps: { showRemove, onRemove },
+  removeProps: { disableRemove, onRemove },
 }) => {
   const sourceName = `relations.${index.toString()}.source`;
   const nudgeName = `relations.${index.toString()}.nudgeType`;
@@ -93,13 +93,16 @@ export const ComponentRelation: React.FC<ComponentRelationProps> = ({
           groupedComponents={groupedComponents}
         />
       </GridItem>
-      {showRemove && (
-        <GridItem span={1}>
-          <Button id={`remove-relation-${index}`} variant="plain" onClick={onRemove}>
-            <MinusCircleIcon />
-          </Button>
-        </GridItem>
-      )}
+      <GridItem span={1}>
+        <Button
+          id={`remove-relation-${index}`}
+          variant="plain"
+          onClick={onRemove}
+          isDisabled={disableRemove}
+        >
+          <MinusCircleIcon />
+        </Button>
+      </GridItem>
     </Grid>
   );
 };

--- a/src/components/ComponentRelation/ComponentRelationModal.tsx
+++ b/src/components/ComponentRelation/ComponentRelationModal.tsx
@@ -60,12 +60,14 @@ export const ComponentRelationModal: React.FC<ComponentRelationModalProps> = ({
     setShowCancelModal(true);
   }, [application, track, workspace]);
 
-  const initialValues: ComponentRelationFormikValue = {
-    relations:
-      loaded && !error && nudgeData.length > 0
-        ? nudgeData
-        : [{ source: '', nudgeType: ComponentRelationNudgeType.NUDGES, target: [] }],
-  };
+  const initialValues: ComponentRelationFormikValue = React.useMemo(() => {
+    return {
+      relations:
+        loaded && !error && nudgeData.length > 0
+          ? nudgeData
+          : [{ source: '', nudgeType: ComponentRelationNudgeType.NUDGES, target: [] }],
+    };
+  }, [error, loaded, nudgeData]);
 
   const handleSubmit = React.useCallback(
     async (
@@ -78,7 +80,7 @@ export const ComponentRelationModal: React.FC<ComponentRelationModalProps> = ({
         workspace,
       });
       try {
-        await updateNudgeDependencies(values.relations, namespace, true);
+        await updateNudgeDependencies(values.relations, initialValues.relations, namespace, true);
       } catch (e) {
         // eslint-disable-next-line no-console
         console.error(`Error while updating dependency data for component`, e);
@@ -86,7 +88,7 @@ export const ComponentRelationModal: React.FC<ComponentRelationModalProps> = ({
         helpers.setSubmitting(false);
         helpers.setStatus({ submitError: e?.message });
       }
-      return updateNudgeDependencies(values.relations, namespace)
+      return updateNudgeDependencies(values.relations, initialValues.relations, namespace)
         .then((compResults: ComponentKind[]) => {
           compResults.forEach((c) => {
             track('Component relationship updated', {
@@ -105,7 +107,7 @@ export const ComponentRelationModal: React.FC<ComponentRelationModalProps> = ({
           helpers.setStatus({ submitError: e?.message });
         });
     },
-    [application, namespace, onSaveRelationships, track, workspace],
+    [application, namespace, onSaveRelationships, track, workspace, initialValues],
   );
 
   if (showSubmissionModal && !showCancelModal) {

--- a/src/components/ComponentRelation/__tests__/ComponentRelationForm.spec.tsx
+++ b/src/components/ComponentRelation/__tests__/ComponentRelationForm.spec.tsx
@@ -14,7 +14,7 @@ describe('ComponentRelationForm', () => {
         componentNames={['asdf', 'asd']}
         groupedComponents={{ app: ['asdf', 'asd'] }}
         removeProps={{
-          showRemove: true,
+          disableRemove: true,
           onRemove: jest.fn(),
         }}
       />,

--- a/src/components/ComponentRelation/__tests__/ComponentRelationForm.spec.tsx
+++ b/src/components/ComponentRelation/__tests__/ComponentRelationForm.spec.tsx
@@ -13,6 +13,10 @@ describe('ComponentRelationForm', () => {
         index={0}
         componentNames={['asdf', 'asd']}
         groupedComponents={{ app: ['asdf', 'asd'] }}
+        removeProps={{
+          showRemove: true,
+          onRemove: jest.fn(),
+        }}
       />,
       {
         relations: [

--- a/src/components/ComponentRelation/__tests__/ComponentRelationModal.spec.tsx
+++ b/src/components/ComponentRelation/__tests__/ComponentRelationModal.spec.tsx
@@ -81,10 +81,11 @@ describe('ComponentRelationModal', () => {
 
   it('should remove a relation', () => {
     render(<ComponentRelationModal modalProps={{ isOpen: true }} application="apps" />);
+    expect(screen.queryAllByTestId(/remove-relation-\d+/)).toHaveLength(1);
     fireEvent.click(screen.getByText(`Add another component relationship`));
     expect(screen.getAllByTestId(/remove-relation-\d+/)).toHaveLength(2);
     fireEvent.click(screen.getByTestId('remove-relation-0'));
-    expect(screen.queryAllByTestId(/remove-relation-\d+/)).toHaveLength(0);
+    expect(screen.queryAllByTestId(/remove-relation-\d+/)).toHaveLength(1);
   });
 
   it('should show cancelation modal when clicked on cancel', () => {

--- a/src/components/ComponentRelation/__tests__/ComponentRelationModal.spec.tsx
+++ b/src/components/ComponentRelation/__tests__/ComponentRelationModal.spec.tsx
@@ -52,6 +52,14 @@ describe('ComponentRelationModal', () => {
     expect(screen.getAllByTestId('toggle-component-menu')).toHaveLength(2);
   });
 
+  it('should remove a relation', () => {
+    render(<ComponentRelationModal modalProps={{ isOpen: true }} application="apps" />);
+    fireEvent.click(screen.getByText(`Add another component relationship`));
+    expect(screen.getAllByTestId(/remove-relation-\d+/)).toHaveLength(2);
+    fireEvent.click(screen.getByTestId('remove-relation-0'));
+    expect(screen.queryAllByTestId(/remove-relation-\d+/)).toHaveLength(0);
+  });
+
   it('should show cancelation modal when clicked on cancel', () => {
     let isOpen = true;
     const onClose = () => {

--- a/src/components/ComponentRelation/__tests__/ComponentRelationModal.spec.tsx
+++ b/src/components/ComponentRelation/__tests__/ComponentRelationModal.spec.tsx
@@ -2,6 +2,9 @@ import * as React from 'react';
 import { configure, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { componentCRMocks } from '../../Components/__data__/mock-data';
 import { ComponentRelationModal } from '../ComponentRelationModal';
+import { ComponentRelationNudgeType, ComponentRelationValue } from '../type';
+import { useNudgeData } from '../useNudgeData';
+import { updateNudgeDependencies } from '../utils';
 import '@testing-library/jest-dom';
 
 configure({ testIdAttribute: 'id' });
@@ -22,7 +25,11 @@ jest.mock('../../../utils/analytics', () => ({
 
 jest.mock('../utils', () => ({
   ...jest.requireActual('../utils'),
-  updateNudgeDependencies: jest.fn(() => Promise.resolve([])),
+  updateNudgeDependencies: jest.fn(),
+}));
+
+jest.mock('../useNudgeData', () => ({
+  useNudgeData: jest.fn(),
 }));
 
 class MockResizeObserver {
@@ -39,9 +46,29 @@ class MockResizeObserver {
   }
 }
 
+const mockComponentRelations: ComponentRelationValue[] = [
+  {
+    source: 'a',
+    nudgeType: ComponentRelationNudgeType.NUDGES,
+    target: ['b'],
+  },
+  {
+    source: 'c',
+    nudgeType: ComponentRelationNudgeType.NUDGES,
+    target: ['d'],
+  },
+];
+
 window.ResizeObserver = MockResizeObserver;
+const useNudgeDataMock = useNudgeData as jest.Mock;
+const updateNudgeDependenciesMock = updateNudgeDependencies as jest.Mock;
 
 describe('ComponentRelationModal', () => {
+  beforeEach(() => {
+    useNudgeDataMock.mockReturnValue([[], true, null]);
+    updateNudgeDependenciesMock.mockResolvedValue(componentCRMocks);
+  });
+
   it('should render modal', () => {
     render(<ComponentRelationModal modalProps={{ isOpen: true }} application="apps" />);
     screen.getByText('Component relationships');
@@ -89,6 +116,34 @@ describe('ComponentRelationModal', () => {
   });
 
   it('should show confirmation modal on relationship save', async () => {
+    useNudgeDataMock.mockReturnValue([mockComponentRelations, true, null]);
+    updateNudgeDependenciesMock.mockResolvedValue(componentCRMocks);
+    let isOpen = true;
+    const onClose = () => {
+      isOpen = false;
+    };
+    const { rerender } = render(
+      <ComponentRelationModal modalProps={{ isOpen, onClose }} application="apps" />,
+    );
+    expect(screen.queryByText('Component relationships')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('nudged-by-0'));
+    const saveButton = screen.getByText('Save relationships');
+    expect(saveButton.getAttribute('class')).not.toContain('pf-m-disabled');
+    fireEvent.click(saveButton);
+    expect(saveButton.getAttribute('class')).toContain('pf-m-in-progress');
+    await waitFor(() => {
+      expect(saveButton.getAttribute('class')).toContain('pf-m-in-progress');
+    });
+
+    rerender(<ComponentRelationModal modalProps={{ isOpen, onClose }} application="apps" />);
+    await waitFor(() => {
+      expect(screen.queryByText('Relationships updated!')).toBeInTheDocument();
+    });
+  });
+
+  it('should display an error on failure', async () => {
+    useNudgeDataMock.mockReturnValue([mockComponentRelations, true, null]);
+    updateNudgeDependenciesMock.mockRejectedValue(new Error('error'));
     let isOpen = true;
     const onClose = () => {
       isOpen = false;
@@ -99,7 +154,6 @@ describe('ComponentRelationModal', () => {
     const saveButton = screen.getByText('Save relationships');
     expect(saveButton.getAttribute('class')).not.toContain('pf-m-disabled');
     fireEvent.click(saveButton);
-    await expect(saveButton.getAttribute('class')).toContain('pf-m-in-progress');
-    await waitFor(() => expect(saveButton.getAttribute('class')).not.toContain('pf-m-in-progress'));
+    await waitFor(() => expect(screen.queryByText('Danger alert:')).toBeInTheDocument());
   });
 });

--- a/src/components/ComponentRelation/__tests__/utils.spec.ts
+++ b/src/components/ComponentRelation/__tests__/utils.spec.ts
@@ -5,37 +5,6 @@ import {
   transformNudgeData,
 } from '../utils';
 
-describe('transformNudgeData', () => {
-  it('should transform data', () => {
-    expect(
-      transformNudgeData([
-        { source: 'abcd', nudgeType: ComponentRelationNudgeType.NUDGES, target: ['b', 'c'] },
-      ]),
-    ).toEqual({ abcd: ['b', 'c'] });
-    expect(
-      transformNudgeData([
-        { source: 'abcd', nudgeType: ComponentRelationNudgeType.NUDGES, target: ['b', 'c'] },
-        { source: 'abcd', nudgeType: ComponentRelationNudgeType.NUDGED_BY, target: ['b', 'c'] },
-      ]),
-    ).toEqual({ abcd: ['b', 'c'], b: ['abcd'], c: ['abcd'] });
-    expect(
-      transformNudgeData([
-        { source: 'abcd', nudgeType: ComponentRelationNudgeType.NUDGES, target: ['b', 'c'] },
-        { source: 'abcd', nudgeType: ComponentRelationNudgeType.NUDGED_BY, target: ['b', 'c'] },
-        { source: 'b', nudgeType: ComponentRelationNudgeType.NUDGED_BY, target: ['abcd', 'c'] },
-      ]),
-    ).toEqual({ abcd: ['b', 'c'], b: ['abcd'], c: ['abcd', 'b'] });
-    expect(
-      transformNudgeData([
-        { source: 'abcd', nudgeType: ComponentRelationNudgeType.NUDGES, target: ['b', 'c'] },
-        { source: 'abcd', nudgeType: ComponentRelationNudgeType.NUDGED_BY, target: ['b', 'c'] },
-        { source: 'b', nudgeType: ComponentRelationNudgeType.NUDGED_BY, target: ['abcd', 'c'] },
-        { source: 'c', nudgeType: ComponentRelationNudgeType.NUDGES, target: ['abcd', 'b'] },
-      ]),
-    ).toEqual({ abcd: ['b', 'c'], b: ['abcd'], c: ['abcd', 'b'] });
-  });
-});
-
 describe('computeNudgeDataChanges', () => {
   it('should compute data changes', () => {
     expect(

--- a/src/components/ComponentRelation/__tests__/utils.spec.ts
+++ b/src/components/ComponentRelation/__tests__/utils.spec.ts
@@ -1,5 +1,71 @@
 import { ComponentRelationNudgeType } from '../type';
-import { componentRelationValidationSchema, transformNudgeData } from '../utils';
+import {
+  componentRelationValidationSchema,
+  computeNudgeDataChanges,
+  transformNudgeData,
+} from '../utils';
+
+describe('transformNudgeData', () => {
+  it('should transform data', () => {
+    expect(
+      transformNudgeData([
+        { source: 'abcd', nudgeType: ComponentRelationNudgeType.NUDGES, target: ['b', 'c'] },
+      ]),
+    ).toEqual({ abcd: ['b', 'c'] });
+    expect(
+      transformNudgeData([
+        { source: 'abcd', nudgeType: ComponentRelationNudgeType.NUDGES, target: ['b', 'c'] },
+        { source: 'abcd', nudgeType: ComponentRelationNudgeType.NUDGED_BY, target: ['b', 'c'] },
+      ]),
+    ).toEqual({ abcd: ['b', 'c'], b: ['abcd'], c: ['abcd'] });
+    expect(
+      transformNudgeData([
+        { source: 'abcd', nudgeType: ComponentRelationNudgeType.NUDGES, target: ['b', 'c'] },
+        { source: 'abcd', nudgeType: ComponentRelationNudgeType.NUDGED_BY, target: ['b', 'c'] },
+        { source: 'b', nudgeType: ComponentRelationNudgeType.NUDGED_BY, target: ['abcd', 'c'] },
+      ]),
+    ).toEqual({ abcd: ['b', 'c'], b: ['abcd'], c: ['abcd', 'b'] });
+    expect(
+      transformNudgeData([
+        { source: 'abcd', nudgeType: ComponentRelationNudgeType.NUDGES, target: ['b', 'c'] },
+        { source: 'abcd', nudgeType: ComponentRelationNudgeType.NUDGED_BY, target: ['b', 'c'] },
+        { source: 'b', nudgeType: ComponentRelationNudgeType.NUDGED_BY, target: ['abcd', 'c'] },
+        { source: 'c', nudgeType: ComponentRelationNudgeType.NUDGES, target: ['abcd', 'b'] },
+      ]),
+    ).toEqual({ abcd: ['b', 'c'], b: ['abcd'], c: ['abcd', 'b'] });
+  });
+});
+
+describe('computeNudgeDataChanges', () => {
+  it('should compute data changes', () => {
+    expect(
+      computeNudgeDataChanges(
+        [{ source: 'a', nudgeType: ComponentRelationNudgeType.NUDGES, target: ['b', 'c'] }],
+        [],
+      ),
+    ).toEqual([{ source: 'a', nudgeType: ComponentRelationNudgeType.NUDGES, target: [] }]);
+    expect(
+      computeNudgeDataChanges(
+        [],
+        [{ source: 'a', nudgeType: ComponentRelationNudgeType.NUDGES, target: ['b', 'c'] }],
+      ),
+    ).toEqual([{ source: 'a', nudgeType: ComponentRelationNudgeType.NUDGES, target: ['b', 'c'] }]);
+    expect(
+      computeNudgeDataChanges(
+        [
+          { source: 'a', nudgeType: ComponentRelationNudgeType.NUDGES, target: ['b'] },
+          { source: 'b', nudgeType: ComponentRelationNudgeType.NUDGES, target: ['c'] },
+          { source: 'c', nudgeType: ComponentRelationNudgeType.NUDGES, target: ['d'] },
+        ],
+        [{ source: 'b', nudgeType: ComponentRelationNudgeType.NUDGES, target: ['c'] }],
+      ),
+    ).toEqual([
+      { source: 'b', nudgeType: ComponentRelationNudgeType.NUDGES, target: ['c'] },
+      { source: 'a', nudgeType: ComponentRelationNudgeType.NUDGES, target: [] },
+      { source: 'c', nudgeType: ComponentRelationNudgeType.NUDGES, target: [] },
+    ]);
+  });
+});
 
 describe('transformNudgeData', () => {
   it('should transform data', () => {

--- a/src/components/ComponentRelation/cr-modals.tsx
+++ b/src/components/ComponentRelation/cr-modals.tsx
@@ -85,7 +85,7 @@ export const DefineComponentRelationModal: React.FC<DefineComponentRelationModal
                         groupedComponents={groupedComponents}
                         index={index}
                         removeProps={{
-                          showRemove: values.relations.length > 1,
+                          disableRemove: values.relations.length <= 1,
                           onRemove: () => arrayHelpers.remove(index),
                         }}
                       />

--- a/src/components/ComponentRelation/cr-modals.tsx
+++ b/src/components/ComponentRelation/cr-modals.tsx
@@ -84,6 +84,10 @@ export const DefineComponentRelationModal: React.FC<DefineComponentRelationModal
                         componentNames={componentNames}
                         groupedComponents={groupedComponents}
                         index={index}
+                        removeProps={{
+                          showRemove: values.relations.length > 1,
+                          onRemove: () => arrayHelpers.remove(index),
+                        }}
                       />
                       {index !== values.relations.length - 1 ? <Divider /> : null}
                     </>


### PR DESCRIPTION
## Fixes 
Missing remove button on component relationship modal


## Description
Fixes [KFLUXBUGS-1197](https://issues.redhat.com//browse/KFLUXBUGS-1197)


## Type of change

- [x] Bugfix


## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x ] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
