### PR TITLE
fix(KFLUXBUGS-1751):  release status replies on status and reason of the release type

### DIFF
--- a/src/components/Releases/__tests__/ReleasesListRow.spec.tsx
+++ b/src/components/Releases/__tests__/ReleasesListRow.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { render, configure } from '@testing-library/react';
+import { ReleaseCondition } from '../../../types';
 import ReleasesListRow from '../ReleasesListRow';
 
 jest.mock('react-router-dom', () => ({
@@ -24,6 +25,7 @@ const mockRelease = {
       {
         reason: 'Succeeded',
         status: 'True',
+        type: ReleaseCondition.Released,
       },
     ],
   },

--- a/src/hooks/__tests__/useReleaseStatus.ts
+++ b/src/hooks/__tests__/useReleaseStatus.ts
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
+import { ReleaseCondition } from '../../types';
 import { useReleaseStatus } from '../useReleaseStatus';
 
 const mockRelease = {
@@ -19,15 +20,14 @@ describe('useApplicationSnapshots', () => {
     expect(result.current).toEqual('Unknown');
   });
 
-  it('should return in progress if any of the conditions is progressing', () => {
+  it('should return in progress if release condition is progressing', () => {
     const { result } = renderHook(() =>
       useReleaseStatus({
         ...mockRelease,
         status: {
           conditions: [
-            { reason: 'Progressing' },
-            { reason: 'Succeeded', status: 'True' },
-            { reson: 'Failed', status: 'False' },
+            { reason: 'Succeeded', status: 'True', type: ReleaseCondition.Validated },
+            { reason: 'Progressing', status: 'True', type: ReleaseCondition.Released },
           ],
         },
       }),
@@ -35,14 +35,14 @@ describe('useApplicationSnapshots', () => {
     expect(result.current).toEqual('In Progress');
   });
 
-  it('should return in succeeded if all of the conditions pass', () => {
+  it('should return in succeeded if release condition is pass', () => {
     const { result } = renderHook(() =>
       useReleaseStatus({
         ...mockRelease,
         status: {
           conditions: [
-            { reason: 'Succeeded', status: 'True' },
-            { reason: 'Succeeded', status: 'True' },
+            { reason: 'Succeeded', status: 'True', type: ReleaseCondition.Released },
+            { reason: 'Progressing', status: 'True', type: ReleaseCondition.Validated },
           ],
         },
       }),
@@ -50,15 +50,15 @@ describe('useApplicationSnapshots', () => {
     expect(result.current).toEqual('Succeeded');
   });
 
-  it('should return in failed if any of the conditions fail', () => {
+  it('should return in failed if release condition is fail', () => {
     const { result } = renderHook(() =>
       useReleaseStatus({
         ...mockRelease,
         status: {
           conditions: [
-            { reason: 'Succeeded', status: 'True' },
-            { reason: 'Succeeded', status: 'True' },
-            { reason: 'Failed', status: 'False' },
+            { reason: 'Succeeded', status: 'True', type: ReleaseCondition.Processed },
+            { reason: 'Succeeded', status: 'True', type: ReleaseCondition.Validated },
+            { reason: 'Failed', status: 'False', type: ReleaseCondition.Released },
           ],
         },
       }),


### PR DESCRIPTION
https://issues.redhat.com/browse/KFLUXBUGS-1751


## Description
When type is 'Released', reason is 'Succeeded' and status is 'True', release should be shown as 'success'.
While if the release does not meet the requirements, its status would be progressing/failed/pending.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
when the release resource is shown as:
```
carawang@pipeline-examples %oc get release five-release -o yaml | grep -b4 'type: Released'
554-  - lastTransitionTime: "2024-11-05T09:57:42Z"
601-    message: ""
617-    reason: Succeeded
639-    status: "True"
658:    type: Released
```
the UI of the release is Succeeded
<img width="1143" alt="Screenshot 2024-11-05 at 18 00 38" src="https://github.com/user-attachments/assets/2dfb0fb7-b736-489c-a5a8-945147a1ea28">

## How to test or reproduce?
Trigger a release, the status of the release on UI should be shown correctly. 

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
