### PR TITLE
Replace Atlas CNAMEs

### DIFF
--- a/integration-tests/tests/advanced-happy-path.spec.ts
+++ b/integration-tests/tests/advanced-happy-path.spec.ts
@@ -151,7 +151,7 @@ describe('Advanced Happy path', () => {
           cy.get(atlasPO.password).type(Cypress.env('ATLAS_PASSWORD'), { log: false });
           cy.get(atlasPO.loginButton).click();
         });
-        cy.origin('https://atlas.stage.devshift.net/', { args: { atlasPO } }, ({ atlasPO }) => {
+        cy.origin('https://atlas.build.stage.devshift.net/', { args: { atlasPO } }, ({ atlasPO }) => {
           cy.contains(atlasPO.headerTitle, 'sha256:').should('be.visible');
           cy.contains(atlasPO.cardTitle, 'Metadata').should('be.visible');
         });

--- a/src/hooks/__tests__/useUIInstance.spec.ts
+++ b/src/hooks/__tests__/useUIInstance.spec.ts
@@ -50,7 +50,7 @@ describe('useSbomUrl', () => {
     chromeMock.mockReturnValue('prod');
     const { result } = renderHook(() => useSbomUrl());
     expect(result.current('image-hash-prod')).toEqual(
-      'https://atlas.devshift.net/sbom/content/image-hash-prod',
+      'https://atlas.build.devshift.net/sbom/content/image-hash-prod',
     );
   });
 
@@ -58,7 +58,7 @@ describe('useSbomUrl', () => {
     chromeMock.mockReturnValue('stage');
     const { result } = renderHook(() => useSbomUrl());
     expect(result.current('image-hash-stage')).toEqual(
-      'https://atlas.stage.devshift.net/sbom/content/image-hash-stage',
+      'https://atlas.build.stage.devshift.net/sbom/content/image-hash-stage',
     );
   });
 });

--- a/src/hooks/useUIInstance.ts
+++ b/src/hooks/useUIInstance.ts
@@ -30,12 +30,12 @@ export const useUIInstance = (): ConsoleDotEnvironments => {
 const SBOM_PLACEHOLDER = '<PLACEHOLDER>';
 const getSBOMEnvUrl = (env: ConsoleDotEnvironments) => (imageHash: string) => {
   if (env === ConsoleDotEnvironments.prod) {
-    return `https://atlas.devshift.net/sbom/content/${SBOM_PLACEHOLDER}`.replace(
+    return `https://atlas.build.devshift.net/sbom/content/${SBOM_PLACEHOLDER}`.replace(
       SBOM_PLACEHOLDER,
       imageHash,
     );
   }
-  return `https://atlas.stage.devshift.net/sbom/content/${SBOM_PLACEHOLDER}`.replace(
+  return `https://atlas.build.stage.devshift.net/sbom/content/${SBOM_PLACEHOLDER}`.replace(
     SBOM_PLACEHOLDER,
     imageHash,
   );


### PR DESCRIPTION
Atlas was recently split into multiple instances and Konflux UI should use the new Build instance and its URL. The underneath instance is still the same but URL is more specific now.


## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->
