### PR TITLE
feat(KFLUXBUGS-1651): add contexts to show page

### DIFF
--- a/src/components/IntegrationTest/ContextSelectList.tsx
+++ b/src/components/IntegrationTest/ContextSelectList.tsx
@@ -1,0 +1,90 @@
+import React, { useState, useCallback } from 'react';
+import {
+  Select,
+  SelectOption,
+  SelectList,
+  MenuToggle,
+  MenuToggleElement,
+  ChipGroup,
+  Chip,
+} from '@patternfly/react-core';
+import { ContextOption } from './ContextsField';
+
+type ContextSelectListProps = {
+  selectedContexts: ContextOption[];
+  onSelect: (
+    _event: React.MouseEvent<Element, MouseEvent> | undefined,
+    contextName: string,
+  ) => void;
+  editing: boolean;
+};
+
+export const ContextSelectList: React.FC<ContextSelectListProps> = ({
+  selectedContexts,
+  onSelect,
+  editing,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const onToggleClick = useCallback(() => {
+    setIsOpen((prevIsOpen) => !prevIsOpen);
+  }, []);
+
+  const selectedContextChips = selectedContexts.filter((ctx) => ctx.selected);
+
+  const renderToggle = useCallback(
+    (toggleRef: React.Ref<MenuToggleElement>) => (
+      <MenuToggle
+        ref={toggleRef}
+        onClick={onToggleClick}
+        isExpanded={isOpen}
+        style={{ minWidth: '750px' } as React.CSSProperties}
+        data-testid="context-dropdown-toggle"
+      >
+        {selectedContextChips.length > 0 ? (
+          <ChipGroup>
+            {selectedContextChips.map((ctx) => (
+              <Chip
+                key={ctx.name}
+                onClick={(_event) => onSelect(_event, ctx.name)}
+                data-testid={`context-chip-${ctx.name}`}
+              >
+                {ctx.name}
+              </Chip>
+            ))}
+          </ChipGroup>
+        ) : (
+          'Select Contexts'
+        )}
+      </MenuToggle>
+    ),
+    [isOpen, onToggleClick, onSelect, selectedContextChips],
+  );
+
+  return (
+    <Select
+      role="menu"
+      id="context-select"
+      isOpen={isOpen}
+      onSelect={(_event, value) => onSelect(_event, value as string)}
+      onOpenChange={setIsOpen}
+      toggle={renderToggle}
+      style={{ maxWidth: '750px' }}
+    >
+      <SelectList>
+        {selectedContexts.map((ctx) => (
+          <SelectOption
+            key={ctx.name}
+            value={ctx.name}
+            isSelected={ctx.selected}
+            description={ctx.description}
+            isDisabled={!editing && ctx.name === 'application'}
+            data-testid={`context-option-${ctx.name}`}
+          >
+            {ctx.name}
+          </SelectOption>
+        ))}
+      </SelectList>
+    </Select>
+  );
+};

--- a/src/components/IntegrationTest/ContextsField.tsx
+++ b/src/components/IntegrationTest/ContextsField.tsx
@@ -1,0 +1,173 @@
+import * as React from 'react';
+import { useParams } from 'react-router-dom';
+import { FormGroup } from '@patternfly/react-core';
+import { FieldArray, useField, FieldArrayRenderProps } from 'formik';
+import { getFieldId } from '../../../src/shared/components/formik-fields/field-utils';
+import { useComponents } from '../../hooks/useComponents';
+import { ComponentKind } from '../../types';
+import { useWorkspaceInfo } from '../../utils/workspace-context-utils';
+import { ContextSelectList } from './ContextSelectList';
+
+export interface ContextOption {
+  name: string;
+  description: string;
+  selected: boolean;
+}
+
+// Base context options list.
+export const contextOptions: ContextOption[] = [
+  {
+    name: 'application',
+    description: 'execute the integration test in all cases - this would be the default state',
+    selected: false,
+  },
+  {
+    name: 'group',
+    description: 'execute the integration test for a Snapshot of the `group` type',
+    selected: false,
+  },
+  {
+    name: 'override',
+    description: 'execute the integration test for a Snapshot of the `override` type',
+    selected: false,
+  },
+  {
+    name: 'component',
+    description: 'execute the integration test for a Snapshot of the `component` type',
+    selected: false,
+  },
+  {
+    name: 'pull_request',
+    description: 'execute the integration test for a Snapshot created for a `pull request` event',
+    selected: false,
+  },
+  {
+    name: 'push',
+    description: 'execute the integration test for a Snapshot created for a `push` event',
+    selected: false,
+  },
+];
+
+/**
+ * Maps over the provided context options and assigns a `selected` property to each context
+ * based on whether its `name` is present in the array of selected context names.
+ *
+ * @param {string[]} selectedContextNames - Array of context names that should be marked as selected.
+ * @param {ContextOption[]} contextSelectOptions - Array of context objects that include details such as name and description.
+ * @returns {ContextOption[]} - An array of context objects where each context has an additional `selected` field indicating if it's selected.
+ */
+export const mapContextsWithSelection = (
+  selectedContextNames: string[],
+  contextSelectOptions: ContextOption[],
+): ContextOption[] => {
+  return contextSelectOptions.map((ctx) => {
+    return { ...ctx, selected: selectedContextNames.some((name) => name === ctx.name) };
+  });
+};
+
+/**
+ * Combines existing selected contexts with new component-based contexts.
+ *
+ * This function creates new context options for each component, including a description and
+ * a `selected` flag based on whether the component is present in the selected context names.
+ * It then merges these component contexts with the provided base selected contexts.
+ *
+ * @param {ContextOption[]} baseSelectedContexts - Array of already selected context objects to be combined with new component contexts.
+ * @param {string[]} selectedContextNames - Array of names that represent the currently selected contexts, including component contexts.
+ * @param {ComponentKind[]} components - Array of components from which new context options will be created.
+ *
+ * @returns {ContextOption[]} - An array combining the base selected contexts and the newly generated component contexts, each having a `selected` field.
+ */
+export const addComponentContexts = (
+  baseSelectedContexts: ContextOption[],
+  selectedContextNames: string[],
+  components: ComponentKind[],
+) => {
+  const selectedContextNameSet = new Set(selectedContextNames); // Faster lookups
+  const componentContexts = components.map((component) => {
+    const componentName = component.metadata.name;
+    return {
+      // if a component context has been previously selected, it should be prefixed with 'component_'
+      // after it's been selected and saved.
+      name: `component_${componentName}`,
+      description: `execute the integration test when component ${componentName} updates`,
+      selected: selectedContextNameSet.has(`component_${componentName}`), // Check if it's selected
+    };
+  });
+
+  return [...baseSelectedContexts, ...componentContexts];
+};
+
+interface IntegrationTestContextProps {
+  heading?: React.ReactNode;
+  fieldName: string;
+  editing: boolean;
+}
+
+const ContextsField: React.FC<IntegrationTestContextProps> = ({ heading, fieldName, editing }) => {
+  const { namespace } = useWorkspaceInfo();
+  const { appName } = useParams();
+  const [components, componentsLoaded] = useComponents(namespace, appName);
+  const [, { value: contexts }] = useField(fieldName);
+  const fieldId = getFieldId(fieldName, 'dropdown');
+  const selectedContextNames = (contexts ?? []).map((c: ContextOption) => c.name);
+  const selectedContexts = React.useMemo(() => {
+    let initialSelectedContexts = mapContextsWithSelection(selectedContextNames, contextOptions);
+    // If this is a new integration test, ensure that 'application' is selected by default
+    if (!editing && !selectedContextNames.includes('application')) {
+      initialSelectedContexts = initialSelectedContexts.map((ctx) => {
+        return ctx.name === 'application' ? { ...ctx, selected: true } : ctx;
+      });
+    }
+
+    // If we have components and they are loaded, add to context option list.
+    // Else, return the base context list.
+    return componentsLoaded && components
+      ? addComponentContexts(initialSelectedContexts, selectedContextNames, components)
+      : initialSelectedContexts;
+  }, [componentsLoaded, components, selectedContextNames, editing]);
+
+  /**
+   * React callback that is used to select or deselect a context option using Formik FieldArray array helpers.
+   * If the context exists and it's been selected, remove from array.
+   * Else push to the Formik FieldArray array.
+   */
+  const handleSelect = React.useCallback(
+    (arrayHelpers: FieldArrayRenderProps, contextName: string) => {
+      const currentContext: ContextOption = selectedContexts.find(
+        (ctx: ContextOption) => ctx.name === contextName,
+      );
+      const isSelected = currentContext && currentContext.selected;
+      const index = contexts.findIndex((c: ContextOption) => c.name === contextName);
+
+      if (isSelected && index !== -1) {
+        arrayHelpers.remove(index); // Deselect
+      } else if (!isSelected) {
+        // Select, add necessary data
+        arrayHelpers.push({ name: contextName, description: currentContext.description });
+      }
+    },
+    [contexts, selectedContexts],
+  );
+
+  return (
+    <FormGroup fieldId={fieldId} label={heading ?? 'Contexts'}>
+      {componentsLoaded && components ? (
+        <FieldArray
+          name={fieldName}
+          render={(arrayHelpers) => (
+            <ContextSelectList
+              selectedContexts={selectedContexts}
+              onSelect={(_event, contextName: string) => handleSelect(arrayHelpers, contextName)}
+              editing={editing}
+            />
+          )}
+        />
+      ) : (
+        'Loading Additional Component Context options'
+      )}
+    </FormGroup>
+  );
+};
+
+export default ContextsField;

--- a/src/components/IntegrationTest/EditContextsModal.tsx
+++ b/src/components/IntegrationTest/EditContextsModal.tsx
@@ -1,0 +1,110 @@
+import * as React from 'react';
+import { k8sPatchResource } from '@openshift/dynamic-plugin-sdk-utils';
+import {
+  Alert,
+  AlertVariant,
+  Button,
+  ButtonType,
+  ButtonVariant,
+  Form,
+  ModalVariant,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { Formik, FormikValues } from 'formik';
+import { IntegrationTestScenarioModel } from '../../models';
+import { IntegrationTestScenarioKind, Context } from '../../types/coreBuildService';
+import { ComponentProps, createModalLauncher } from '../modal/createModalLauncher';
+import ContextsField from './ContextsField';
+import { formatContexts } from './IntegrationTestForm/utils/create-utils';
+
+type EditContextsModalProps = ComponentProps & {
+  intTest: IntegrationTestScenarioKind;
+};
+
+export const EditContextsModal: React.FC<React.PropsWithChildren<EditContextsModalProps>> = ({
+  intTest,
+  onClose,
+}) => {
+  const [error, setError] = React.useState<string>();
+
+  const getFormContextValues = (contexts: Context[] = []) => {
+    return contexts.map(({ name, description }) => ({ name, description }));
+  };
+
+  const updateIntegrationTest = async (values: FormikValues) => {
+    try {
+      await k8sPatchResource({
+        model: IntegrationTestScenarioModel,
+        queryOptions: {
+          name: intTest.metadata.name,
+          ns: intTest.metadata.namespace,
+        },
+        patches: [
+          { op: 'replace', path: '/spec/contexts', value: formatContexts(values.contexts) },
+        ],
+      });
+      onClose(null, { submitClicked: true });
+    } catch (e) {
+      setError(e.message || e.toString());
+    }
+  };
+
+  const onReset = () => {
+    onClose(null, { submitClicked: false });
+  };
+
+  const initialContexts = getFormContextValues(intTest?.spec?.contexts);
+
+  return (
+    <Formik
+      onSubmit={updateIntegrationTest}
+      initialValues={{ contexts: initialContexts, confirm: false }}
+      onReset={onReset}
+    >
+      {({ handleSubmit, handleReset, isSubmitting, values }) => {
+        const isChanged = values.contexts !== initialContexts;
+        const showConfirmation = isChanged && values.strategy === 'Automatic';
+        const isValid = isChanged && (showConfirmation ? values.confirm : true);
+
+        return (
+          <Form data-test="edit-contexts-modal">
+            <Stack hasGutter>
+              <StackItem>
+                <ContextsField fieldName="contexts" editing={true} />
+              </StackItem>
+              <StackItem>
+                {error && (
+                  <Alert isInline variant={AlertVariant.danger} title="An error occurred">
+                    {error}
+                  </Alert>
+                )}
+                <Button
+                  type={ButtonType.submit}
+                  isLoading={isSubmitting}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    handleSubmit();
+                  }}
+                  isDisabled={!isValid || isSubmitting}
+                  data-testid="update-resource"
+                >
+                  Save
+                </Button>
+                <Button variant={ButtonVariant.link} onClick={handleReset}>
+                  Cancel
+                </Button>
+              </StackItem>
+            </Stack>
+          </Form>
+        );
+      }}
+    </Formik>
+  );
+};
+
+export const createEditContextsModal = createModalLauncher(EditContextsModal, {
+  'data-testid': `edit-its-contexts`,
+  variant: ModalVariant.medium,
+  title: `Edit contexts`,
+});

