### PR TITLE
fix(e2e): set fixed chrome-service version to enable jobs

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -53,6 +53,7 @@ bonfire deploy \
         --clowd-env ${ENV_NAME} \
         --set-template-ref ${COMPONENT}=${GIT_COMMIT} \
         --set-image-tag ${IMAGE}=${IMAGE_TAG} \
+        --set-image-tag quay.io/redhat-services-prod/hcc-platex-services/chrome-service=latest \
         --namespace ${NAMESPACE}
 
 


### PR DESCRIPTION
## Description
Tests started to fail as the chrome-service image with the specified tag was absent. Temporarily set it to the latest to make jobs work again.
