### PR TITLE
feat(KFLUXUI-326): get partial data for tekton records

### DIFF
--- a/src/utils/__tests__/tekton-results.spec.ts
+++ b/src/utils/__tests__/tekton-results.spec.ts
@@ -365,10 +365,10 @@ describe('tekton-results', () => {
   describe('createTektonResultsUrl', () => {
     it('should create minimal URL', () => {
       expect(createTektonResultsUrl('test-ws', 'test-ns', [DataType.PipelineRun])).toEqual(
-        '/plugins/tekton-results/workspaces/test-ws/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=30&filter=data_type+in+%5B%22tekton.dev%2Fv1.PipelineRun%22%5D',
+        '/plugins/tekton-results/workspaces/test-ws/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=30&PartialResponse=true&fields=records.name%2Crecords.data.value.apiVersion%2Crecords.data.value.kind%2Crecords.data.value.metadata.annotations%2Crecords.data.value.metadata.labels%2Crecords.data.value.metadata.name%2Crecords.data.value.metadata.namespace%2Crecords.data.value.metadata.uid%2Crecords.data.value.metadata.creationTimestamp%2Crecords.data.value.metadata.ownerReferences%2Crecords.data.value.status.conditions%2Crecords.data.value.status.results%2Crecords.data.value.status.startTime%2Crecords.data.value.status.completionTime%2Crecords.data.value.status.pipelineSpec.tasks%2Crecords.data.value.status.pipelineSpec.finally%2Crecords.data.value.status.pipelineResults&filter=data_type+in+%5B%22tekton.dev%2Fv1.PipelineRun%22%5D',
       );
       expect(createTektonResultsUrl('test-ws', 'test-ns', [DataType.TaskRun])).toEqual(
-        '/plugins/tekton-results/workspaces/test-ws/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=30&filter=data_type+in+%5B%22tekton.dev%2Fv1.TaskRun%22%5D',
+        '/plugins/tekton-results/workspaces/test-ws/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=30&PartialResponse=true&fields=records.name%2Crecords.data.value.apiVersion%2Crecords.data.value.kind%2Crecords.data.value.metadata.annotations%2Crecords.data.value.metadata.labels%2Crecords.data.value.metadata.name%2Crecords.data.value.metadata.namespace%2Crecords.data.value.metadata.uid%2Crecords.data.value.metadata.creationTimestamp%2Crecords.data.value.metadata.ownerReferences%2Crecords.data.value.status.conditions%2Crecords.data.value.status.results%2Crecords.data.value.status.startTime%2Crecords.data.value.status.completionTime%2Crecords.data.value.status.podName%2Crecords.data.value.status.taskSpec.description%2Crecords.data.value.spec.taskRef.params%2Crecords.data.value.spec.taskRef.name%2Crecords.data.value.spec.containers%2Crecords.data.value.spec.status%2Crecords.data.value.status.taskResults%2Crecords.data.value.status.containerStatuses&filter=data_type+in+%5B%22tekton.dev%2Fv1.TaskRun%22%5D',
       );
     });
 
@@ -389,7 +389,7 @@ describe('tekton-results', () => {
       expect(
         createTektonResultsUrl('test-ws', 'test-ns', [DataType.PipelineRun], 'foo=bar'),
       ).toEqual(
-        '/plugins/tekton-results/workspaces/test-ws/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=30&filter=data_type+in+%5B%22tekton.dev%2Fv1.PipelineRun%22%5D+%26%26+foo%3Dbar',
+        '/plugins/tekton-results/workspaces/test-ws/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=30&PartialResponse=true&fields=records.name%2Crecords.data.value.apiVersion%2Crecords.data.value.kind%2Crecords.data.value.metadata.annotations%2Crecords.data.value.metadata.labels%2Crecords.data.value.metadata.name%2Crecords.data.value.metadata.namespace%2Crecords.data.value.metadata.uid%2Crecords.data.value.metadata.creationTimestamp%2Crecords.data.value.metadata.ownerReferences%2Crecords.data.value.status.conditions%2Crecords.data.value.status.results%2Crecords.data.value.status.startTime%2Crecords.data.value.status.completionTime%2Crecords.data.value.status.pipelineSpec.tasks%2Crecords.data.value.status.pipelineSpec.finally%2Crecords.data.value.status.pipelineResults&filter=data_type+in+%5B%22tekton.dev%2Fv1.PipelineRun%22%5D+%26%26+foo%3Dbar',
       );
     });
 
@@ -432,7 +432,7 @@ describe('tekton-results', () => {
           sampleOptions,
         ),
       ).toContain(
-        'filter=data_type+in+%5B%22tekton.dev%2Fv1.PipelineRun%22%5D+%26%26+foo%3Dbar+%26%26+data.metadata.labels%5B%22test%22%5D+%3D%3D+%22a%22+%26%26+data.metadata.labels%5B%22mtest%22%5D+%3D%3D+%22ma%22+%26%26+count+%3E+1',
+        '/plugins/tekton-results/workspaces/test-ws/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=30&PartialResponse=true&fields=records.name%2Crecords.data.value.apiVersion%2Crecords.data.value.kind%2Crecords.data.value.metadata.annotations%2Crecords.data.value.metadata.labels%2Crecords.data.value.metadata.name%2Crecords.data.value.metadata.namespace%2Crecords.data.value.metadata.uid%2Crecords.data.value.metadata.creationTimestamp%2Crecords.data.value.metadata.ownerReferences%2Crecords.data.value.status.conditions%2Crecords.data.value.status.results%2Crecords.data.value.status.startTime%2Crecords.data.value.status.completionTime%2Crecords.data.value.status.pipelineSpec.tasks%2Crecords.data.value.status.pipelineSpec.finally%2Crecords.data.value.status.pipelineResults&filter=data_type+in+%5B%22tekton.dev%2Fv1.PipelineRun%22%5D+%26%26+foo%3Dbar+%26%26+data.metadata.labels%5B%22test%22%5D+%3D%3D+%22a%22+%26%26+data.metadata.labels%5B%22mtest%22%5D+%3D%3D+%22ma%22+%26%26+count+%3E+1',
       );
     });
   });
