### PR TITLE
chore(KFLUXVNGD-245): add tekton-bundle-builder-oci-ta to UI

### DIFF
--- a/src/components/ImportForm/PipelineSection/__tests__/usePipelineTemplate.spec.ts
+++ b/src/components/ImportForm/PipelineSection/__tests__/usePipelineTemplate.spec.ts
@@ -74,6 +74,11 @@ describe('usePipelineTemplate', () => {
             bundle:
               'quay.io/konflux-ci/tekton-catalog/pipeline-tekton-bundle-builder@sha256:f9ab9253f8ef1b288149d3bc76749cb0091f7a306e9ca71b8e3e5c56db63a57d',
           },
+          {
+            name: 'tekton-bundle-builder-oci-ta',
+            bundle:
+              'quay.io/konflux-ci/tekton-catalog/pipeline-tekton-bundle-builder-oci-ta@sha256:b3a65fcc910b3405c309adcfdbb710ce051a1215a82c91b568129c2b353014e0',
+          },
         ],
       },
       true,

--- a/src/components/ImportForm/PipelineSection/usePipelineTemplate.ts
+++ b/src/components/ImportForm/PipelineSection/usePipelineTemplate.ts
@@ -34,6 +34,11 @@ const PIPELINE_DATA = {
       bundle:
         'quay.io/konflux-ci/tekton-catalog/pipeline-tekton-bundle-builder@sha256:f9ab9253f8ef1b288149d3bc76749cb0091f7a306e9ca71b8e3e5c56db63a57d',
     },
+    {
+      name: 'tekton-bundle-builder-oci-ta',
+      bundle:
+        'quay.io/konflux-ci/tekton-catalog/pipeline-tekton-bundle-builder-oci-ta@sha256:b3a65fcc910b3405c309adcfdbb710ce051a1215a82c91b568129c2b353014e0',
+    },
   ],
 };
 


### PR DESCRIPTION
Add tekton-bundle-builder-oci-ta pipeline to Konflux UI Konflux UI would support dynamic pipeline when it is online. 
The hardcode would be used as the backup when there is no dynamic pipeline config found.