--- a/src/components/IntegrationTest/IntegrationTestForm/IntegrationTestSection.tsx
+++ b/src/components/IntegrationTest/IntegrationTestForm/IntegrationTestSection.tsx
@@ -9,6 +9,7 @@ import {
 import { useField } from 'formik';
 import { CheckboxField, InputField } from '../../../shared';
 import { RESOURCE_NAME_REGEX_MSG } from '../../../utils/validation-utils';
+import ContextsField from '../ContextsField';
 import FormikParamsField from '../FormikParamsField';
 import './IntegrationTestSection.scss';
 
@@ -69,6 +70,7 @@ const IntegrationTestSection: React.FC<React.PropsWithChildren<Props>> = ({ isIn
           data-test="git-path-repo"
           required
         />
+        <ContextsField fieldName="integrationTest.contexts" editing={edit} />
         <FormikParamsField fieldName="integrationTest.params" />
 
         <CheckboxField

--- a/src/components/IntegrationTest/IntegrationTestForm/IntegrationTestView.tsx
+++ b/src/components/IntegrationTest/IntegrationTestForm/IntegrationTestView.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Formik } from 'formik';
-import { IntegrationTestScenarioKind } from '../../../types/coreBuildService';
+import { IntegrationTestScenarioKind, Context } from '../../../types/coreBuildService';
 import { useTrackEvent, TrackEvents } from '../../../utils/analytics';
 import { useWorkspaceInfo } from '../../../utils/workspace-context-utils';
 import IntegrationTestForm from './IntegrationTestForm';
@@ -52,6 +52,19 @@ const IntegrationTestView: React.FunctionComponent<
     return formParams;
   };
 
+  interface FormContext {
+    name: string;
+    description: string;
+  }
+
+  const getFormContextValues = (contexts: Context[] | null | undefined): FormContext[] => {
+    if (!contexts?.length) return [];
+
+    return contexts.map((context) => {
+      return context.name ? { name: context.name, description: context.description } : context;
+    });
+  };
+
   const initialValues = {
     integrationTest: {
       name: integrationTest?.metadata.name ?? '',
@@ -59,6 +72,7 @@ const IntegrationTestView: React.FunctionComponent<
       revision: revision?.value ?? '',
       path: path?.value ?? '',
       params: getFormParamValues(integrationTest?.spec?.params),
+      contexts: getFormContextValues(integrationTest?.spec?.contexts),
       optional:
         integrationTest?.metadata.labels?.[IntegrationTestLabels.OPTIONAL] === 'true' ?? false,
     },

--- a/src/components/IntegrationTest/IntegrationTestForm/__tests__/IntegrationTestSection.spec.tsx
+++ b/src/components/IntegrationTest/IntegrationTestForm/__tests__/IntegrationTestSection.spec.tsx
@@ -9,6 +9,10 @@ const navigateMock = jest.fn();
 jest.mock('react-router-dom', () => ({
   Link: (props) => <a href={props.to}>{props.children}</a>,
   useNavigate: () => navigateMock,
+  // Used in ContextsField
+  useParams: jest.fn(() => ({
+    appName: 'test-app',
+  })),
 }));
 
 jest.mock('react-i18next', () => ({

--- a/src/components/IntegrationTest/IntegrationTestForm/__tests__/IntegrationTestView.spec.tsx
+++ b/src/components/IntegrationTest/IntegrationTestForm/__tests__/IntegrationTestView.spec.tsx
@@ -2,7 +2,9 @@ import * as React from 'react';
 import { useK8sWatchResource } from '@openshift/dynamic-plugin-sdk-utils';
 import { configure, fireEvent, render, RenderResult, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { MockComponents } from '../../../../components/Commits/CommitDetails/visualization/__data__/MockCommitWorkflowData';
 import { useApplications } from '../../../../hooks/useApplications';
+import { useComponents } from '../../../../hooks/useComponents';
 import { useReleasePlans } from '../../../../hooks/useReleasePlans';
 import { namespaceRenderer } from '../../../../utils/test-utils';
 import { WorkspaceContext } from '../../../../utils/workspace-context-utils';
@@ -47,6 +49,11 @@ jest.mock('../../../../hooks/useApplications', () => ({
   useApplications: jest.fn(),
 }));
 
+jest.mock('../../../../hooks/useComponents', () => ({
+  // Used in ContextsField
+  useComponents: jest.fn(),
+}));
+
 jest.mock('../../../../utils/workspace-context-utils', () => {
   const actual = jest.requireActual('../../../../utils/workspace-context-utils');
   return {
@@ -61,6 +68,7 @@ jest.mock('../../../../utils/rbac', () => ({
 
 const createIntegrationTestMock = createIntegrationTest as jest.Mock;
 const useReleasePlansMock = useReleasePlans as jest.Mock;
+const mockUseComponents = useComponents as jest.Mock;
 
 configure({ testIdAttribute: 'data-test' });
 
@@ -103,6 +111,7 @@ describe('IntegrationTestView', () => {
     useApplicationsMock.mockReturnValue([[mockApplication], true]);
     watchResourceMock.mockReturnValueOnce([[], true]);
     useReleasePlansMock.mockReturnValue([[], true]);
+    mockUseComponents.mockReturnValue([MockComponents, true]);
   });
   const fillIntegrationTestForm = (wrapper: RenderResult) => {
     fireEvent.input(wrapper.getByLabelText(/Integration test name/), {

--- a/src/components/IntegrationTest/IntegrationTestForm/types.ts
+++ b/src/components/IntegrationTest/IntegrationTestForm/types.ts
@@ -1,5 +1,5 @@
 import { K8sResourceCommon } from '@openshift/dynamic-plugin-sdk-utils';
-import { Param } from '../../../types/coreBuildService';
+import { Param, Context } from '../../../types/coreBuildService';
 
 export type IntegrationTestFormValues = {
   name: string;
@@ -11,6 +11,7 @@ export type IntegrationTestFormValues = {
   environmentName?: string;
   environmentType?: string;
   params?: Param[];
+  contexts?: Context[];
 };
 
 export enum IntegrationTestAnnotations {

--- a/src/components/IntegrationTest/IntegrationTestForm/utils/__tests__/create-utils.spec.ts
+++ b/src/components/IntegrationTest/IntegrationTestForm/utils/__tests__/create-utils.spec.ts
@@ -42,8 +42,8 @@ const integrationTestData = {
     },
     contexts: [
       {
-        description: 'Application testing',
         name: 'application',
+        description: 'execute the integration test in all cases - this would be the default state',
       },
     ],
   },

--- a/src/components/IntegrationTest/IntegrationTestForm/utils/create-utils.ts
+++ b/src/components/IntegrationTest/IntegrationTestForm/utils/create-utils.ts
@@ -7,6 +7,7 @@ import {
 import {
   IntegrationTestScenarioKind,
   Param,
+  Context,
   ResolverParam,
   ResolverType,
 } from '../../../../types/coreBuildService';
@@ -45,12 +46,29 @@ export const formatParams = (params): Param[] => {
   return newParams.length > 0 ? newParams : null;
 };
 
+export const formatContexts = (contexts = [], setDefault = false): Context[] | null => {
+  const defaultContext = {
+    name: 'application',
+    description: 'execute the integration test in all cases - this would be the default state',
+  };
+  const newContextNames = new Set(contexts.map((ctx) => ctx.name));
+  const newContexts = contexts.map(({ name, description }) => ({ name, description }));
+  // Even though this option is preselected in the context option list,
+  // it's not appended to the Formik field array when submitting.
+  // Lets set the default here so we know it will be applied.
+  if (setDefault && !newContextNames.has('application')) {
+    newContexts.push(defaultContext);
+  }
+
+  return newContexts.length ? newContexts : null;
+};
+
 export const editIntegrationTest = (
   integrationTest: IntegrationTestScenarioKind,
   integrationTestValues: IntegrationTestFormValues,
   dryRun?: boolean,
 ): Promise<IntegrationTestScenarioKind> => {
-  const { url, revision, path, optional, environmentName, environmentType, params } =
+  const { url, revision, path, optional, environmentName, environmentType, params, contexts } =
     integrationTestValues;
   const integrationTestResource: IntegrationTestScenarioKind = {
     ...integrationTest,
@@ -79,6 +97,7 @@ export const editIntegrationTest = (
         ],
       },
       params: formatParams(params),
+      contexts: formatContexts(contexts),
     },
   };
 
@@ -109,7 +128,7 @@ export const createIntegrationTest = (
   namespace: string,
   dryRun?: boolean,
 ): Promise<IntegrationTestScenarioKind> => {
-  const { name, url, revision, path, optional, params } = integrationTestValues;
+  const { name, url, revision, path, optional, params, contexts } = integrationTestValues;
   const isEC =
     url === EC_INTEGRATION_TEST_URL &&
     revision === EC_INTEGRATION_TEST_REVISION &&
@@ -134,12 +153,7 @@ export const createIntegrationTest = (
         ],
       },
       params: formatParams(params),
-      contexts: [
-        {
-          description: 'Application testing',
-          name: 'application',
-        },
-      ],
+      contexts: formatContexts(contexts, true),
     },
   };
 

--- a/src/components/IntegrationTest/__tests__/ContextsField.spec.tsx
+++ b/src/components/IntegrationTest/__tests__/ContextsField.spec.tsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { useParams } from 'react-router-dom';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { FieldArray, useField } from 'formik';
+import { ComponentKind } from 'src/types';
+import { useComponents } from '../../../../src/hooks/useComponents';
+import { useWorkspaceInfo } from '../../../../src/utils/workspace-context-utils';
+import ContextsField, {
+  contextOptions,
+  mapContextsWithSelection,
+  addComponentContexts,
+} from '../ContextsField';
+
+// Mock the hooks used in the component
+jest.mock('react-router-dom', () => ({
+  useParams: jest.fn(),
+}));
+jest.mock('../../../../src/utils/workspace-context-utils', () => ({
+  useWorkspaceInfo: jest.fn(),
+}));
+jest.mock('../../../../src/hooks/useComponents', () => ({
+  useComponents: jest.fn(),
+}));
+jest.mock('formik', () => ({
+  useField: jest.fn(),
+  FieldArray: jest.fn(),
+}));
+
+describe('ContextsField', () => {
+  const mockUseParams = useParams as jest.Mock;
+  const mockUseWorkspaceInfo = useWorkspaceInfo as jest.Mock;
+  const mockUseComponents = useComponents as jest.Mock;
+  const mockUseField = useField as jest.Mock;
+  const mockUseFieldArray = FieldArray as jest.Mock;
+
+  const fieldName = 'it.contexts';
+
+  const setupMocks = (selectedContexts = [], components = []) => {
+    mockUseParams.mockReturnValue({ appName: 'test-app' });
+    mockUseWorkspaceInfo.mockReturnValue({ namespace: 'test-namespace' });
+    mockUseComponents.mockReturnValue([components, true]);
+    mockUseField.mockReturnValue([{}, { value: selectedContexts }]);
+    mockUseFieldArray.mockImplementation((props) => {
+      const renderFunction = props.render;
+      return <div>{renderFunction({ push: jest.fn(), remove: jest.fn() })}</div>;
+    });
+  };
+
+  const openDropdown = () => {
+    const toggleButton = screen.getByTestId('context-dropdown-toggle');
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
+    act(() => {
+      fireEvent.click(toggleButton);
+    });
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
+  };
+
+  const testContextOption = (name: string) => {
+    expect(screen.getByTestId(`context-option-${name}`)).toBeInTheDocument();
+  };
+
+  beforeEach(() => {
+    setupMocks(); // Reset the mocks with no selected contexts or components
+  });
+
+  it('should render custom header if passed', () => {
+    mockUseField.mockReturnValue([{}, { value: [] }]);
+    render(<ContextsField fieldName={fieldName} heading="Test Heading" editing={true} />);
+    expect(screen.getByText('Test Heading')).toBeInTheDocument();
+  });
+
+  it('should allow selecting and deselecting a context', () => {
+    const pushMock = jest.fn();
+    const removeMock = jest.fn();
+    mockUseFieldArray.mockImplementation((props) => {
+      const renderFunction = props.render;
+      return <div>{renderFunction({ push: pushMock, remove: removeMock })}</div>;
+    });
+
+    // This will be our previously selected contextOption.
+    const selectedContext = {
+      name: contextOptions[0].name,
+      description: contextOptions[0].description,
+    };
+    mockUseField.mockReturnValue([{}, { value: [selectedContext] }]);
+
+    render(<ContextsField fieldName={fieldName} editing={true} />);
+
+    openDropdown();
+    testContextOption(contextOptions[0].name);
+
+    act(() => {
+      fireEvent.click(screen.getByTestId(`context-option-${contextOptions[0].name}`).childNodes[0]);
+    });
+
+    // Ensure deselecting
+    expect(removeMock).toHaveBeenCalledWith(0);
+
+    // Simulate selecting another context
+    act(() => {
+      fireEvent.click(screen.getByTestId(`context-option-${contextOptions[1].name}`).childNodes[0]);
+    });
+
+    // Ensure selecting
+    expect(pushMock).toHaveBeenCalledWith({
+      name: contextOptions[1].name,
+      description: contextOptions[1].description,
+    });
+  });
+
+  it('should render additional component contexts when components are loaded', () => {
+    const mockComponents = [
+      { metadata: { name: 'componentA' } },
+      { metadata: { name: 'componentB' } },
+    ];
+    setupMocks([], mockComponents);
+
+    render(<ContextsField fieldName={fieldName} editing={true} />);
+
+    openDropdown();
+
+    // Names should be visible as a menu option
+    ['componentA', 'componentB'].forEach((componentName) => {
+      testContextOption(`component_${componentName}`);
+    });
+    // Descriptions should also be visible
+    expect(screen.getByText('execute the integration test when component componentA updates'));
+    expect(screen.getByText('execute the integration test when component componentB updates'));
+  });
+
+  it('should have applications pre-set as a default context when creating a new integration test', async () => {
+    mockUseField.mockReturnValue([{}, { value: [] }]);
+    render(<ContextsField fieldName={fieldName} heading="Test Heading" editing={false} />);
+    const chip = screen.getByTestId('context-chip-application');
+    // Check that context option already has a chip
+    expect(chip).toBeInTheDocument();
+    // Unselecting the drop down value should not be possible when creating a new integration test.
+    openDropdown();
+    testContextOption('application');
+    expect(screen.getByTestId('context-option-application').childNodes[0]).toBeDisabled();
+  });
+});
+
+describe('mapContextsWithSelection', () => {
+  it('gets the previously selected contexts and marks them selected', () => {
+    const testNames = new Set(['group', 'component', 'push']);
+    const selectedNames = contextOptions
+      .filter((ctx) => testNames.has(ctx.name))
+      .map((ctx) => ctx.name);
+
+    const result = mapContextsWithSelection(selectedNames, contextOptions);
+    selectedNames.forEach((name) => {
+      const selectedContext = result.find((ctx) => ctx.name === name);
+      expect(selectedContext.selected).toBeTruthy();
+    });
+  });
+});
+
+describe('addComponentContexts', () => {
+  it('gets the previously selected components, adds them to context options and updates selected value', () => {
+    const selectedComponentNames = ['component_componentA', 'component_componentC'];
+
+    const components = [
+      { metadata: { name: 'componentA' } },
+      { metadata: { name: 'componentB' } },
+      { metadata: { name: 'componentC' } },
+    ];
+
+    const result = addComponentContexts(
+      contextOptions,
+      selectedComponentNames,
+      components as ComponentKind[],
+    );
+    selectedComponentNames.forEach((name) => {
+      const selectedComponentContext = result.find((ctx) => ctx.name === name);
+      expect(selectedComponentContext.selected).toBeTruthy();
+    });
+
+    // This component was not previously selected or saved, even with the 'component_' prefix added
+    // so it should not be marked as selected.
+    const unselectedComponent = result.find((ctx) => ctx.name === 'component_componentB');
+    expect(unselectedComponent.selected).toBeFalsy();
+  });
+});

--- a/src/components/IntegrationTest/__tests__/ContextsSelectList.spec.tsx
+++ b/src/components/IntegrationTest/__tests__/ContextsSelectList.spec.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render, fireEvent, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ContextSelectList } from '../ContextSelectList';
+
+const mockContexts = [
+  { name: 'application', description: 'Test context application', selected: true },
+  { name: 'component', description: 'Test context component', selected: true },
+  { name: 'group', description: 'Test context group', selected: false },
+];
+
+describe('ContextSelectList Component', () => {
+  const mockOnSelect = jest.fn();
+
+  const openDropdown = async () => {
+    const toggleButton = screen.getByTestId('context-dropdown-toggle');
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
+    await act(async () => {
+      fireEvent.click(toggleButton); // Wrap state update in act
+    });
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
+  };
+
+  const testContextOption = (name: string) => {
+    expect(screen.getByTestId(`context-option-${name}`)).toBeInTheDocument();
+  };
+
+  it('renders correctly with selected contexts and chips', async () => {
+    render(
+      <ContextSelectList selectedContexts={mockContexts} onSelect={mockOnSelect} editing={true} />,
+    );
+
+    // Assert that the "Select Contexts" button is present and renders the selected chips
+    const toggleButton = screen.getByTestId('context-dropdown-toggle');
+    expect(toggleButton).toBeInTheDocument();
+
+    // Chips should be rendered
+    const chip1 = screen.getByTestId('context-chip-application');
+    const chip2 = screen.getByTestId('context-chip-component');
+    expect(chip1).toBeInTheDocument();
+    expect(chip2).toBeInTheDocument();
+    // The context option 'group' is not selected, it shouldn't have a chip.
+    expect(screen.queryByTestId('context-chip-group')).not.toBeInTheDocument();
+
+    // We should also see the passed context options listed once the dropdown is open.
+    await openDropdown(); // Use act to wrap state updates
+    mockContexts.forEach((ctx) => testContextOption(ctx.name));
+  });
+
+  it('calls onSelect when a chip is clicked', async () => {
+    render(
+      <ContextSelectList selectedContexts={mockContexts} onSelect={mockOnSelect} editing={true} />,
+    );
+
+    // Get the button element for this context chip
+    const chip1 = screen.getByTestId('context-chip-application').childNodes[1].childNodes[0];
+    // Click it
+    await act(async () => {
+      fireEvent.click(chip1); // Wrap in act to handle state changes
+    });
+
+    // Assert the mock function was called with the correct context name
+    expect(mockOnSelect).toHaveBeenCalledWith(expect.anything(), 'application');
+  });
+
+  it('calls onSelect when a dropdown option is clicked', async () => {
+    render(
+      <ContextSelectList selectedContexts={mockContexts} onSelect={mockOnSelect} editing={true} />,
+    );
+
+    // Open the dropdown and select an unselected option
+    await openDropdown(); // Wrap in act
+
+    // Get the button element for this context option
+    const option2 = screen.getByTestId('context-option-group').childNodes[0];
+    // Click it
+    await act(async () => {
+      fireEvent.click(option2); // Wrap in act to handle state updates
+    });
+
+    // Assert the mock function was called with the correct context name
+    expect(mockOnSelect).toHaveBeenCalledWith(expect.anything(), 'group');
+  });
+});

--- a/src/components/IntegrationTest/tabs/IntegrationTestOverviewTab.tsx
+++ b/src/components/IntegrationTest/tabs/IntegrationTestOverviewTab.tsx
@@ -20,6 +20,7 @@ import { IntegrationTestScenarioKind } from '../../../types/coreBuildService';
 import { useWorkspaceInfo } from '../../../utils/workspace-context-utils';
 import { useModalLauncher } from '../../modal/ModalProvider';
 import MetadataList from '../../PipelineRunDetailsView/MetadataList';
+import { createEditContextsModal } from '../EditContextsModal';
 import { createEditParamsModal } from '../EditParamsModal';
 import { IntegrationTestLabels } from '../IntegrationTestForm/types';
 import {
@@ -42,6 +43,7 @@ const IntegrationTestOverviewTab: React.FC<
   const showModal = useModalLauncher();
 
   const params = integrationTest?.spec?.params;
+  const contexts = integrationTest?.spec?.contexts;
 
   return (
     <>
@@ -137,6 +139,36 @@ const IntegrationTestOverviewTab: React.FC<
                     );
                   })}
                 </>
+              )}
+              {contexts && (
+                <DescriptionListGroup data-test="its-overview-contexts">
+                  <DescriptionListTerm>
+                    Contexts{' '}
+                    <Tooltip content="Contexts where the integration test can be applied.">
+                      <OutlinedQuestionCircleIcon />
+                    </Tooltip>
+                  </DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {pluralize(contexts.length, 'context')}
+                    <div>
+                      {' '}
+                      <Button
+                        variant={ButtonVariant.link}
+                        className="pf-v5-u-pl-0"
+                        onClick={() =>
+                          showModal(
+                            createEditContextsModal({
+                              intTest: integrationTest,
+                            }),
+                          )
+                        }
+                        data-test="edit-context-button"
+                      >
+                        Edit contexts
+                      </Button>
+                    </div>
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
               )}
               {params && (
                 <DescriptionListGroup data-test="its-overview-params">


### PR DESCRIPTION
## Fixes 
[KFLUXBUGS-1651](https://issues.redhat.com/browse/KFLUXBUGS-1651)


## Description
Add the contexts to the integration show page. Also add a modal for quick edits.


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