@@ -519,7 +519,7 @@ describe('tekton-results', () => {
     it('should query tekton results with options', async () => {
       await getPipelineRuns('test-ws', 'test-ns', sampleOptions, 'test-token');
       expect(commonFetchJSONMock).toHaveBeenCalledWith(
-        '/plugins/tekton-results/workspaces/test-ws/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=30&page_token=test-token&filter=data_type+in+%5B%22tekton.dev%2Fv1.PipelineRun%22%2C%22tekton.dev%2Fv1beta1.PipelineRun%22%5D+%26%26+data.metadata.labels%5B%22test%22%5D+%3D%3D+%22a%22+%26%26+data.metadata.labels%5B%22mtest%22%5D+%3D%3D+%22ma%22+%26%26+count+%3E+1',
+        '/plugins/tekton-results/workspaces/test-ws/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=30&page_token=test-token&PartialResponse=true&fields=records.name%2Crecords.data.value.apiVersion%2Crecords.data.value.kind%2Crecords.data.value.metadata.annotations%2Crecords.data.value.metadata.labels%2Crecords.data.value.metadata.name%2Crecords.data.value.metadata.namespace%2Crecords.data.value.metadata.uid%2Crecords.data.value.metadata.creationTimestamp%2Crecords.data.value.metadata.ownerReferences%2Crecords.data.value.status.conditions%2Crecords.data.value.status.results%2Crecords.data.value.status.startTime%2Crecords.data.value.status.completionTime%2Crecords.data.value.status.pipelineSpec.tasks%2Crecords.data.value.status.pipelineSpec.finally%2Crecords.data.value.status.pipelineResults&filter=data_type+in+%5B%22tekton.dev%2Fv1.PipelineRun%22%2C%22tekton.dev%2Fv1beta1.PipelineRun%22%5D+%26%26+data.metadata.labels%5B%22test%22%5D+%3D%3D+%22a%22+%26%26+data.metadata.labels%5B%22mtest%22%5D+%3D%3D+%22ma%22+%26%26+count+%3E+1',
       );
     });
   });
