### PR TITLE
fix: use status.managedProcessing to get the pipelineRun for Release

### DIFF
--- a/src/components/Releases/ReleaseOverviewTab.tsx
+++ b/src/components/Releases/ReleaseOverviewTab.tsx
@@ -25,11 +25,16 @@ type ReleaseOverviewTabProps = {
   release: ReleaseKind;
 };
 
+const getPipelineRunFromRelease = (release: ReleaseKind): string => {
+  // backward compatibility until https://issues.redhat.com/browse/RELEASE-1109 is released.
+  return release.status?.processing?.pipelineRun ?? release.status?.managedProcessing?.pipelineRun;
+};
+
 const ReleaseOverviewTab: React.FC<React.PropsWithChildren<ReleaseOverviewTabProps>> = ({
   release,
 }) => {
   const { namespace, workspace } = useWorkspaceInfo();
-  const [pipelineRun, prWorkspace] = useWorkspaceResource(release.status?.processing?.pipelineRun);
+  const [pipelineRun, prWorkspace] = useWorkspaceResource(getPipelineRunFromRelease(release));
   const [releasePlan, releasePlanLoaded] = useK8sWatchResource<ReleasePlanKind>({
     name: release.spec.releasePlan,
     groupVersionKind: ReleasePlanGroupVersionKind,
@@ -121,12 +126,6 @@ const ReleaseOverviewTab: React.FC<React.PropsWithChildren<ReleaseOverviewTabPro
                 <DescriptionListTerm>Release Target</DescriptionListTerm>
                 <DescriptionListDescription>
                   <>{release.status?.target ?? '-'}</>
-                </DescriptionListDescription>
-              </DescriptionListGroup>
-              <DescriptionListGroup>
-                <DescriptionListTerm>Release Strategy</DescriptionListTerm>
-                <DescriptionListDescription>
-                  {release.status?.processing?.releaseStrategy?.split('/')[1] ?? '-'}
                 </DescriptionListDescription>
               </DescriptionListGroup>
               <DescriptionListGroup>

--- a/src/components/Releases/__data__/mock-release-data.ts
+++ b/src/components/Releases/__data__/mock-release-data.ts
@@ -63,3 +63,24 @@ export const mockReleases = [
     },
   },
 ];
+
+export const mockReleaseWithManagedProcessing = {
+  apiVersion: 'appstudio.redhat.com/v1alpha1',
+  kind: 'Release',
+  metadata: {
+    name: 'test-release-3',
+    creationTimestamp: '2023-01-01T10:30:00Z',
+  },
+  spec: {
+    releasePlan: 'test-plan-3',
+    snapshot: 'test-snapshot-3',
+  },
+  status: {
+    startTime: '2023-01-01T10:30:00Z',
+    completionTime: '2023-01-01T10:30:10Z',
+    target: 'test-target',
+    managedProcessing: {
+      pipelineRun: 'my-ns/test-pipelinerun',
+    },
+  },
+};

--- a/src/components/Releases/__tests__/ReleaseOverviewTab.spec.tsx
+++ b/src/components/Releases/__tests__/ReleaseOverviewTab.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
-import { mockReleases } from '../__data__/mock-release-data';
+import { mockReleases, mockReleaseWithManagedProcessing } from '../__data__/mock-release-data';
 import ReleaseOverviewTab from '../ReleaseOverviewTab';
 
 jest.mock('react-router-dom', () => ({
@@ -41,11 +41,15 @@ describe('ReleaseOverviewTab', () => {
     expect(screen.getByText('Release Target')).toBeVisible();
     expect(screen.getByText('test-target')).toBeVisible();
 
-    expect(screen.getByText('Release Strategy')).toBeVisible();
-    expect(screen.getByText('test-strategy')).toBeVisible();
-
     expect(screen.getByText('Pipeline Run')).toBeVisible();
-    expect(screen.getByText('test-strategy')).toBeVisible();
+    expect(screen.getByRole('link', { name: 'test-pipelinerun' }).getAttribute('href')).toBe(
+      '/application-pipeline/workspaces/target-ws/applications/test-app/pipelineruns/test-pipelinerun',
+    );
+  });
+
+  it('should render correct details if managedProcessing', () => {
+    render(<ReleaseOverviewTab release={mockReleaseWithManagedProcessing} />);
+    expect(screen.getByText('Pipeline Run')).toBeVisible();
     expect(screen.getByRole('link', { name: 'test-pipelinerun' }).getAttribute('href')).toBe(
       '/application-pipeline/workspaces/target-ws/applications/test-app/pipelineruns/test-pipelinerun',
     );

--- a/src/types/release.ts
+++ b/src/types/release.ts
@@ -15,6 +15,13 @@ export type ReleaseKind = K8sResourceCommon & {
     startTime?: string;
     completionTime?: string;
     automated?: boolean;
+    managedProcessing?: {
+      completionTime?: string;
+      pipelineRun?: string;
+      startTime?: string;
+      roleBinding?: string;
+    };
+    // keep this for backward compatibility
     processing?: {
       target?: string;
       pipelineRun?: string;


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/KFLUXBUGS-1683

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Release service updated the status of Releases as part of https://issues.redhat.com/browse/RELEASE-1109 `status.managedProcessing` should be used instead of `status.processing` to get the data for PipelineRun

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [X] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
