### PR TITLE
fix(KFLUXBUGS-1786): git provider of gitlab.cee.redhat.com is gitlab

### DIFF
--- a/src/components/ImportForm/ComponentSection/GitProviderDropdown.tsx
+++ b/src/components/ImportForm/ComponentSection/GitProviderDropdown.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Alert, AlertVariant } from '@patternfly/react-core';
 import { useField } from 'formik';
 import { DropdownField } from '../../../shared';
 import { GIT_PROVIDER_ANNOTATION_VALUE } from '../../../utils/component-utils';
@@ -11,24 +12,27 @@ type GitProviderDropdownProps = Omit<
 export const GitProviderDropdown: React.FC<React.PropsWithChildren<GitProviderDropdownProps>> = (
   props,
 ) => {
-  const [{ value }, , { setValue }] = useField<string>(props.name);
+  const [{ value }, { error }, { setValue }] = useField<string>(props.name);
 
   const dropdownItems = [
     { key: GIT_PROVIDER_ANNOTATION_VALUE.GITHUB, value: GIT_PROVIDER_ANNOTATION_VALUE.GITHUB },
     { key: GIT_PROVIDER_ANNOTATION_VALUE.GITLAB, value: GIT_PROVIDER_ANNOTATION_VALUE.GITLAB },
-    { key: GIT_PROVIDER_ANNOTATION_VALUE.OTHERS, value: GIT_PROVIDER_ANNOTATION_VALUE.OTHERS },
   ];
 
   return (
     <div className="pf-v5-u-mb-md">
       <DropdownField
         {...props}
+        required
         label="Git provider annotation"
         placeholder={'Select git provider'}
         value={value}
         items={dropdownItems}
         onChange={(provider: string) => setValue(provider)}
       />
+      {error && (
+        <Alert isInline variant={AlertVariant.danger} title="Provider must be GitLab or GitHub" />
+      )}
     </div>
   );
 };

--- a/src/components/ImportForm/ComponentSection/SourceSection.tsx
+++ b/src/components/ImportForm/ComponentSection/SourceSection.tsx
@@ -39,7 +39,7 @@ export const SourceSection = () => {
         let name: string;
         try {
           parsed = GitUrlParse(event.target?.value ?? '');
-          setFieldValue('gitURLAnnotation', `https://${parsed?.resource}`);
+          setFieldValue('gitURLAnnotation', `${parsed?.protocol}://${parsed?.resource}`);
           name = parsed.name;
         } catch {
           name = '';

--- a/src/components/ImportForm/ComponentSection/SourceSection.tsx
+++ b/src/components/ImportForm/ComponentSection/SourceSection.tsx
@@ -20,12 +20,12 @@ export const SourceSection = () => {
 
   const handleChange = React.useCallback(
     (event) => {
+      const gitType = detectGitType(event.target?.value);
+      if (gitType !== GitProvider.GITHUB && gitType !== GitProvider.GITLAB) {
+        setFieldValue('gitProviderAnnotation', '');
+        setGitAdvancedOpen(true);
+      }
       if (validated) {
-        const gitType = detectGitType(event.target?.value);
-        if (gitType !== GitProvider.GITHUB && gitType !== GitProvider.GITLAB) {
-          setFieldValue('gitProviderAnnotation', '');
-          setGitAdvancedOpen(true);
-        }
         if (gitType === GitProvider.GITHUB) {
           setFieldValue('gitProviderAnnotation', GIT_PROVIDER_ANNOTATION_VALUE.GITHUB);
           setGitAdvancedOpen(false);
@@ -39,7 +39,7 @@ export const SourceSection = () => {
         let name: string;
         try {
           parsed = GitUrlParse(event.target?.value ?? '');
-          setFieldValue('gitURLAnnotation', parsed?.resource);
+          setFieldValue('gitURLAnnotation', `https://${parsed?.resource}`);
           name = parsed.name;
         } catch {
           name = '';

--- a/src/components/ImportForm/ComponentSection/__tests__/ComponentSection.spec.tsx
+++ b/src/components/ImportForm/ComponentSection/__tests__/ComponentSection.spec.tsx
@@ -65,4 +65,20 @@ describe('ComponentSection', () => {
       ),
     );
   });
+
+  it('should populate git provider as gitlab when git repo is gitlab.cee', async () => {
+    formikRenderer(<ComponentSection />, {
+      source: { git: { url: '' } },
+    });
+    const user = userEvent.setup();
+    const source = screen.getByPlaceholderText('Enter your source');
+
+    await user.type(source, 'https://gitlab.cee.redhat.com/errata-guild/errata-rails.git');
+    await user.tab();
+    await waitFor(() =>
+      expect((screen.getByTestId('url-annotation') as HTMLInputElement).value).toBe(
+        'https://gitlab.cee.redhat.com',
+      ),
+    );
+  });
 });

--- a/src/components/ImportForm/ComponentSection/__tests__/ComponentSection.spec.tsx
+++ b/src/components/ImportForm/ComponentSection/__tests__/ComponentSection.spec.tsx
@@ -60,7 +60,9 @@ describe('ComponentSection', () => {
     await user.type(source, 'https://gitlab.com/abcd/repo.git');
     await user.tab();
     await waitFor(() =>
-      expect((screen.getByTestId('url-annotation') as HTMLInputElement).value).toBe('gitlab.com'),
+      expect((screen.getByTestId('url-annotation') as HTMLInputElement).value).toBe(
+        'https://gitlab.com',
+      ),
     );
   });
 });

--- a/src/components/ImportForm/validation.utils.ts
+++ b/src/components/ImportForm/validation.utils.ts
@@ -17,6 +17,7 @@ const componentSchema = yup.object({
   }),
   componentName: resourceNameYupValidation,
   pipeline: yup.string().required('Required'),
+  gitProviderAnnotation: yup.string().required('Required'),
 });
 
 export const formValidationSchema = yup.mixed().test(

--- a/src/shared/utils/git-utils.tsx
+++ b/src/shared/utils/git-utils.tsx
@@ -32,7 +32,7 @@ export const detectGitType = (url: string): GitProvider => {
   if (hasDomain(url, 'bitbucket.org')) {
     return GitProvider.BITBUCKET;
   }
-  if (hasDomain(url, 'gitlab.com')) {
+  if (hasDomain(url, 'gitlab.com') || hasDomain(url, 'gitlab.cee.redhat.com')) {
     return GitProvider.GITLAB;
   }
   // Not a known URL


### PR DESCRIPTION
## Fixes 
[KFLUXBUGS-1786](https://issues.redhat.com/browse/KFLUXBUGS-1786)


## Description
When people create component and specify the git source as 'https://gitlab.cee.redhat.com/test.git', the git provider should be auto-filled as 'gitlab'.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<img width="777" alt="Screenshot 2024-10-30 at 17 53 55" src="https://github.com/user-attachments/assets/541efe8e-9f35-4520-9354-4dec18c783f4">



## How to test or reproduce?
1. create component
2. input the https://gitlab.cee.redhat.com/test.git as the git repo url
3. click the 'show advanced git' to ensure the 'gitlab' is shown as the git provider annotation.

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge