### PR TITLE
fix(HAC-5855): only suggest branches for component

### DIFF
--- a/src/components/ImportForm/ComponentSection/GitOptions.tsx
+++ b/src/components/ImportForm/ComponentSection/GitOptions.tsx
@@ -26,7 +26,7 @@ const GitOptions: React.FC<React.PropsWithChildren<GitOptionProps>> = ({
           <InputField
             name="source.git.revision"
             label="Git reference"
-            helperText="Optional branch, tag or commit."
+            helperText="Optional branch."
             data-testid="git-reference"
           />
 


### PR DESCRIPTION
## Fixes 
[HAC-5855](https://issues.redhat.com/browse/HAC-5855)


## Description
Using a tag or commit can have unintended consequences. Lets only recommend that users use a branch when setting up their components.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
**Before:**
![image](https://github.com/user-attachments/assets/9688a7ce-fd9c-4879-adfe-53f4517a8a33)

**After:**
![image](https://github.com/user-attachments/assets/cb886fde-b737-49ad-961a-41a794250cbb)

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
