### PR TITLE
fix(KFLUXBUGS-1719): support dot in the username format

### DIFF
--- a/src/components/UserAccess/UserAccessForm/UsernameSection.tsx
+++ b/src/components/UserAccess/UserAccessForm/UsernameSection.tsx
@@ -22,7 +22,7 @@ type Props = {
   disabled?: boolean;
 };
 
-const usernameRegex = /^[-_a-zA-Z0-9]{2,45}$/;
+const usernameRegex = /^[-_a-zA-Z0-9.]{2,45}$/;
 
 export const UsernameSection: React.FC<React.PropsWithChildren<Props>> = ({ disabled }) => {
   const [, { value: usernames, error }, { setValue, setError }] = useField<string[]>('usernames');

--- a/src/components/UserAccess/UserAccessForm/__tests__/UsernameSection.spec.tsx
+++ b/src/components/UserAccess/UserAccessForm/__tests__/UsernameSection.spec.tsx
@@ -91,7 +91,7 @@ describe('UsernameSection', () => {
     validateMock.mockResolvedValue(true);
     formikRenderer(<UsernameSection />, { usernames: [] });
     await act(async () => {
-      fireEvent.input(screen.getByRole('searchbox'), { target: { value: 'user-123' } });
+      fireEvent.input(screen.getByRole('searchbox'), { target: { value: 'user-12.3' } });
     });
     await waitFor(() => expect(screen.getByText('Validated')).toBeVisible());
 


### PR DESCRIPTION
## Fixes 
[KFLUXBUGS-1719](https://issues.redhat.com/browse/KFLUXBUGS-1719)


## Description
1. Change the username regex to ensure '.' is valid.
2. Improve the related test for the improved user format


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bugfix


## Screen shots / Gifs for design review 
![Screenshot 2024-10-11 at 09 35 24](https://github.com/user-attachments/assets/d25357eb-c545-4b9c-b3a8-97029bafd632)

## How to test or reproduce?
1. Click the 'User Access'
2. Click the 'Grant User'
3. Enter the username as 'anatale.openshift'

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge


<!-- ## Checklist: -->

<!-- 
- [x] Code follows the style guidelines
- [x] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ x] Changes generate no new warnings
- [x] Added tests that prove this fix is effective or that the feature works
- [x] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
