### PR TITLE
fix(KFLUXBUGS-1680):  filter records on creationTimestamp

### DIFF
--- a/src/components/Activity/__tests__/ActivityTab.spec.tsx
+++ b/src/components/Activity/__tests__/ActivityTab.spec.tsx
@@ -18,6 +18,10 @@ jest.mock('react-router-dom', () => {
   };
 });
 
+jest.mock('../../../hooks/useApplications', () => ({
+  useApplication: jest.fn().mockReturnValue([{ metadata: { name: 'test' } }, true]),
+}));
+
 jest.mock('../../../utils/workspace-context-utils', () => ({
   useWorkspaceInfo: jest.fn(() => ({ namespace: 'test-ns', workspace: 'test-ws' })),
 }));

--- a/src/components/Commits/__tests__/CommitsListView.spec.tsx
+++ b/src/components/Commits/__tests__/CommitsListView.spec.tsx
@@ -36,6 +36,10 @@ jest.mock('../commit-status', () => ({
   useCommitStatus: () => ['-', true],
 }));
 
+jest.mock('../../../hooks/useApplications', () => ({
+  useApplication: jest.fn().mockReturnValue([{ metadata: { name: 'test' } }, true]),
+}));
+
 jest.mock('../../../shared/components/table/TableComponent', () => {
   return (props) => {
     const { data, filters, selected, match, kindObj } = props;

--- a/src/components/Components/ComponentDetails/__tests__/ComponentActivityTab.spec.tsx
+++ b/src/components/Components/ComponentDetails/__tests__/ComponentActivityTab.spec.tsx
@@ -34,6 +34,10 @@ jest.mock('../../../../hooks/useComponents', () => ({
   useComponents: jest.fn(),
 }));
 
+jest.mock('../../../../hooks/useApplications', () => ({
+  useApplication: jest.fn().mockReturnValue([{ metadata: { name: 'test' } }, true]),
+}));
+
 const watchResourceMock = useK8sWatchResource as jest.Mock;
 const useComponentsMock = useComponents as jest.Mock;
 const useNavigateMock = useNavigate as jest.Mock;

--- a/src/components/Components/__tests__/ComponentListView.spec.tsx
+++ b/src/components/Components/__tests__/ComponentListView.spec.tsx
@@ -34,6 +34,10 @@ jest.mock('../../../utils/rbac', () => ({
   useAccessReviewForModel: jest.fn(() => [true, true]),
 }));
 
+jest.mock('../../../hooks/useApplications', () => ({
+  useApplication: jest.fn().mockReturnValue([{ metadata: { name: 'test' } }, true]),
+}));
+
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');
   return {

--- a/src/components/PipelineRunDetailsView/__tests__/PipelineRunDetailsView.spec.tsx
+++ b/src/components/PipelineRunDetailsView/__tests__/PipelineRunDetailsView.spec.tsx
@@ -24,6 +24,10 @@ jest.mock('../../../utils/workspace-context-utils', () => ({
   useWorkspaceInfo: jest.fn(() => ({ namespace: 'test-ns', workspace: 'test-ws' })),
 }));
 
+jest.mock('../../../hooks/useApplications', () => ({
+  useApplication: jest.fn().mockReturnValue([{ metadata: { name: 'test' } }, true]),
+}));
+
 jest.mock('../../PipelineRunDetailsView/PipelineRunVisualization', () => () => <div />);
 
 jest.mock('../../../utils/component-utils', () => {

--- a/src/components/PipelineRunDetailsView/tabs/__tests__/PipelineRunDetailsTab.spec.tsx
+++ b/src/components/PipelineRunDetailsView/tabs/__tests__/PipelineRunDetailsTab.spec.tsx
@@ -29,6 +29,10 @@ jest.mock('../../../../hooks/useUIInstance', () => {
   };
 });
 
+jest.mock('../../../../hooks/useApplications', () => ({
+  useApplication: jest.fn().mockReturnValue([{ metadata: { name: 'test' } }, true]),
+}));
+
 jest.mock('../../../topology/factories/VisualizationFactory', () => () => <div />);
 
 configure({ testIdAttribute: 'data-test' });

--- a/src/components/PipelineRunListView/__tests__/PipelineRunListView.spec.tsx
+++ b/src/components/PipelineRunListView/__tests__/PipelineRunListView.spec.tsx
@@ -20,6 +20,10 @@ jest.mock('../../../hooks/usePipelineRuns', () => ({
   usePipelineRuns: jest.fn(),
 }));
 
+jest.mock('../../../hooks/useApplications', () => ({
+  useApplication: jest.fn().mockReturnValue([{ metadata: { name: 'test' } }, true]),
+}));
+
 jest.mock('../../../utils/workspace-context-utils', () => ({
   useWorkspaceInfo: jest.fn(() => ({ namespace: 'test-ns', workspace: 'test-ws' })),
 }));

--- a/src/hooks/__tests__/useBuildPipelines.spec.ts
+++ b/src/hooks/__tests__/useBuildPipelines.spec.ts
@@ -6,6 +6,10 @@ import { useTRPipelineRuns } from '../useTektonResults';
 
 jest.mock('../useTektonResults');
 
+jest.mock('../useApplications', () => ({
+  useApplication: jest.fn().mockReturnValue([{ metadata: { name: 'test' } }, true]),
+}));
+
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   useK8sWatchResource: jest.fn(() => [[], true]),
   getActiveWorkspace: jest.fn(),

--- a/src/hooks/__tests__/useLatestBuildPipelines.spec.ts
+++ b/src/hooks/__tests__/useLatestBuildPipelines.spec.ts
@@ -11,6 +11,10 @@ jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   getActiveWorkspace: jest.fn(),
 }));
 
+jest.mock('../../hooks/useApplications', () => ({
+  useApplication: jest.fn().mockReturnValue([{ metadata: { name: 'test' } }, true]),
+}));
+
 const useK8sWatchResourceMock = useK8sWatchResource as jest.Mock;
 const useTRPipelineRunsMock = useTRPipelineRuns as jest.Mock;
 

--- a/src/hooks/__tests__/usePACStatesForComponents.spec.ts
+++ b/src/hooks/__tests__/usePACStatesForComponents.spec.ts
@@ -21,6 +21,10 @@ jest.mock('../../hooks/useApplicationPipelineGitHubApp', () => ({
   })),
 }));
 
