### PR TITLE
fix(KFLUXBUGS-96): make the secret forms more clear

### DIFF
--- a/integration-tests/utils/Applications.ts
+++ b/integration-tests/utils/Applications.ts
@@ -164,7 +164,7 @@ export class Applications {
     }
     if (secret) {
       UIhelper.clickButton('Add secret');
-      cy.contains(applicationsPagePO.formGroup, 'Select or enter name').within(() => {
+      cy.contains(applicationsPagePO.formGroup, 'Select or enter secret name').within(() => {
         cy.get('input').clear().type(secret.secretName);
         cy.contains(
           'button',

--- a/src/components/Secrets/SecretForm.tsx
+++ b/src/components/Secrets/SecretForm.tsx
@@ -70,7 +70,7 @@ const SecretForm: React.FC<React.PropsWithChildren<SecretFormProps>> = ({ existi
         required
         key={values.type}
         name="secretName"
-        label="Select or enter name"
+        label="Select or enter secret name"
         helpText="Unique name of the new secret."
         isCreatable
         isInputValuePersisted

--- a/src/components/Secrets/SecretsForm/SecretTypeSubForm.tsx
+++ b/src/components/Secrets/SecretsForm/SecretTypeSubForm.tsx
@@ -112,11 +112,10 @@ export const SecretTypeSubForm: React.FC<React.PropsWithChildren<unknown>> = () 
       {isPartnerTaskAvailable(currentTypeRef.current) ? (
         <SelectInputField
           name="name"
-          label="Secret name"
-          toggleAriaLabel="Secret name"
+          label="Select or enter secret name"
+          toggleAriaLabel="Select or enter secret name"
           helpText="Unique name of the new secret"
           toggleId="secret-name-toggle"
-          placeholderText="Enter name"
           variant={SelectVariant.typeahead}
           options={options}
           isCreatable

--- a/src/components/Secrets/__tests___/AddSecretForm.spec.tsx
+++ b/src/components/Secrets/__tests___/AddSecretForm.spec.tsx
@@ -57,7 +57,7 @@ describe('AddSecretForm', () => {
 
     await waitFor(() => {
       screen.getByText('Secret type');
-      screen.getByText('Secret name');
+      screen.getByText('Select or enter secret name');
       screen.getByText('Labels');
     });
   });

--- a/src/components/Secrets/__tests___/SecretTypeSubForm.spec.tsx
+++ b/src/components/Secrets/__tests___/SecretTypeSubForm.spec.tsx
@@ -45,7 +45,7 @@ describe('SecretTypeSubForm', () => {
 
   it('should render Secret type sub form and fields', () => {
     expect(screen.getByText('Secret type')).toBeVisible();
-    expect(screen.getByText('Secret name')).toBeVisible();
+    expect(screen.getByText('Select or enter secret name')).toBeVisible();
   });
 
   it('should render subforms correctly for specified targets', async () => {
@@ -60,8 +60,8 @@ describe('SecretTypeSubForm', () => {
 
   it('should render correct variant of name field', async () => {
     await waitFor(async () => {
-      expect(screen.getByRole('button', { name: 'Secret name' })).toBeVisible();
-      await fireEvent.click(screen.getByRole('button', { name: 'Secret name' }));
+      expect(screen.getByRole('button', { name: 'Select or enter secret name' })).toBeVisible();
+      await fireEvent.click(screen.getByRole('button', { name: 'Select or enter secret name' }));
       expect(screen.getByText('snyk-secret')).toBeVisible();
     });
   });


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
[KFLUXBUGS-96](https://issues.redhat.com//browse/KFLUXBUGS-96)

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
The secret forms were not clear regarding the name of the secret variable. It was recommended to change to "Select or enter secret name" across multiple views.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [x] Edge


<!-- ## Checklist: -->

<!-- 
- [x] Code follows the style guidelines
- [x] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [x] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
