### PR TITLE
fix(KFLUXBUGS-1648): display parameter name for IntegrationTests

### DIFF
--- a/src/components/IntegrationTest/FormikParamsField.tsx
+++ b/src/components/IntegrationTest/FormikParamsField.tsx
@@ -121,7 +121,7 @@ const IntegrationTestParams: React.FC<React.PropsWithChildren<IntegrationTestPar
                               <DataListItemCells
                                 dataListCells={[
                                   <DataListCell key="param-title" width={5}>
-                                    <TextContent>{`Parameter${i + 1}`}</TextContent>
+                                    <TextContent>{p.name}</TextContent>
                                   </DataListCell>,
 
                                   <DataListCell key="remove-param-button" width={3}>


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/KFLUXBUGS-1648


## Description
In the IntegrationTests edit parameter modal, only a generic `Parameter[i]` name was displayed, which made it difficult to find the right parameter. Instead, now the parameter name is displayed in the header. Same thing applies to the parameters when editing the whole integration test or creating a new release plan in the current workspace, which allows users to specify parameters.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [X] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
Before:
![KFLUXBUGS-1648_old](https://github.com/user-attachments/assets/d73f1789-6b26-41db-aafc-a846bb3b012d)
![KFLUXBUGS-1648_old-extended](https://github.com/user-attachments/assets/734148bf-e656-42ce-afd1-4ee33d4ebb6c)

After:
![KFLUXBUGS-1648_new](https://github.com/user-attachments/assets/26dc18b7-cb87-4d63-a465-0685d05e7a17)
![KFLUXBUGS-1648_new-extended](https://github.com/user-attachments/assets/070e7520-dc18-477d-9017-0118600174ce)


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [X] Chrome
- [X] Firefox
- [ ] Safari
- [ ] Edge