+jest.mock('../../hooks/useApplications', () => ({
+  useApplication: jest.fn().mockReturnValue([{ metadata: { name: 'test' } }, true]),
+}));
+
 jest.mock('@openshift/dynamic-plugin-sdk-utils', () => ({
   useK8sWatchResource: jest.fn(() => [[], true]),
   getActiveWorkspace: jest.fn(),

--- a/src/hooks/__tests__/usePipelineRuns.spec.ts
+++ b/src/hooks/__tests__/usePipelineRuns.spec.ts
@@ -19,6 +19,10 @@ jest.mock('@openshift/dynamic-plugin-sdk-utils');
 jest.mock('../useTektonResults');
 jest.mock('../useComponents');
 
+jest.mock('../useApplications', () => ({
+  useApplication: jest.fn().mockReturnValue([{ metadata: { name: 'test' } }, true]),
+}));
+
 jest.mock('../../utils/workspace-context-utils', () => ({
   useWorkspaceInfo: jest.fn(() => ({ namespace: 'test-ns', workspace: 'test-ws' })),
 }));

--- a/src/hooks/useLatestBuildPipelines.ts
+++ b/src/hooks/useLatestBuildPipelines.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { PipelineRunLabel, PipelineRunType } from '../consts/pipelinerun';
 import { PipelineRunKind } from '../types';
+import { useApplication } from './useApplications';
 import { usePipelineRuns } from './usePipelineRuns';
 
 export const useLatestBuildPipelines = (
@@ -10,6 +11,7 @@ export const useLatestBuildPipelines = (
 ): [PipelineRunKind[], boolean, unknown] => {
   const [foundNames, setFoundNames] = React.useState<string[]>([]);
   const [latestBuilds, setLatestBuilds] = React.useState<PipelineRunKind[]>([]);
+  const [application, applicationLoaded] = useApplication(namespace, applicationName);
 
   React.useEffect(() => {
     setFoundNames([]);
@@ -21,24 +23,18 @@ export const useLatestBuildPipelines = (
   );
 
   const [pipelines, loaded, error, getNextPage] = usePipelineRuns(
-    neededNames?.length ? namespace : null,
+    applicationLoaded && neededNames?.length ? namespace : null,
     React.useMemo(
       () => ({
         selector: {
+          filterByCreationTimestampAfter: application?.metadata?.creationTimestamp,
           matchLabels: {
             [PipelineRunLabel.APPLICATION]: applicationName,
             [PipelineRunLabel.PIPELINE_TYPE]: PipelineRunType.BUILD,
           },
-          matchExpressions: [
-            {
-              key: PipelineRunLabel.COMPONENT,
-              operator: 'In',
-              values: neededNames,
-            },
-          ],
         },
       }),
-      [applicationName, neededNames],
+      [applicationName, application],
     ),
   );
 

--- a/src/hooks/useLatestIntegrationTestPipelines.ts
+++ b/src/hooks/useLatestIntegrationTestPipelines.ts
@@ -39,11 +39,6 @@ export const useLatestIntegrationTestPipelines = (
           },
           matchExpressions: [
             {
-              key: PipelineRunLabel.COMPONENT,
-              operator: 'In',
-              values: componentNames,
-            },
-            {
               key: PipelineRunLabel.TEST_SERVICE_SCENARIO,
               operator: 'In',
               values: neededNames,
@@ -51,7 +46,7 @@ export const useLatestIntegrationTestPipelines = (
           ],
         },
       }),
-      [applicationName, componentNames, neededNames],
+      [applicationName, neededNames],
     ),
   );
 

--- a/src/utils/__tests__/tekton-results.spec.ts
+++ b/src/utils/__tests__/tekton-results.spec.ts
@@ -183,7 +183,21 @@ describe('tekton-results', () => {
           selectorToFilter({
             filterByName: 'resource-name',
           }),
-        ).toStrictEqual('data.metadata.labels["filterByName"] == "resource-name"');
+        ).toStrictEqual('data.metadata.name.startsWith("resource-name")');
+      });
+
+      it('should return creationTimestamp filter', () => {
+        expect(
+          selectorToFilter({
+            filterByCreationTimestampAfter: '2021-01-01T00:00:00Z',
+          }),
+        ).toStrictEqual('data.metadata.creationTimestamp > "2021-01-01T00:00:00Z"');
+
+        expect(
+          selectorToFilter({
+            filterByCreationTimestampAfter: 'not a timestamp',
+          }),
+        ).toStrictEqual('');
       });
 
       it('should return the label filter', () => {

--- a/src/utils/tekton-results.ts
+++ b/src/utils/tekton-results.ts
@@ -98,6 +98,12 @@ export const commitShaFilter = (commitSha: string): string =>
     EQ(`data.metadata.annotations["${PipelineRunLabel.COMMIT_ANNOTATION}"]`, commitSha),
   );
 
+export const creationTimestampFilterAfter = (creationTimestamp: string): string => {
+  return Date.parse(creationTimestamp)
+    ? EXP(`data.metadata.creationTimestamp`, `"${creationTimestamp}"`, '>')
+    : '';
+};
+
 export const expressionsToFilter = (expressions: Omit<MatchExpression, 'value'>[]): string =>
   AND(
     ...expressions
@@ -150,7 +156,17 @@ export const expressionsToFilter = (expressions: Omit<MatchExpression, 'value'>[
 export const selectorToFilter = (selector?: Selector) => {
   let filter = '';
   if (selector) {
-    const { matchLabels, matchExpressions, filterByName, filterByCommit } = selector;
+    const {
+      matchLabels,
+      matchExpressions,
+      filterByName,
+      filterByCommit,
+      filterByCreationTimestampAfter,
+    } = selector;
+
+    if (filterByCreationTimestampAfter) {
+      filter = AND(filter, creationTimestampFilterAfter(filterByCreationTimestampAfter as string));
+    }
 
     if (filterByName) {
       filter = AND(filter, nameFilter(filterByName as string));
@@ -167,8 +183,6 @@ export const selectorToFilter = (selector?: Selector) => {
       if (matchExpressions) {
         filter = AND(filter, expressionsToFilter(matchExpressions));
       }
-    } else {
-      filter = labelsToFilter(selector as MatchLabels);
     }
   }
   return filter;


### PR DESCRIPTION
## Fixes 
[KFLUXBUGS-1680](https://issues.redhat.com//browse/KFLUXBUGS-1680)


## Description
Querying pipelineruns or records may include all component names making the query to long and throws an HTTP error 414 or 431. Component names were included in the filter to avoid a visual issue when recreating an application with the same name, previously ran pipelineruns are displayed.

The component filter array is removed and uses the record creationTimestamp filter to be greater than the application creationTimestamp.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [X] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
Create a large number of components with large names.

[ ] Test A 
Initial issue:
When the query is too long, we should hit an http error 414 or as I do, a 431 locally.

 [ ] Test B 
Once change applied,  the filter includes a creationTimestamp attribute and removed the component matchExpression filter.

**Test Configuration(s)**:
I have an application with 240 components, named `devfile-sample-other-very-long-meaningless-name-${n}`

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