@@ -533,7 +533,7 @@ describe('tekton-results', () => {
     it('should query tekton results with options', async () => {
       await getTaskRuns('test-ws', 'test-ns', sampleOptions, 'test-token');
       expect(commonFetchJSONMock).toHaveBeenCalledWith(
-        '/plugins/tekton-results/workspaces/test-ws/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=30&page_token=test-token&filter=data_type+in+%5B%22tekton.dev%2Fv1.TaskRun%22%2C%22tekton.dev%2Fv1beta1.TaskRun%22%5D+%26%26+data.metadata.labels%5B%22test%22%5D+%3D%3D+%22a%22+%26%26+data.metadata.labels%5B%22mtest%22%5D+%3D%3D+%22ma%22+%26%26+count+%3E+1',
+        '/plugins/tekton-results/workspaces/test-ws/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=30&page_token=test-token&PartialResponse=true&fields=records.name%2Crecords.data.value.apiVersion%2Crecords.data.value.kind%2Crecords.data.value.metadata.annotations%2Crecords.data.value.metadata.labels%2Crecords.data.value.metadata.name%2Crecords.data.value.metadata.namespace%2Crecords.data.value.metadata.uid%2Crecords.data.value.metadata.creationTimestamp%2Crecords.data.value.metadata.ownerReferences%2Crecords.data.value.status.conditions%2Crecords.data.value.status.results%2Crecords.data.value.status.startTime%2Crecords.data.value.status.completionTime%2Crecords.data.value.status.podName%2Crecords.data.value.status.taskSpec.description%2Crecords.data.value.spec.taskRef.params%2Crecords.data.value.spec.taskRef.name%2Crecords.data.value.spec.containers%2Crecords.data.value.spec.status%2Crecords.data.value.status.taskResults%2Crecords.data.value.status.containerStatuses&filter=data_type+in+%5B%22tekton.dev%2Fv1.TaskRun%22%2C%22tekton.dev%2Fv1beta1.TaskRun%22%5D+%26%26+data.metadata.labels%5B%22test%22%5D+%3D%3D+%22a%22+%26%26+data.metadata.labels%5B%22mtest%22%5D+%3D%3D+%22ma%22+%26%26+count+%3E+1',
       );
     });
   });

--- a/src/utils/tekton-results.ts
+++ b/src/utils/tekton-results.ts
@@ -206,6 +206,40 @@ const InFlightStore: { [key: string]: boolean } = {};
 
 const getTRUrlPrefix = (workspace: string): string => URL_PREFIX.replace(_WORKSPACE_, workspace);
 
