### PR TITLE
fix(pipeline): null check on status of taskrun

### DIFF
--- a/src/components/EnterpriseContractView/__tests__/useEnterpriseContractResultFromLogs.spec.tsx
+++ b/src/components/EnterpriseContractView/__tests__/useEnterpriseContractResultFromLogs.spec.tsx
@@ -64,6 +64,20 @@ describe('useEnterpriseContractResultFromLogs', () => {
     expect(result.current[0][0].warnings).toEqual(undefined);
   });
 
+  it('should call tknResults when taskRun is empty array', async () => {
+    mockUseTaskRuns.mockReturnValueOnce([[], true, undefined]);
+    mockGetTaskRunLogs.mockReturnValue(`asdfcdfadsf
+      [report-json] { "components": [] }
+      `);
+    const { result } = renderHook(() => useEnterpriseContractResultFromLogs('dummy-abcd'));
+    const [, loaded] = result.current;
+    expect(mockCommmonFetchJSON).toHaveBeenCalled();
+    expect(loaded).toBe(true);
+    expect(mockCommmonFetchJSON).toHaveBeenLastCalledWith(
+      '/api/v1/namespaces/test-ns/pods/pod-acdf/log?container=step-report-json&follow=true',
+    );
+  });
+
   it('should filter out all 404 image url components from EC results', async () => {
     const { result, waitForNextUpdate } = renderHook(() =>
       useEnterpriseContractResultFromLogs('dummy-abcd'),

--- a/src/components/EnterpriseContractView/useEnterpriseContractResultFromLogs.tsx
+++ b/src/components/EnterpriseContractView/useEnterpriseContractResultFromLogs.tsx
@@ -21,10 +21,7 @@ export const useEnterpriseContractResultFromLogs = (
   const [ecJson, setEcJson] = React.useState<EnterpriseContractResult>();
   const [ecLoaded, setEcLoaded] = React.useState<boolean>(false);
   const ecResultOpts = React.useMemo(() => {
-    const podName =
-      loaded && !error
-        ? Array.isArray(taskRun) && taskRun.length > 0 && taskRun[0].status?.podName
-        : null;
+    const podName = loaded && !error ? taskRun?.[0]?.status?.podName : null;
     return podName
       ? {
           ns: namespace,

--- a/src/components/EnterpriseContractView/useEnterpriseContractResultFromLogs.tsx
+++ b/src/components/EnterpriseContractView/useEnterpriseContractResultFromLogs.tsx
@@ -21,7 +21,10 @@ export const useEnterpriseContractResultFromLogs = (
   const [ecJson, setEcJson] = React.useState<EnterpriseContractResult>();
   const [ecLoaded, setEcLoaded] = React.useState<boolean>(false);
   const ecResultOpts = React.useMemo(() => {
-    const podName = loaded && !error ? taskRun[0].status.podName : null;
+    const podName =
+      loaded && !error
+        ? Array.isArray(taskRun) && taskRun.length > 0 && taskRun[0].status?.podName
+        : null;
     return podName
       ? {
           ns: namespace,
@@ -37,6 +40,9 @@ export const useEnterpriseContractResultFromLogs = (
 
   React.useEffect(() => {
     let unmount = false;
+    if (loaded && !ecResultOpts) {
+      setFetchTknLogs(true);
+    }
     if (ecResultOpts) {
       commonFetchJSON(getK8sResourceURL(PodModel, undefined, ecResultOpts))
         .then((res: EnterpriseContractResult) => {
@@ -58,7 +64,7 @@ export const useEnterpriseContractResultFromLogs = (
     return () => {
       unmount = true;
     };
-  }, [ecResultOpts]);
+  }, [ecResultOpts, loaded]);
 
   React.useEffect(() => {
     let unmount = false;


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/KFLUXBUGS-1710

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Adds null check for taskRun status and also adds block to fetch Tektonrecords if no taskrun is found

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

<img width="1789" alt="Screenshot 2024-10-09 at 6 54 18 PM" src="https://github.com/user-attachments/assets/e77f5ec3-6945-40c9-9801-3e3cec42efd6">
<img width="1792" alt="Screenshot 2024-10-09 at 6 54 45 PM" src="https://github.com/user-attachments/assets/3e095c81-d2a7-4663-bdf7-f13d38942a1b">

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
