### PR TITLE
fix(KFLUXBUGS-1910): add Gitlab push event type

### DIFF
--- a/src/components/PipelineRunListView/__tests__/pipelinerun-actions.spec.tsx
+++ b/src/components/PipelineRunListView/__tests__/pipelinerun-actions.spec.tsx
@@ -86,6 +86,45 @@ describe('usePipelinerunActions', () => {
     );
   });
 
+  it('should contain enabled actions for Gitlab pipeline run event type', async () => {
+    const { result } = renderHook(() =>
+      usePipelinerunActions({
+        metadata: {
+          labels: {
+            'pipelines.appstudio.openshift.io/type': 'build',
+            [PipelineRunLabel.COMMIT_EVENT_TYPE_LABEL]: 'Push',
+          },
+        },
+        status: { conditions: [{ type: 'Succeeded', status: runStatus.Running }] },
+      } as any),
+    );
+    const actions = result.current;
+
+    expect(actions[0]).toEqual(
+      expect.objectContaining({
+        label: 'Rerun',
+        disabled: false,
+        disabledTooltip: null,
+      }),
+    );
+
+    expect(actions[1]).toEqual(
+      expect.objectContaining({
+        label: 'Stop',
+        disabled: false,
+        disabledTooltip: undefined,
+      }),
+    );
+
+    expect(actions[2]).toEqual(
+      expect.objectContaining({
+        label: 'Cancel',
+        disabled: false,
+        disabledTooltip: undefined,
+      }),
+    );
+  });
+
   it('should contain disabled actions for Stop and Cancel', async () => {
     useAccessReviewForModelMock.mockReturnValueOnce([true, true]);
     const { result } = renderHook(() =>
@@ -119,6 +158,30 @@ describe('usePipelinerunActions', () => {
           labels: {
             'pipelines.appstudio.openshift.io/type': 'build',
             [PipelineRunLabel.COMMIT_EVENT_TYPE_LABEL]: PipelineRunEventType.PUSH,
+          },
+        },
+        status: { conditions: [{ type: 'Succeeded', status: 'True' }] },
+      } as any),
+    );
+    const actions = result.current;
+
+    expect(actions[0]).toEqual(
+      expect.objectContaining({
+        label: 'Rerun',
+        disabled: false,
+        disabledTooltip: null,
+      }),
+    );
+  });
+
+  it('should contain enabled rerun actions when PAC enabled for Gitlab pipeline run event type', async () => {
+    useAccessReviewForModelMock.mockReturnValueOnce([true, true]);
+    const { result } = renderHook(() =>
+      usePipelinerunActions({
+        metadata: {
+          labels: {
+            'pipelines.appstudio.openshift.io/type': 'build',
+            [PipelineRunLabel.COMMIT_EVENT_TYPE_LABEL]: 'Push',
           },
         },
         status: { conditions: [{ type: 'Succeeded', status: 'True' }] },

--- a/src/components/PipelineRunListView/pipelinerun-actions.tsx
+++ b/src/components/PipelineRunListView/pipelinerun-actions.tsx
@@ -30,7 +30,7 @@ export const usePipelinererunAction = (pipelineRun: PipelineRunKind) => {
   const isPushBuildType = [PipelineRunEventType.PUSH, PipelineRunEventType.INCOMING].includes(
     pipelineRun?.metadata?.labels?.[
       PipelineRunLabel.COMMIT_EVENT_TYPE_LABEL
-    ] as PipelineRunEventType,
+    ]?.toLowerCase() as PipelineRunEventType,
   );
 
   const snapshot = React.useMemo(


### PR DESCRIPTION
## Fixes 
Fixes: https://issues.redhat.com/browse/KFLUXBUGS-1910


## Description
It appears that the `PipelineRunTypeEvent` differs between Github and Gitlab (`push` vs `Push`). This prevents the user from re-running on-push pipelines.

### Before
![image](https://github.com/user-attachments/assets/ba7f01ea-daac-4dab-805f-e9fa5f4d21a0)

### After
![image](https://github.com/user-attachments/assets/f7fbdadd-6e57-4fdf-8c9e-e8846b0c85db)

## Type of change
- [x] Bugfix

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
