### PR TITLE
fix(e2e): enable sbom test, fix missing pageobjects

### DIFF
--- a/integration-tests/support/pageObjects/atlas-po.ts
+++ b/integration-tests/support/pageObjects/atlas-po.ts
@@ -1,0 +1,7 @@
+export const atlasPO = {
+  username: '#username',
+  password: '#password',
+  loginButton: '#submit',
+  headerTitle: '.pf-v5-c-page__main-section',
+  cardTitle: '.pf-v5-c-card__title-text',
+};

--- a/integration-tests/tests/advanced-happy-path.spec.ts
+++ b/integration-tests/tests/advanced-happy-path.spec.ts
@@ -1,11 +1,7 @@
 import { NavItem } from '../support/constants/PageTitle';
 import { atlasPO } from '../support/pageObjects/atlas-po';
 import { ApplicationDetailPage } from '../support/pages/ApplicationDetailPage';
-import {
-  ComponentDetailsPage,
-  ComponentPageTabs,
-  DeploymentsTab,
-} from '../support/pages/ComponentDetailsPage';
+import { ComponentDetailsPage, ComponentPageTabs } from '../support/pages/ComponentDetailsPage';
 import { ComponentPage } from '../support/pages/ComponentsPage';
 import { SecretsPage } from '../support/pages/SecretsPage';
 import { ComponentsTabPage } from '../support/pages/tabs/ComponentsTabPage';


### PR DESCRIPTION
## Description
Fix missing page objects for Atlas. Enable advanced test again, with SBOM check.