### PR TITLE
feat(KFLUXBUGS-1372): improve the label of private image repo

### DIFF
--- a/src/components/ImportForm/ComponentSection/SourceSection.tsx
+++ b/src/components/ImportForm/ComponentSection/SourceSection.tsx
@@ -64,7 +64,7 @@ export const SourceSection = () => {
         onChange={handleChange}
       />
       {validated === ValidatedOptions.success ? (
-        <SwitchField name="isPrivateRepo" label="Is this a private repository?" />
+        <SwitchField name="isPrivateRepo" label="Should the image produced be private?" />
       ) : null}
       {validated === ValidatedOptions.success ? (
         <GitOptions isGitAdvancedOpen={isGitAdvancedOpen} setGitAdvancedOpen={setGitAdvancedOpen} />

--- a/src/components/ImportForm/ComponentSection/__tests__/ComponentSection.spec.tsx
+++ b/src/components/ImportForm/ComponentSection/__tests__/ComponentSection.spec.tsx
@@ -26,6 +26,22 @@ describe('ComponentSection', () => {
     await waitFor(() => screen.getByText('Show advanced Git options'));
   });
 
+  it('should get private image repo switch when git src is ready', async () => {
+    formikRenderer(<ComponentSection />, {
+      source: { git: { url: '' } },
+    });
+    const user = userEvent.setup();
+    const source = screen.getByPlaceholderText('Enter your source');
+
+    await user.type(source, 'https://github.com/abcd/repo.git');
+    await user.tab();
+
+    const switchCheckbox = screen.getByLabelText('Should the image produced be private?');
+    expect(switchCheckbox).not.toBeChecked();
+    await user.click(switchCheckbox);
+    expect(switchCheckbox).toBeChecked();
+  });
+
   it('should expand git options if source url is others', async () => {
     formikRenderer(<ComponentSection />, {
       source: { git: { url: '' } },

--- a/src/components/ImportForm/__tests__/submit-utils.spec.ts
+++ b/src/components/ImportForm/__tests__/submit-utils.spec.ts
@@ -87,7 +87,7 @@ describe('Submit Utils: createResources', () => {
         application: 'test-app',
         inAppContext: true,
         showComponent: true,
-        isPrivateRepo: false,
+        isPrivateRepo: true,
         source: {
           git: {
             url: 'https://github.com/',


### PR DESCRIPTION
## Fixes 
[KFLUXBUGS-1372](https://issues.redhat.com/browse/KFLUXBUGS-1372)

## Description
When creating component, there is a switch labeled with 'is this a private repo?'. 
People consider it is talking about the 'git repo' itself but it is talking about 'image repo'. 
Enable the switch, the image repository would be private. The original switch context is confusing. 
The patch improve the label from 'is this a private repo' to 'is this a private image repo'.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

<img width="757" alt="Screenshot 2024-10-29 at 09 33 39" src="https://github.com/user-attachments/assets/27629d72-e2d8-49af-8cbc-267dcb5dea93">


## How to test or reproduce?
1. Click 'Create an application'
2. Input the valid git repo
3. Check the switch 'Should the image produced be private?'
4. Input the Dockerfile path and component name
5. Click 'Add Component'
6. Run 'kubectl get imagerepository' to ensure the target imagerepository is private
7. After the build pipeline, navigate to quay.io to ensure the access of the target image repo is protected.


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge