### PR TITLE
fix(KFLUXBUGS-1537): activity tab should use component.metadata.name

### DIFF
--- a/src/components/Components/ComponentDetails/__tests__/ComponentActivityTab.spec.tsx
+++ b/src/components/Components/ComponentDetails/__tests__/ComponentActivityTab.spec.tsx
@@ -72,7 +72,7 @@ describe('ComponentActivityTab', () => {
       fireEvent.click(plrTab);
     });
     expect(navigateMock).toHaveBeenCalledWith(
-      '/application-pipeline/workspaces/test-ws/applications/my-test-output/components/stock-app-webshop-jhnj/undefined/pipelineruns',
+      '/application-pipeline/workspaces/test-ws/applications/my-test-output/components/sample-component/undefined/pipelineruns',
     );
   });
 });

--- a/src/components/Components/ComponentDetails/__tests__/ComponentDetails.spec.tsx
+++ b/src/components/Components/ComponentDetails/__tests__/ComponentDetails.spec.tsx
@@ -204,6 +204,26 @@ describe('ComponentDetailsView', () => {
     );
   });
 
+  it('should render activity tab with metadata.name', async () => {
+    useComponentMock.mockReturnValue([
+      { ...mockComponent, spec: { componentName: 'human', ...mockComponent.spec } },
+      true,
+    ]);
+    routerRenderer(
+      <ComponentDetailsViewWrapper>
+        <ComponentDetailsView applicationName="test-application" componentName="human-resources" />,
+      </ComponentDetailsViewWrapper>,
+    );
+    const activityTab = screen.getByTestId('details__tabItem activity');
+
+    await act(async () => {
+      fireEvent.click(activityTab);
+    });
+    expect(navigateMock).toHaveBeenCalledWith(
+      '/application-pipeline/workspaces/test-ws/applications/test-application/components/human-resources/activity',
+    );
+  });
+
   it('should show an error state when latest build information is not available', () => {
     useLatestSuccessfulBuildPipelineRunForComponentMock.mockReturnValue([
       {},

--- a/src/components/Components/ComponentDetails/tabs/ComponentActivityTab.tsx
+++ b/src/components/Components/ComponentDetails/tabs/ComponentActivityTab.tsx
@@ -23,7 +23,7 @@ export const ComponentActivityTab: React.FC<React.PropsWithChildren<ComponentAct
   const applicationName = component.spec.application;
   const { activeTab: parentTab, compActivity: activeTab } = params;
   const [lastSelectedTab, setLocalStorageItem] = useLocalStorage<string>(
-    `${component ? `${component.spec.componentName}_` : ''}${ACTIVITY_SECONDARY_TAB_KEY}`,
+    `${component ? `${component.metadata.name}_` : ''}${ACTIVITY_SECONDARY_TAB_KEY}`,
   );
   const currentTab = activeTab || lastSelectedTab || 'latest-commits';
   const navigate = useNavigate();
@@ -31,11 +31,11 @@ export const ComponentActivityTab: React.FC<React.PropsWithChildren<ComponentAct
     (newTab: string) => {
       if (currentTab !== newTab) {
         navigate(
-          `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/components/${component.spec.componentName}/${parentTab}/${newTab}`,
+          `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/components/${component.metadata.name}/${parentTab}/${newTab}`,
         );
       }
     },
-    [applicationName, component.spec.componentName, currentTab, navigate, parentTab, workspace],
+    [applicationName, component.metadata.name, currentTab, navigate, parentTab, workspace],
   );
 
   React.useEffect(() => {
@@ -47,14 +47,14 @@ export const ComponentActivityTab: React.FC<React.PropsWithChildren<ComponentAct
   React.useEffect(() => {
     if (!activeTab && lastSelectedTab) {
       navigate(
-        `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/components/${component.spec.componentName}/${parentTab}/${lastSelectedTab}`,
+        `/application-pipeline/workspaces/${workspace}/applications/${applicationName}/components/${component.metadata.name}/${parentTab}/${lastSelectedTab}`,
         { replace: true },
       );
     }
   }, [
     activeTab,
     applicationName,
-    component.spec.componentName,
+    component.metadata.name,
     lastSelectedTab,
     navigate,
     parentTab,


### PR DESCRIPTION
## Fixes 
[KFLUXBUGS-1537](https://issues.redhat.com/browse/KFLUXBUGS-1537)


## Description
There is one 'Activity' tab on Component Details page. When users click it, its navigation should
point to component.metadata.name(the unique ID of component).


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<img width="1060" alt="Screenshot 2024-10-31 at 20 58 30" src="https://github.com/user-attachments/assets/0cdfbc7a-9707-4614-918f-6a4920b6866a">


## How to test or reproduce?
1.  clone the repo https://github.com/testcara/KFLUXBUGS-1537-reproduce/tree/product-1
2. create the application, component and imagerepository with application-1.yaml, component-1.yaml, image-repo-1.yaml by cli
3. go to the konflux UI dashboard then navigate to the component details page
4. click the 'Activity' tab on it to ensure there is no '404' error.

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
