### PR TITLE
fix(KFLUXBUGS-1779): allow highlightable links

### DIFF
--- a/src/components/Components/ComponentDetails/tabs/ComponentDetails.tsx
+++ b/src/components/Components/ComponentDetails/tabs/ComponentDetails.tsx
@@ -92,6 +92,7 @@ const ComponentDetails: React.FC<React.PropsWithChildren<ComponentDetailsProps>>
                       : `https://${componentImageURL}`
                   }
                   text={componentImageURL}
+                  isHighlightable
                 />
               </DescriptionListDescription>
             </DescriptionListGroup>

--- a/src/components/GitLink/GitRepoLink.tsx
+++ b/src/components/GitLink/GitRepoLink.tsx
@@ -35,7 +35,7 @@ const GitRepoLink: React.FC<React.PropsWithChildren<Props>> = ({
 
   return (
     <Tooltip content={fullUrl} position={TooltipPosition.bottom}>
-      <ExternalLink href={fullUrl} icon={icon} hideIcon dataTestID={dataTestID}>
+      <ExternalLink href={fullUrl} icon={icon} hideIcon dataTestID={dataTestID} isHighlightable>
         {parsed.owner}/{parsed.name}
         {revision ? (
           <>

--- a/src/shared/components/links/ExternalLink.scss
+++ b/src/shared/components/links/ExternalLink.scss
@@ -1,0 +1,3 @@
+.highlightable-link {
+  user-select: text; /* Enables text selection */
+}

--- a/src/shared/components/links/ExternalLink.tsx
+++ b/src/shared/components/links/ExternalLink.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import { ButtonProps, ButtonVariant, Icon } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
+import { css } from '@patternfly/react-styles';
 import AnalyticsButton from '../../../components/AnalyticsButton/AnalyticsButton';
 import { AnalyticsButtonProperties } from '../../../utils/analytics';
+import './ExternalLink.scss';
 
 type ExternalLinkProps = {
   href: string;
@@ -18,6 +20,7 @@ type ExternalLinkProps = {
   onClick?: ButtonProps['onClick'];
   analytics?: AnalyticsButtonProperties;
   size?: 'sm' | 'md' | 'lg' | 'xl';
+  isHighlightable?: boolean;
 };
 
 const ExternalLink: React.FC<React.PropsWithChildren<ExternalLinkProps>> = ({
@@ -34,11 +37,12 @@ const ExternalLink: React.FC<React.PropsWithChildren<ExternalLinkProps>> = ({
   icon,
   onClick,
   size = 'sm',
+  isHighlightable,
 }) => (
   <AnalyticsButton
     component="a"
     style={style}
-    className={additionalClassName}
+    className={css(additionalClassName, isHighlightable && 'highlightable-link')}
     href={href}
     target="_blank"
     rel="noopener noreferrer"


### PR DESCRIPTION
## Fixes 
[KFLUXBUGS-1779](https://issues.redhat.com/browse/KFLUXBUGS-1779)


## Description
The external links in the Component details page are not highlight-able for users, so they cannot copy those values. 
An optional CSS class was added so they can become highlight-able where desired.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

### Before

[links-not-highlightable.webm](https://github.com/user-attachments/assets/bc4dffd6-1cbd-4f8a-be9e-7e5378ead476)

### After

[links-now-highlightable.webm](https://github.com/user-attachments/assets/9e5f0933-e392-4dc8-bb25-bdaf6712a228)


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
