### PR TITLE
feat(KFLUXUI-256): support component.spec.containerImage as latestImage

### DIFF
--- a/src/components/ApplicationDetails/__data__/WorkflowComponentsData.ts
+++ b/src/components/ApplicationDetails/__data__/WorkflowComponentsData.ts
@@ -106,7 +106,7 @@ export const mockComponentsData = [
     spec: {
       application: 'test-dev-samples',
       componentName: 'test-dotnet60',
-      containerImage: 'quay.io/redhat-appstudio/user-workload:test-ns-test-dotnet60',
+      containerImage: 'quay.io/redhat-appstudio/user-workload:test-ns-test-dotnet61',
       replicas: 1,
       resources: {
         requests: {
@@ -140,6 +140,7 @@ export const mockComponentsData = [
           type: 'Created',
         },
       ],
+      lastPromotedImage: 'quay.io/redhat-appstudio/user-workload:test-ns-test-dotnet60',
       containerImage: 'quay.io/redhat-appstudio/user-workload:test-ns-test-dotnet60',
       devfile:
         'commands:\n- apply:\n    component: dockerfile-build\n  id: build-image\ncomponents:\n- image:\n    dockerfile:\n      rootRequired: false\n      uri: https://raw.githubusercontent.com/test-user-1/devfile-sample-dotnet60-basic/main/docker/Dockerfile\n    imageName: ""\n  name: dockerfile-build\n- attributes:\n    deployment/container-port: 8081\n    deployment/cpuRequest: 10m\n    deployment/memoryRequest: 100Mi\n    deployment/replicas: 1\n    deployment/storageRequest: "0"\n  kubernetes:\n    inlined: placeholder\n  name: kubernetes\nmetadata:\n  description: Basic Devfile for a Dockerfile Component\n  name: dockerfile-component\nschemaVersion: 2.2.0\n',

--- a/src/components/Components/ComponentDetails/tabs/ComponentDetails.tsx
+++ b/src/components/Components/ComponentDetails/tabs/ComponentDetails.tsx
@@ -11,6 +11,7 @@ import yamlParser from 'js-yaml';
 import { useLatestPushBuildPipelineRunForComponent } from '../../../../hooks/usePipelineRuns';
 import ExternalLink from '../../../../shared/components/links/ExternalLink';
 import { ComponentKind } from '../../../../types';
+import { getLastestImage } from '../../../../utils/component-utils';
 import { getPipelineRunStatusResults } from '../../../../utils/pipeline-utils';
 import { useWorkspaceInfo } from '../../../../utils/workspace-context-utils';
 import GitRepoLink from '../../../GitLink/GitRepoLink';
@@ -35,7 +36,7 @@ const ComponentDetails: React.FC<React.PropsWithChildren<ComponentDetailsProps>>
       ? getPipelineRunStatusResults(latestPushBuildPLR)
       : null;
   const latestImageURL = results?.find((result) => result.name === RESULT_NAME);
-  const componentImageURL = latestImageURL?.value ?? component.spec.containerImage;
+  const componentImageURL = latestImageURL?.value ?? getLastestImage(component);
 
   const runTime = React.useMemo(() => {
     try {

--- a/src/components/Components/ComponentDetails/tabs/ComponentLatestBuild.tsx
+++ b/src/components/Components/ComponentDetails/tabs/ComponentLatestBuild.tsx
@@ -20,6 +20,7 @@ import { Timestamp } from '../../../../shared/components/timestamp/Timestamp';
 import { HttpError } from '../../../../shared/utils/error/http-error';
 import { ComponentKind } from '../../../../types';
 import { getCommitsFromPLRs } from '../../../../utils/commits-utils';
+import { getLastestImage } from '../../../../utils/component-utils';
 import { useWorkspaceInfo } from '../../../../utils/workspace-context-utils';
 import { useBuildLogViewerModal } from '../../../LogViewer/BuildLogViewer';
 import ScanDescriptionListGroup from '../../../PipelineRunDetailsView/tabs/ScanDescriptionListGroup';
@@ -43,7 +44,7 @@ const ComponentLatestBuild: React.FC<React.PropsWithChildren<ComponentLatestBuil
   const [taskRuns, taskRunsLoaded] = useTaskRuns(namespace, pipelineRun?.metadata?.name);
   const buildLogsModal = useBuildLogViewerModal(component);
 
-  const containerImage = component.spec.containerImage;
+  const containerImage = getLastestImage(component);
 
   if (error) {
     const httpError = HttpError.fromCode((error as any).code);

--- a/src/components/Components/ComponentsListRow.tsx
+++ b/src/components/Components/ComponentsListRow.tsx
@@ -8,6 +8,7 @@ import PipelineRunStatus from '../../shared/components/pipeline-run-status/Pipel
 import { RowFunctionArgs, TableData } from '../../shared/components/table';
 import { ComponentKind, PipelineRunKind } from '../../types';
 import { getCommitsFromPLRs } from '../../utils/commits-utils';
+import { getLastestImage } from '../../utils/component-utils';
 import { useWorkspaceInfo } from '../../utils/workspace-context-utils';
 import { useComponentActions } from '../ApplicationDetails/component-actions';
 import { ComponentRelationStatusIcon } from '../ComponentRelation/details-page/ComponentRelationStatusIcon';
@@ -32,6 +33,7 @@ const ComponentsListRow: React.FC<RowFunctionArgs<ComponentWithLatestBuildPipeli
   const name = component.metadata.name;
   const actions = useComponentActions(component, name);
   const buildLogsModal = useBuildLogViewerModal(component);
+  const latestImage = getLastestImage(component);
 
   const commit = React.useMemo(
     () =>
@@ -68,14 +70,14 @@ const ComponentsListRow: React.FC<RowFunctionArgs<ComponentWithLatestBuildPipeli
               />
             </FlexItem>
           )}
-          {component.spec.containerImage && (
+          {latestImage && (
             <FlexItem>
               <ExternalLink
                 /** by default patternfly button disable text selection on Button component
                     this enables it on <a /> tag */
                 style={{ userSelect: 'auto' }}
-                href={getContainerImageLink(component.spec.containerImage)}
-                text={component.spec.containerImage}
+                href={getContainerImageLink(latestImage)}
+                text={latestImage}
               />
             </FlexItem>
           )}

--- a/src/components/CustomizedPipeline/CustomizePipelines.tsx
+++ b/src/components/CustomizedPipeline/CustomizePipelines.tsx
@@ -29,7 +29,12 @@ import { ComponentModel } from '../../models';
 import ExternalLink from '../../shared/components/links/ExternalLink';
 import { ComponentKind } from '../../types';
 import { useTrackEvent, TrackEvents } from '../../utils/analytics';
-import { enablePAC, disablePAC, useComponentBuildStatus } from '../../utils/component-utils';
+import {
+  enablePAC,
+  disablePAC,
+  useComponentBuildStatus,
+  getLastestImage,
+} from '../../utils/component-utils';
 import { useAccessReviewForModel } from '../../utils/rbac';
 import { useWorkspaceInfo } from '../../utils/workspace-context-utils';
 import AnalyticsButton from '../AnalyticsButton/AnalyticsButton';
@@ -111,6 +116,7 @@ const Row: React.FC<
   const buildStatus = useComponentBuildStatus(component);
   const pacError = buildStatus?.pac?.['error-message'];
   const prURL = buildStatus?.pac?.['merge-url'];
+  const latestImage = getLastestImage(component);
 
   React.useEffect(() => {
     onStateChange(pacState);
@@ -140,16 +146,12 @@ const Row: React.FC<
               />
             </div>
           )}
-          {component.spec.containerImage && (
+          {latestImage && (
             <div>
               Image:{' '}
               <ExternalLink
-                href={
-                  component.spec.containerImage.startsWith('http')
-                    ? component.spec.containerImage
-                    : `https://${component.spec.containerImage}`
-                }
-                text={<Truncate content={component.spec.containerImage} />}
+                href={latestImage.startsWith('http') ? latestImage : `https://${latestImage}`}
+                text={<Truncate content={latestImage} />}
               />
             </div>
           )}

--- a/src/components/CustomizedPipeline/__tests__/CustomizePipeline.spec.tsx
+++ b/src/components/CustomizedPipeline/__tests__/CustomizePipeline.spec.tsx
@@ -266,11 +266,15 @@ describe('CustomizePipeline', () => {
       <CustomizePipeline
         components={[
           {
+            spec: {
+              application: 'my-component-test',
+            },
             metadata: {
               name: 'my-component-test',
             },
-            spec: {
+            status: {
               containerImage: 'quay.io/org/test:latest',
+              lastPromotedImage: 'quay.io/org/test:latest',
             },
           } as ComponentKind,
         ]}

--- a/src/components/SnapshotDetails/tabs/__tests__/SnapshotComponentsListRow.spec.tsx
+++ b/src/components/SnapshotDetails/tabs/__tests__/SnapshotComponentsListRow.spec.tsx
@@ -20,7 +20,7 @@ configure({ testIdAttribute: 'data-test-id' });
 const rowData: SnapshotComponentTableData = {
   metadata: { uid: mockComponentsData[1].metadata.uid, name: mockComponentsData[1].metadata.name },
   name: mockComponentsData[1].metadata.name,
-  containerImage: mockComponentsData[1].spec.containerImage,
+  containerImage: mockComponentsData[1].status.lastPromotedImage,
   application: 'test-app',
   source: { git: { url: mockComponentsData[1].spec.source.git.url, revision: 'main' } },
 };

--- a/src/types/component.ts
+++ b/src/types/component.ts
@@ -50,6 +50,7 @@ export type ComponentSpecs = {
 export type ComponentKind = K8sResourceCommon & {
   spec: ComponentSpecs;
   status?: {
+    lastPromotedImage?: string;
     containerImage?: string;
     conditions?: ResourceStatusCondition[];
     devfile?: string;

--- a/src/utils/__tests__/component-utils.spec.ts
+++ b/src/utils/__tests__/component-utils.spec.ts
@@ -11,6 +11,7 @@ import {
   startNewBuild,
   BUILD_REQUEST_ANNOTATION,
   BuildRequest,
+  getLastestImage,
 } from '../component-utils';
 
 jest.mock('../../hooks/useApplicationPipelineGitHubApp', () => ({
@@ -163,5 +164,37 @@ describe('component-utils', () => {
       pac: { state: 'enabled', 'merge-url': 'example.com' },
       message: 'done',
     });
+  });
+  it('should return status.lastPromotedImage when lastPromotedImage is available', () => {
+    const mockComponent = {
+      status: {
+        lastPromotedImage: 'test-url',
+      },
+    } as unknown as ComponentKind;
+
+    expect(getLastestImage(mockComponent)).toEqual('test-url');
+  });
+
+  it('should return spec.containerImage when lastPromotedImage is unavailable', () => {
+    const mockComponent = {
+      spec: {
+        containerImage: 'test-url',
+      },
+    } as unknown as ComponentKind;
+
+    expect(getLastestImage(mockComponent)).toEqual('test-url');
+  });
+
+  it('should return status.lastPromotedImage when lastPromotedImage and containerImage are both available', () => {
+    const mockComponent = {
+      spec: {
+        containerImage: 'test-url',
+      },
+      status: {
+        lastPromotedImage: 'test-url-promoted',
+      },
+    } as unknown as ComponentKind;
+
+    expect(getLastestImage(mockComponent)).toEqual('test-url-promoted');
   });
 });

--- a/src/utils/component-utils.ts
+++ b/src/utils/component-utils.ts
@@ -46,6 +46,19 @@ export type ComponentBuildStatus = {
 };
 
 /**
+ *
+ * @param component
+ * @returns name of latest container image
+ *
+ * The latest container image fieled is likely changed from time to time.
+ * So it is valueable to track it as utils to avoid bringing multiple changes
+ * accross several files for furture possible changes.
+ *
+ */
+export const getLastestImage = (component: ComponentKind) =>
+  component.status?.lastPromotedImage || component.spec?.containerImage;
+
+/**
  * If whole pac section is missing, PaC state is considered disabled
  * Missing pac section shows that PaC was never requested on this component before,
  * where as pac.state=disabled means that it was provisioned and then removed.


### PR DESCRIPTION
## Fixes 
[KFLUXUI-256](https://issues.redhat.com/browse/KFLUXUI-256)


## Description
The integration service recently migrated from using the component's spec.containerImage field to store the latest image to using the component's status.lastPromotedImage field.

The patch support the component.spec.containerImage as the latestImage when it's valid.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 



## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