+const commonFields = [
+  'records.name',
+  'records.data.value.apiVersion',
+  'records.data.value.kind',
+  'records.data.value.metadata.annotations',
+  'records.data.value.metadata.labels',
+  'records.data.value.metadata.name',
+  'records.data.value.metadata.namespace',
+  'records.data.value.metadata.uid',
+  'records.data.value.metadata.creationTimestamp',
+  'records.data.value.metadata.ownerReferences',
+  'records.data.value.status.conditions',
+  'records.data.value.status.results',
+  'records.data.value.status.startTime',
+  'records.data.value.status.completionTime',
+];
+
+const remainingTaskrunFields = [
+  'records.data.value.status.podName',
+  'records.data.value.status.taskSpec.description',
+  'records.data.value.spec.taskRef.params',
+  'records.data.value.spec.taskRef.name',
+  'records.data.value.spec.containers',
+  'records.data.value.spec.status',
+  'records.data.value.status.taskResults',
+  'records.data.value.status.containerStatuses',
+];
+
+const remainingPipelinerunFields = [
+  'records.data.value.status.pipelineSpec.tasks',
+  'records.data.value.status.pipelineSpec.finally',
+  'records.data.value.status.pipelineResults',
+];
+
 export const createTektonResultsUrl = (
   workspace: string,
   namespace: string,
@@ -222,6 +256,11 @@ export const createTektonResultsUrl = (
       Math.min(MAXIMUM_PAGE_SIZE, options?.limit >= 0 ? options.limit : options?.pageSize ?? 30),
     )}`,
     ...(nextPageToken ? { ['page_token']: nextPageToken } : {}),
+    // get partial response with required fields
+    ['PartialResponse']: 'true',
+    ['fields']: dataTypes.every((item) => item.includes('PipelineRun'))
+      ? [...commonFields, ...remainingPipelinerunFields].join(',')
+      : [...commonFields, ...remainingTaskrunFields].join(','),
     filter: AND(
       IN('data_type', dataTypes),
       filter,


### PR DESCRIPTION
## Fixes 
[KFLUXUI-326](https://issues.redhat.com/browse/KFLUXUI-326)

## Description
Without the patch, we filter the integrated records. However, we just enjoy few fields of the records to show data on UI.
In this patch, we let the tekton just return the required fileds for records which will decrease the payload size and save the time.


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

1. For the pipelinerun list page:
![Screenshot 2025-03-07 at 13 34 25](https://github.com/user-attachments/assets/3e47f0d8-b75e-4cea-8c51-69593d0a759f)

2. For the test pipeline:
![Screenshot 2025-03-07 at 13 35 02](https://github.com/user-attachments/assets/491da838-0b06-4960-a4c7-2cfa1f1fd2c9)
![Screenshot 2025-03-07 at 13 35 30](https://github.com/user-attachments/assets/bd0b0440-5869-4517-bb51-a9feb181bcd3)
![Screenshot 2025-03-07 at 13 35 40](https://github.com/user-attachments/assets/07397657-5422-4741-81bf-d3ea3bd0a9ec)

3. For the build pipeline:
![Screenshot 2025-03-07 at 15 56 12](https://github.com/user-attachments/assets/6ee5ec5d-9bf2-4714-835d-2079d9a8d14f)
![Screenshot 2025-03-07 at 15 56 24](https://github.com/user-attachments/assets/b75d8135-e202-4398-b62c-1ed9f840269d)
![Screenshot 2025-03-07 at 15 57 00](https://github.com/user-attachments/assets/11ef548b-89d5-4cf4-ae19-f19a3aa38164)

4. For the managed pipeline
![Screenshot 2025-03-07 at 16 03 16](https://github.com/user-attachments/assets/4c02625c-6155-42bb-ace3-362e48f0cb6c)
![Screenshot 2025-03-07 at 16 04 53](https://github.com/user-attachments/assets/1bda3541-154f-4332-bbf9-1bd90a59db84)
![Screenshot 2025-03-07 at 16 24 40](https://github.com/user-attachments/assets/ae2a0caf-7159-4133-a569-27748587b215)

5. For the pipeline action
![Screenshot 2025-03-07 at 16 44 20](https://github.com/user-attachments/assets/8ffbd852-86bc-4a1c-bd0d-deddeb4ba57d)
![Screenshot 2025-03-07 at 16 44 50](https://github.com/user-attachments/assets/55d8732f-e657-44ec-ab06-0214abfecd6b)
![Screenshot 2025-03-07 at 16 45 48](https://github.com/user-attachments/assets/f44c93e1-39be-4d24-9fd2-d5d5b43575ed)
![Screenshot 2025-03-07 at 16 47 07](https://github.com/user-attachments/assets/0bcd68d6-5390-473f-a5be-d5e43d114c72)

6. Check the vulnerabilities
![Screenshot 2025-03-07 at 18 30 00](https://github.com/user-attachments/assets/953e8892-38aa-4b53-b21c-63d98852cca5)





## How to test or reproduce?
Test Scenarios:
1. Visiting the list, details, logs of the pipelinerun and test run pages and compared all of them with those in stage konflux. --> PASS, screenshots have been uploaded.
2. Reproduce the first step for different pipeline types like Build, Test, Managed. -> PASS, screenshots have been uploaded.
3. Choose the test pipeline and check its action, try 'rerun', 'stop', 'Cancel' to ensure it works well. ->  PASS, all work. Screenshots have been uploaded.
4. Choose the managed pipeline and check its action. -> PASS, rerun is shown as the same as the stage konflux but clicking it does not make any change.
5. Check the Vulnerabilities to ensure it can be shown well. -> PASS, some vulnerabilities data are shown well.

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->