### PR TITLE
fix(e2e): enable tests on eph env

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -53,6 +53,7 @@ bonfire deploy \
         --clowd-env ${ENV_NAME} \
         --set-template-ref ${COMPONENT}=${GIT_COMMIT} \
         --set-image-tag ${IMAGE}=${IMAGE_TAG} \
+        --set-image-tag quay.io/redhat-services-prod/hcc-platex-services/chrome-service=latest \
         --namespace ${NAMESPACE}
 
 
@@ -67,6 +68,13 @@ oc get deployment $ENV_NAME-mbop -o json | \
      {"name": "KEYCLOAK_PASSWORD", "value": $pass},
      {"name": "KEYCLOAK_VERSION", "value": "23.0.1"}])' | oc replace -f -
 oc rollout status deployment $ENV_NAME-mbop
+
+# workaround for BETA flag being used on testing env (eph env)
+oc get frontend hac-dev --output json | jq '.spec.frontend.paths += ["/beta/api/plugins/hac-dev"]' | oc apply -f -
+oc get frontend hac-core --output json | jq '.spec.frontend.paths += ["/beta/apps/hac-core"]' | oc apply -f -
+
+oc rollout status deployment hac-dev-frontend
+oc rollout status deployment hac-core-frontend
 
 # Call the keycloak API and add a user
 B64_USER=$(oc get secret ${ENV_NAME}-keycloak -o json | jq '.data.username'| tr -d '"')


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/KFLUXUI-171

## Description
Add paths to frontends to workaround issue with /beta path. It's a little hacky way, but it's agreed that hac-dev (and therefore hac-core) is being decommissioned soon. The other way is publishing a fixed image again but the process is currently not clear and easy.
